### PR TITLE
Make syntax for defining funs more consistent with lets and vars ...

### DIFF
--- a/lib/dora-parser/src/parser.rs
+++ b/lib/dora-parser/src/parser.rs
@@ -796,10 +796,29 @@ impl<'a> Parser<'a> {
             self.advance_token()?;
 
             Ok(None)
+        } else if self.token.is(TokenKind::Eq) {
+            let expr = self.parse_function_block_expression()?;
+
+            Ok(Some(expr))
         } else {
             let block = self.parse_block()?;
 
             Ok(Some(block))
+        }
+    }
+
+    fn parse_function_block_expression(&mut self) -> Result<Box<Stmt>, MsgWithPos> {
+        self.advance_token()?;
+        let pos = self.token.position;
+
+        match self.token.kind {
+            TokenKind::Throw => self.parse_throw(),
+            TokenKind::Return => self.parse_return(),
+            _ => {
+                let expr = self.parse_expression().ok();
+                self.expect_token(TokenKind::Semicolon)?;
+                Ok(Box::new(Stmt::create_return(self.generate_id(), pos, expr)))
+            }
         }
     }
 

--- a/tests/fn9.dora
+++ b/tests/fn9.dora
@@ -1,0 +1,11 @@
+fun main() -> int {
+  return myadd(1, 2) - 3;
+}
+
+fun myzero() -> int = 0 * (42 - 23);
+
+fun myfour() -> int = return 4;
+
+fun myadd(x: int, y: int) -> int = x + y + myfour() * myzero();
+
+fun mythrow(x: int) -> int = throw "foo";

--- a/tests/fn9.dora
+++ b/tests/fn9.dora
@@ -8,4 +8,4 @@ fun myfour() -> int = return 4;
 
 fun myadd(x: int, y: int) -> int = x + y + myfour() * myzero();
 
-fun mythrow(x: int) -> int = throw "foo";
+fun mythrow(x: int) throws -> int = throw "foo";


### PR DESCRIPTION
... by allowing a single expression as a function body:

    fun zero() -> int = 0 * (42 - 23);