### PR TITLE
Identity comparison (===) works on all types

### DIFF
--- a/src/semck/typeck.rs
+++ b/src/semck/typeck.rs
@@ -643,22 +643,6 @@ impl<'a, 'ast> TypeCheck<'a, 'ast> {
     ) {
         match cmp {
             CmpOp::Is | CmpOp::IsNot => {
-                if !lhs_type.reference_type() {
-                    let lhs_type = lhs_type.name(self.ctxt);
-                    self.ctxt
-                        .diag
-                        .lock()
-                        .report(e.pos, Msg::ReferenceTypeExpected(lhs_type));
-                }
-
-                if !rhs_type.reference_type() {
-                    let rhs_type = rhs_type.name(self.ctxt);
-                    self.ctxt
-                        .diag
-                        .lock()
-                        .report(e.pos, Msg::ReferenceTypeExpected(rhs_type));
-                }
-
                 if !(lhs_type.is_nil() || lhs_type.allows(self.ctxt, rhs_type))
                     && !(rhs_type.is_nil() || rhs_type.allows(self.ctxt, lhs_type))
                 {

--- a/stdlib/prelude.dora
+++ b/stdlib/prelude.dora
@@ -290,6 +290,33 @@ internal class Array<T> {
   internal fun len() -> int;
   internal fun get(idx: int) -> T;
   internal fun set(idx: int, val: T);
+
+  fun contains(value: T /* : Equals*/) -> bool {
+    var i = 0;
+
+    while i < self.len() {
+      let x = self[i];
+      if /*x.equals(value) ||*/ x === value {
+        return true;
+      }
+      i = i + 1;
+    }
+
+    return false;
+  }
+
+  fun has(value: T) -> bool {
+    var i = 0;
+
+    while i < self.len() {
+      if self[i] === value {
+        return true;
+      }
+      i = i + 1;
+    }
+
+    return false;
+  }
 }
 
 fun arraycopy<T>(src: Array<T>, srcPos: int, dest: Array<T>, destPos: int, len: int) {

--- a/tests/generic-array-has.dora
+++ b/tests/generic-array-has.dora
@@ -1,0 +1,9 @@
+fun main() {
+  let ais = Array::<int>(100, 2);
+  ais[99] = 23;
+  assert(ais.has(23));
+
+  let ads = Array::<double>(100, 2.0);
+  ads[99] = 0.0/0.0;
+  assert(ads.has(0.0/0.0));
+}

--- a/tests/identity.dora
+++ b/tests/identity.dora
@@ -1,9 +1,4 @@
 fun main() {
-    let f1 = Foo(1);
-    let f2 = Foo(2);
-    assert(f1 === f1);
-    assert(f1 !== f2);
-
     let b1 = 1.toByte();
     let b2 = 2.toByte();
     assert(b1 === b1);
@@ -32,6 +27,27 @@ fun main() {
     assert(d1 !== d2);
     assert(0.0 !== -0.0);
     assert(0.0/0.0 === 0.0/0.0);
+
+    let f1 = Foo(1);
+    let f2 = Foo(2);
+    assert(f1 === f1);
+    assert(f1 !== f2);
+
+    assert(bar::<int>(1, 1));
+    assert(!bar::<int>(1, 2));
+
+    assert(bar::<double>(1.0, 1.0));
+    assert(!bar::<double>(1.0, 2.0));
+    assert(!bar::<double>(0.0, (-0.0)));
+    assert(bar::<double>(0.0/0.0, 0.0/0.0));
+
+    assert(bar::<Foo>(f1, f1));
+    assert(!bar::<Foo>(f1, Foo(1)));
+    assert(!bar::<Foo>(f1, f2));
 }
 
 class Foo(i: int) {}
+
+fun bar<T>(a: T, b: T) -> bool {
+    return a === b;
+}

--- a/tests/identity.dora
+++ b/tests/identity.dora
@@ -1,0 +1,37 @@
+fun main() {
+    let f1 = Foo(1);
+    let f2 = Foo(2);
+    assert(f1 === f1);
+    assert(f1 !== f2);
+
+    let b1 = 1.toByte();
+    let b2 = 2.toByte();
+    assert(b1 === b1);
+    assert(b1 !== b2);
+
+    let i1 = 1;
+    let i2 = 2;
+    assert(i1 === i1);
+    assert(i1 !== i2);
+
+    let l1 = 1L;
+    let l2 = 2L;
+    assert(l1 === l1);
+    assert(l1 !== l2);
+
+    let f1 = 1.0F;
+    let f2 = 2.0F;
+    assert(f1 === f1);
+    assert(f1 !== f2);
+    assert(0.0F !== -0.0F);
+    assert(0.0F/0.0F === 0.0F/0.0F);
+
+    let d1 = 1.0;
+    let d2 = 2.0;
+    assert(d1 === d1);
+    assert(d1 !== d2);
+    assert(0.0 !== -0.0);
+    assert(0.0/0.0 === 0.0/0.0);
+}
+
+class Foo(i: int) {}

--- a/tests/nil2.dora
+++ b/tests/nil2.dora
@@ -2,6 +2,8 @@ fun main() {
   let x: Str = nil;
 
   assert(x === nil);
+  assert(!(x !== nil));
+
   assert(nil === x);
   assert(nil === nil);
   assert(!(nil !== nil));


### PR DESCRIPTION
- Already worked for references
- Now works for whole numbers (same as ==)
- Now works for floating point numbers such that
  float1  === float2  ----> float1.asInt()   == float2.asInt()
  double1 === double2 ----> double1.asLong() == double2.asLong()