### PR TITLE
Rename Str to String

### DIFF
--- a/bench/raytracer/primitive.dora
+++ b/bench/raytracer/primitive.dora
@@ -11,7 +11,7 @@ open abstract class Primitive {
 
     abstract fun normal(pnt: Vec3) -> Vec3;
     abstract fun intersect(ry: Ray) -> Isect;
-    abstract fun toString() -> Str;
+    abstract fun toString() -> String;
     abstract fun getCenter() -> Vec3;
     abstract fun setCenter(c: Vec3);
 }

--- a/bench/raytracer/ray.dora
+++ b/bench/raytracer/ray.dora
@@ -21,7 +21,7 @@ class Ray {
         )
     }
 
-    fun toString() -> Str {
+    fun toString() -> String {
         return "{" + self.P.toString() + " -> " + self.D.toString() + "}";
     }
 }

--- a/bench/raytracer/vec.dora
+++ b/bench/raytracer/vec.dora
@@ -99,7 +99,7 @@ class Vec3 {
         return len;
     }
 
-    fun toString() -> Str {
+    fun toString() -> String {
         return "<" + x.toString() + "," + y.toString() + "," +
                z.toString() + ">";
     }

--- a/bench/splay/splay.dora
+++ b/bench/splay/splay.dora
@@ -106,7 +106,7 @@ class Benchmark {
     }
 }
 
-fun generatePayloadTree(depth: int, tag: Str) -> PayloadNode {
+fun generatePayloadTree(depth: int, tag: String) -> PayloadNode {
     if depth == 0 {
         let arr = Array::<int>(10);
         var i = 0;

--- a/bench/splunc/splunc.dora
+++ b/bench/splunc/splunc.dora
@@ -131,7 +131,7 @@ open abstract class Node {
         }
     }
 
-    fun printTree(date: int, prefix: Str) {
+    fun printTree(date: int, prefix: String) {
         print(prefix);
         print("age: " + (date - self.birthday).toString());
         println(" value: " + self.value.toString());

--- a/lib/dora-parser/src/parser.rs
+++ b/lib/dora-parser/src/parser.rs
@@ -2539,7 +2539,7 @@ mod tests {
     fn parse_method() {
         let (prog, interner) = parse("class Foo {
             fun zero() -> int { return 0; }
-            fun id(a: Str) -> Str { return a; }
+            fun id(a: String) -> String { return a; }
         }");
 
         let cls = prog.cls0();
@@ -2568,7 +2568,7 @@ mod tests {
             .to_basic()
             .unwrap()
             .name;
-        assert_eq!("Str", *interner.str(rt2));
+        assert_eq!("String", *interner.str(rt2));
     }
 
     #[test]
@@ -2748,7 +2748,7 @@ mod tests {
 
     #[test]
     fn parse_do() {
-        let stmt = parse_stmt("do { 1; } catch e: Str { 2; }
+        let stmt = parse_stmt("do { 1; } catch e: String { 2; }
                                           catch e: IntArray { 3; } finally { 4; }");
         let try = stmt.to_do().unwrap();
 
@@ -2833,7 +2833,7 @@ mod tests {
 
     #[test]
     fn parse_is_expr() {
-        let (expr, _) = parse_expr("a is Str");
+        let (expr, _) = parse_expr("a is String");
         let expr = expr.to_conv().unwrap();
         assert_eq!(true, expr.object.is_ident());
         assert_eq!(true, expr.is);
@@ -2841,7 +2841,7 @@ mod tests {
 
     #[test]
     fn parse_as_expr() {
-        let (expr, _) = parse_expr("a as Str");
+        let (expr, _) = parse_expr("a as String");
         let expr = expr.to_conv().unwrap();
         assert_eq!(true, expr.object.is_ident());
         assert_eq!(false, expr.is);

--- a/src/ctxt.rs
+++ b/src/ctxt.rs
@@ -130,7 +130,7 @@ impl<'ast> SemContext<'ast> {
                 float_class: empty_class_id,
                 double_class: empty_class_id,
                 object_class: empty_class_id,
-                str_class: empty_class_id,
+                string_class: empty_class_id,
 
                 array_class: empty_class_id,
 
@@ -556,7 +556,7 @@ pub struct KnownElements {
     pub float_class: ClassId,
     pub double_class: ClassId,
     pub object_class: ClassId,
-    pub str_class: ClassId,
+    pub string_class: ClassId,
     pub array_class: ClassId,
 
     pub testing_class: ClassId,
@@ -598,7 +598,7 @@ impl KnownElements {
         if let Some(cls_id) = *str_class_def {
             cls_id
         } else {
-            let cls_id = specialize_class_id(ctxt, self.str_class);
+            let cls_id = specialize_class_id(ctxt, self.string_class);
             *str_class_def = Some(cls_id);
             cls_id
         }

--- a/src/semck/nameck.rs
+++ b/src/semck/nameck.rs
@@ -410,7 +410,7 @@ mod tests {
     #[test]
     fn shadow_type_with_param() {
         err(
-            "fun test(bool: Str) {}",
+            "fun test(bool: String) {}",
             pos(1, 10),
             Msg::ShadowClass("bool".into()),
         );
@@ -419,9 +419,9 @@ mod tests {
     #[test]
     fn shadow_type_with_var() {
         err(
-            "fun test() { let Str = 3; }",
+            "fun test() { let String = 3; }",
             pos(1, 14),
-            Msg::ShadowClass("Str".into()),
+            Msg::ShadowClass("String".into()),
         );
     }
 
@@ -443,7 +443,7 @@ mod tests {
     #[test]
     fn shadow_param() {
         err(
-            "fun f(a: int, b: int, a: Str) {}",
+            "fun f(a: int, b: int, a: String) {}",
             pos(1, 23),
             Msg::ShadowParam("a".into()),
         );
@@ -451,7 +451,7 @@ mod tests {
 
     #[test]
     fn multiple_params() {
-        ok("fun f(a: int, b: int, c:Str) {}");
+        ok("fun f(a: int, b: int, c:String) {}");
     }
 
     #[test]

--- a/src/semck/prelude.rs
+++ b/src/semck/prelude.rs
@@ -16,9 +16,9 @@ pub fn internal_classes<'ast>(ctxt: &mut SemContext<'ast>) {
     ctxt.vips.double_class = internal_class(ctxt, "double", Some(BuiltinType::Double));
 
     ctxt.vips.object_class = internal_class(ctxt, "Object", None);
-    ctxt.vips.str_class = internal_class(ctxt, "Str", None);
+    ctxt.vips.string_class = internal_class(ctxt, "String", None);
 
-    let cls = ctxt.classes.idx(ctxt.vips.str_class);
+    let cls = ctxt.classes.idx(ctxt.vips.string_class);
     let mut cls = cls.write();
     cls.is_str = true;
 
@@ -208,7 +208,7 @@ pub fn internal_functions<'ast>(ctxt: &mut SemContext<'ast>) {
     intrinsic_method(ctxt, clsid, "equals", Intrinsic::BoolEq);
     intrinsic_method(ctxt, clsid, "not", Intrinsic::BoolNot);
 
-    let clsid = ctxt.vips.str_class;
+    let clsid = ctxt.vips.string_class;
     native_method(ctxt, clsid, "compareTo", stdlib::strcmp as *const u8);
     native_method(ctxt, clsid, "parseInt", stdlib::str_parse_int as *const u8);
     native_method(
@@ -231,7 +231,7 @@ pub fn internal_functions<'ast>(ctxt: &mut SemContext<'ast>) {
     native_method(
         ctxt,
         clsid,
-        "fromStrPartOrNull",
+        "fromStringPartOrNull",
         stdlib::str_from_bytes as *const u8,
     );
 

--- a/src/semck/returnck.rs
+++ b/src/semck/returnck.rs
@@ -186,18 +186,18 @@ mod tests {
 
     #[test]
     fn do_returns() {
-        ok("fun f() -> int { do { return 1; } catch x: Str { return 2; } }");
-        ok("fun f() -> int { do { } catch x: Str { return 2; } return 1; }");
-        ok("fun f() -> int { do { return 2; } catch x: Str { } return 1; }");
-        ok("fun f() -> int { do { } catch x: Str { } return 1; }");
-        ok("fun f() -> int { do { } catch x: Str { } finally { return 1; } }");
+        ok("fun f() -> int { do { return 1; } catch x: String { return 2; } }");
+        ok("fun f() -> int { do { } catch x: String { return 2; } return 1; }");
+        ok("fun f() -> int { do { return 2; } catch x: String { } return 1; }");
+        ok("fun f() -> int { do { } catch x: String { } return 1; }");
+        ok("fun f() -> int { do { } catch x: String { } finally { return 1; } }");
         err(
-            "fun f() -> int { do { return 1; } catch x: Str { } }",
-            pos(1, 48),
+            "fun f() -> int { do { return 1; } catch x: String { } }",
+            pos(1, 51),
             Msg::NoReturnValue,
         );
         err(
-            "fun f() -> int { do { } catch x: Str { return 1; } }",
+            "fun f() -> int { do { } catch x: String { return 1; } }",
             pos(1, 21),
             Msg::NoReturnValue,
         );

--- a/src/semck/specialize.rs
+++ b/src/semck/specialize.rs
@@ -233,7 +233,7 @@ fn create_specialized_class(
 
         let super_id = cls
             .parent_class
-            .expect("Array & Str should have super class");
+            .expect("Array & String should have super class");
         let id = specialize_class_id(ctxt, super_id);
         parent_id = Some(id);
     } else {

--- a/src/semck/superck.rs
+++ b/src/semck/superck.rs
@@ -254,7 +254,7 @@ mod tests {
     //     assert_eq!(Header::size() + 8, class_size("class Foo(let a: long)"));
     //     assert_eq!(Header::size() + mem::ptr_width(), class_size("class Foo(let a: bool)"));
     //     assert_eq!(Header::size() + mem::ptr_width(),
-    //                class_size("class Foo(let a: Str)"));
+    //                class_size("class Foo(let a: String)"));
     // }
 
     // fn class_size(code: &'static str) -> i32 {
@@ -268,10 +268,10 @@ mod tests {
     // }
 
     // #[test]
-    // fn test_internal_class_size() {
+    // fn test_intrinsic_class_size() {
     //     ok_with_test("", |ctxt| {
     //         assert_eq!(0, class_size_name(ctxt, "Array"));
-    //         assert_eq!(0, class_size_name(ctxt, "Str"));
+    //         assert_eq!(0, class_size_name(ctxt, "String"));
     //         assert_eq!(1, class_size_name(ctxt, "bool"));
     //         assert_eq!(4, class_size_name(ctxt, "int"));
     //         assert_eq!(1, class_size_name(ctxt, "byte"));
@@ -291,7 +291,7 @@ mod tests {
     // fn test_super_size() {
     //     ok_with_test("open class A { var a: int; }
     //         open class B: A { var b1: int; var b2: int; }
-    //         class C: B { var c: Str; }",
+    //         class C: B { var c: String; }",
     //                  |ctxt| {
     //         check_class(ctxt, "A", mem::ptr_width(), Some("Object"));
     //         check_field(ctxt, "A", "a", Header::size());

--- a/src/semck/typeck.rs
+++ b/src/semck/typeck.rs
@@ -1339,7 +1339,7 @@ impl<'a, 'ast> Visitor<'ast> for TypeCheck<'a, 'ast> {
             ExprLitInt(ref expr) => self.check_expr_lit_int(expr),
             ExprLitFloat(ref expr) => self.check_expr_lit_float(expr),
             ExprLitStr(ExprLitStrType { id, .. }) => {
-                let str_ty = self.ctxt.cls(self.ctxt.vips.str_class);
+                let str_ty = self.ctxt.cls(self.ctxt.vips.string_class);
                 self.src.set_ty(id, str_ty);
                 self.expr_type = str_ty;
             }
@@ -2239,14 +2239,14 @@ mod tests {
 
     #[test]
     fn type_method_len() {
-        ok("fun f(a: Str) -> int { return a.len(); }");
-        ok("fun f(a: Str) -> int { return \"abc\".len(); }");
+        ok("fun f(a: String) -> int { return a.len(); }");
+        ok("fun f(a: String) -> int { return \"abc\".len(); }");
     }
 
     #[test]
     fn type_object_field() {
         ok("class Foo(let a:int) fun f(x: Foo) -> int { return x.a; }");
-        ok("class Foo(let a:Str) fun f(x: Foo) -> Str { return x.a; }");
+        ok("class Foo(let a:String) fun f(x: Foo) -> String { return x.a; }");
         err(
             "class Foo(let a:int) fun f(x: Foo) -> bool { return x.a; }",
             pos(1, 46),
@@ -2298,9 +2298,9 @@ mod tests {
                  fun bar() -> int { return 0; }
              }
 
-             fun f(x: Foo) -> Str { return x.bar(); }",
-            pos(5, 37),
-            Msg::ReturnType("Str".into(), "int".into()),
+             fun f(x: Foo) -> String { return x.bar(); }",
+            pos(5, 40),
+            Msg::ReturnType("String".into(), "int".into()),
         );
     }
 
@@ -2336,7 +2336,7 @@ mod tests {
         err(
             "class Foo {
                 fun bar(a: int) {}
-                fun bar(a: Str) {}
+                fun bar(a: String) {}
             }",
             pos(3, 17),
             Msg::MethodExists("Foo".into(), "bar".into(), pos(2, 17)),
@@ -2444,7 +2444,7 @@ mod tests {
     fn type_var_wrong_type_defined() {
         ok("fun f() { let a : int = 1; }");
         ok("fun f() { let a : bool = false; }");
-        ok("fun f() { let a : Str = \"f\"; }");
+        ok("fun f() { let a : String = \"f\"; }");
 
         err(
             "fun f() { let a : int = true; }",
@@ -2539,8 +2539,8 @@ mod tests {
     fn type_bin_op() {
         ok("fun f(a: int) { a+a; a-a; a*a; a/a; a%a; }");
         ok("fun f(a: int) { a<a; a<=a; a==a; a!=a; a>a; a>=a; }");
-        ok("fun f(a: Str) { a<a; a<=a; a==a; a!=a; a>a; a>=a; }");
-        ok("fun f(a: Str) { a===a; a!==a; a+a; }");
+        ok("fun f(a: String) { a<a; a<=a; a==a; a!=a; a>a; a>=a; }");
+        ok("fun f(a: String) { a===a; a!==a; a+a; }");
         ok("class Foo fun f(a: Foo) { a===a; a!==a; }");
         ok("fun f(a: int) { a|a; a&a; a^a; }");
         ok("fun f(a: bool) { a||a; a&&a; }");
@@ -2576,19 +2576,19 @@ mod tests {
             Msg::BinOpType("&&".into(), "int".into(), "int".into()),
         );
         err(
-            "fun f(a: Str) { a-a; }",
-            pos(1, 18),
-            Msg::BinOpType("-".into(), "Str".into(), "Str".into()),
+            "fun f(a: String) { a-a; }",
+            pos(1, 21),
+            Msg::BinOpType("-".into(), "String".into(), "String".into()),
         );
         err(
-            "fun f(a: Str) { a*a; }",
-            pos(1, 18),
-            Msg::BinOpType("*".into(), "Str".into(), "Str".into()),
+            "fun f(a: String) { a*a; }",
+            pos(1, 21),
+            Msg::BinOpType("*".into(), "String".into(), "String".into()),
         );
         err(
-            "fun f(a: Str) { a%a; }",
-            pos(1, 18),
-            Msg::BinOpType("%".into(), "Str".into(), "Str".into()),
+            "fun f(a: String) { a%a; }",
+            pos(1, 21),
+            Msg::BinOpType("%".into(), "String".into(), "String".into()),
         );
     }
 
@@ -2641,7 +2641,7 @@ mod tests {
 
     #[test]
     fn type_return_nil() {
-        ok("fun foo() -> Str { return nil; }");
+        ok("fun foo() -> String { return nil; }");
         ok("class Foo fun foo() -> Foo { return nil; }");
         err(
             "fun foo() -> int { return nil; }",
@@ -2652,7 +2652,7 @@ mod tests {
 
     #[test]
     fn type_nil_as_argument() {
-        ok("fun foo(a: Str) {} fun test() { foo(nil); }");
+        ok("fun foo(a: String) {} fun test() { foo(nil); }");
         err(
             "fun foo(a: int) {} fun test() { foo(nil); }",
             pos(1, 33),
@@ -2662,7 +2662,7 @@ mod tests {
 
     #[test]
     fn type_nil_for_ctor() {
-        ok("class Foo(let a: Str) fun test() { Foo(nil); }");
+        ok("class Foo(let a: String) fun test() { Foo(nil); }");
         err(
             "class Foo(let a: int) fun test() { Foo(nil); }",
             pos(1, 36),
@@ -2672,7 +2672,7 @@ mod tests {
 
     #[test]
     fn type_nil_for_local_variable() {
-        ok("fun f() { let x: Str = nil; }");
+        ok("fun f() { let x: String = nil; }");
         err(
             "fun f() { let x: int = nil; }",
             pos(1, 11),
@@ -2682,7 +2682,7 @@ mod tests {
 
     #[test]
     fn type_nil_for_field() {
-        ok("class Foo(var a: Str) fun f() { Foo(nil).a = nil; }");
+        ok("class Foo(var a: String) fun f() { Foo(nil).a = nil; }");
         err(
             "class Foo(var a: int) fun f() { Foo(1).a = nil; }",
             pos(1, 42),
@@ -2702,7 +2702,7 @@ mod tests {
     #[test]
     fn type_nil_as_method_argument() {
         ok("class Foo {
-            fun f(a: Str) {}
+            fun f(a: String) {}
         } fun f() { Foo().f(nil); }");
     }
 
@@ -2710,9 +2710,9 @@ mod tests {
     fn type_array() {
         ok("fun f(a: Array<int>) -> int { return a[1]; }");
         err(
-            "fun f(a: Array<int>) -> Str { return a[1]; }",
-            pos(1, 31),
-            Msg::ReturnType("Str".into(), "int".into()),
+            "fun f(a: Array<int>) -> String { return a[1]; }",
+            pos(1, 34),
+            Msg::ReturnType("String".into(), "int".into()),
         );
     }
 
@@ -2729,7 +2729,7 @@ mod tests {
             Msg::UnknownMethod(
                 "Array<int>".into(),
                 "set".into(),
-                vec!["int".into(), "Str".into()],
+                vec!["int".into(), "String".into()],
             ),
         );
     }
@@ -2762,7 +2762,7 @@ mod tests {
 
     #[test]
     fn type_catch_variable() {
-        ok("fun f() { do {} catch a: Str { print(a); } }");
+        ok("fun f() { do {} catch a: String { print(a); } }");
         ok("fun f() { var x = 0; do {} catch a: Array<int> { x=a.len(); } }");
     }
 
@@ -2898,9 +2898,9 @@ mod tests {
             fun f(a: A) -> bool { return a is A; }");
         err(
             "open class A class B: A
-             fun f(a: A) -> bool { return a is Str; }",
+             fun f(a: A) -> bool { return a is String; }",
             pos(2, 45),
-            Msg::TypesIncompatible("A".into(), "Str".into()),
+            Msg::TypesIncompatible("A".into(), "String".into()),
         );
         err(
             "open class A class B: A class C
@@ -2921,9 +2921,9 @@ mod tests {
             fun f(a: A) -> A { return a as A; }");
         err(
             "open class A class B: A
-             fun f(a: A) -> Str { return a as Str; }",
-            pos(2, 44),
-            Msg::TypesIncompatible("A".into(), "Str".into()),
+             fun f(a: A) -> String { return a as String; }",
+            pos(2, 47),
+            Msg::TypesIncompatible("A".into(), "String".into()),
         );
         err(
             "open class A class B: A class C
@@ -2948,7 +2948,7 @@ mod tests {
 
     #[test]
     fn check_cmp_is() {
-        ok("fun f(x: Str) {
+        ok("fun f(x: String) {
                 let a = nil === x;
                 let b = x === nil;
                 let c = nil === nil;
@@ -3045,7 +3045,7 @@ mod tests {
             "fun one() throws -> int { return 1; }
              fun me() -> int { return try one() else \"bla\"; }",
             pos(2, 39),
-            Msg::TypesIncompatible("int".into(), "Str".into()),
+            Msg::TypesIncompatible("int".into(), "String".into()),
         );
         err(
             "fun one() throws -> int { return 1; }
@@ -3343,7 +3343,7 @@ mod tests {
             Msg::WrongNumberTypeParams(1, 0),
         );
         ok("fun f<T>() {} fun g() { f::<int>(); }");
-        ok("fun f<T1, T2>() {} fun g() { f::<int, Str>(); }");
+        ok("fun f<T1, T2>() {} fun g() { f::<int, String>(); }");
     }
 
     #[test]
@@ -3357,9 +3357,9 @@ mod tests {
 
         err(
             "const one: int = 1;
-            fun f() { let x: Str = one; }",
+            fun f() { let x: String = one; }",
             pos(2, 23),
-            Msg::AssignType("x".into(), "Str".into(), "int".into()),
+            Msg::AssignType("x".into(), "String".into(), "int".into()),
         );
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -34,7 +34,7 @@ where
     let mut ast = Ast::new();
     let args: Args = Default::default();
 
-    for file in &["stdlib/prelude.dora", "stdlib/str.dora", "stdlib/test.dora"] {
+    for file in &["stdlib/prelude.dora", "stdlib/string.dora", "stdlib/test.dora"] {
         let reader = Reader::from_file(file).unwrap();
         let mut parser = Parser::new(reader, &id_generator, &mut ast, &mut interner);
         parser.parse().unwrap()

--- a/stdlib/io.dora
+++ b/stdlib/io.dora
@@ -1,4 +1,4 @@
-class File(let name: Str) {
+class File(let name: String) {
   fun delete() throws {
     let ptr = native_string(self.name);
     let fct = loadFunction("unlink");

--- a/stdlib/prelude.dora
+++ b/stdlib/prelude.dora
@@ -1,4 +1,4 @@
-internal fun fatalError(msg: Str);
+internal fun fatalError(msg: String);
 internal fun abort();
 internal fun exit(status: int);
 fun unreachable() {
@@ -9,17 +9,17 @@ fun unimplemented() {
   fatalError("not yet implemented");
 }
 
-internal fun print(text: Str);
-internal fun println(text: Str);
+internal fun print(text: String);
+internal fun println(text: String);
 internal fun addressOf(object: Object) -> long;
 internal fun assert(val: bool);
 internal fun debug();
 internal fun argc() -> int;
-internal fun argv(idx: int) -> Str;
+internal fun argv(idx: int) -> String;
 internal fun forceCollect();
 internal fun forceMinorCollect();
 
-internal fun call(fct: Str);
+internal fun call(fct: String);
 internal fun throwFromNative(val: bool) throws;
 internal fun throwFromNativeButNotThrows(val: bool);
 
@@ -27,7 +27,7 @@ internal fun timestamp() -> long;
 
 internal class bool {
   internal fun toInt() -> int;
-  fun toString() -> Str {
+  fun toString() -> String {
     if self {
       return "true";
     } else {
@@ -42,7 +42,7 @@ internal class bool {
 internal class byte {
   internal fun toInt() -> int;
   internal fun toLong() -> long;
-  internal fun toString() -> Str;
+  internal fun toString() -> String;
 
   internal fun equals(rhs: byte) -> bool;
   internal fun compareTo(rhs: byte) -> int;
@@ -51,7 +51,7 @@ internal class byte {
 internal class char {
   internal fun toInt() -> int;
   internal fun toLong() -> long;
-  internal fun toString() -> Str;
+  internal fun toString() -> String;
 
   internal fun equals(rhs: char) -> bool;
   internal fun compareTo(rhs: char) -> int;
@@ -102,7 +102,7 @@ internal class int {
   }
   internal fun toCharUnchecked() -> char;
   internal fun toLong() -> long;
-  internal fun toString() -> Str;
+  internal fun toString() -> String;
 
   internal fun toFloat() -> float;
   internal fun toDouble() -> double;
@@ -174,7 +174,7 @@ internal class long {
   }
   internal fun toCharUnchecked() -> char;
   internal fun toInt() -> int;
-  internal fun toString() -> Str;
+  internal fun toString() -> String;
 
   internal fun toFloat() -> float;
   internal fun toDouble() -> double;
@@ -231,7 +231,7 @@ internal class float {
   internal fun toInt() -> int;
   internal fun toLong() -> long;
   internal fun toDouble() -> double;
-  internal fun toString() -> Str;
+  internal fun toString() -> String;
 
   internal fun asInt() -> int;
 
@@ -254,7 +254,7 @@ internal class double {
   internal fun toInt() -> int;
   internal fun toLong() -> long;
   internal fun toFloat() -> float;
-  internal fun toString() -> Str;
+  internal fun toString() -> String;
 
   internal fun asLong() -> long;
 
@@ -370,7 +370,7 @@ fun bubbleSort<T: Comparable>(array: Array<T>) {
 
 internal fun defaultValue<T>() -> T;
 
-internal fun loadFunction(name: Str) -> long;
+internal fun loadFunction(name: String) -> long;
 internal fun call0(fct: long) -> long;
 internal fun call1(fct: long, arg0: long) -> long;
 internal fun call2(fct: long, arg0: long, arg1: long) -> long;
@@ -380,7 +380,7 @@ internal fun native_malloc(size: long) -> long;
 internal fun native_free(address: long);
 internal fun set_uint8(address: long, val: byte);
 
-fun native_string(val: Str) -> long {
+fun native_string(val: String) -> long {
   var i = 0;
   let len = val.len();
 
@@ -409,11 +409,11 @@ fun getppid() -> int {
 internal fun sleep(seconds: int);
 
 class Exception {
-  var msg: Str = nil;
+  var msg: String = nil;
   var backtrace: Array<int> = nil;
   var elements: Array<StackTraceElement> = nil;
 
-  init(msg: Str) {
+  init(msg: String) {
     self.retrieveStackTrace();
     self.msg = msg;
   }
@@ -465,8 +465,8 @@ class Exception {
   internal fun getStackTraceElement(idx: int) -> StackTraceElement;
 }
 
-class StackTraceElement(let name: Str, let line: int) {
-  fun toString() -> Str {
+class StackTraceElement(let name: String, let line: int) {
+  fun toString() -> String {
     return self.name + ": " + self.line.toString();
   }
 }

--- a/stdlib/string.dora
+++ b/stdlib/string.dora
@@ -1,5 +1,5 @@
-internal class Str {
-  fun equals(rhs: Str) -> bool {
+internal class String {
+  fun equals(rhs: String) -> bool {
     var i = 0;
 
     if self.len() != rhs.len() {
@@ -19,31 +19,21 @@ internal class Str {
     return true;
   }
 
-  internal fun compareTo(rhs: Str) -> int;
+  internal fun compareTo(rhs: String) -> int;
 
   internal fun len() -> int;
   internal fun parseInt() -> int;
   internal fun parseLong() -> long;
-  internal fun plus(rhs: Str) -> Str;
+  internal fun plus(rhs: String) -> String;
 
   internal fun getByte(idx: int) -> byte;
-  internal fun clone() -> Str;
+  internal fun clone() -> String;
 
-  internal static fun fromBytesPartOrNull(val: Array<byte>, offset: int, len: int) -> Str;
-  internal static fun fromStrPartOrNull(val: Str, offset: int, len: int) -> Str;
+  internal static fun fromBytesPartOrNull(val: Array<byte>, offset: int, len: int) -> String;
+  internal static fun fromStringPartOrNull(val: String, offset: int, len: int) -> String;
 
-  static fun fromBytesPart(val: Array<byte>, offset: int, len: int) throws -> Str {
-    let str = Str::fromBytesPartOrNull(val, offset, len);
-
-    if str === nil {
-      throw "invalid utf-8 encoding.";
-    }
-
-    return str;
-  }
-
-  static fun fromBytes(val: Array<byte>) throws -> Str {
-    let str = Str::fromBytesPartOrNull(val, 0, val.len());
+  static fun fromBytesPart(val: Array<byte>, offset: int, len: int) throws -> String {
+    let str = String::fromBytesPartOrNull(val, offset, len);
 
     if str === nil {
       throw "invalid utf-8 encoding.";
@@ -52,8 +42,8 @@ internal class Str {
     return str;
   }
 
-  static fun fromStrPart(val: Str, offset: int, len: int) throws -> Str {
-    let str = Str::fromStrPartOrNull(val, offset, len);
+  static fun fromBytes(val: Array<byte>) throws -> String {
+    let str = String::fromBytesPartOrNull(val, 0, val.len());
 
     if str === nil {
       throw "invalid utf-8 encoding.";
@@ -62,7 +52,17 @@ internal class Str {
     return str;
   }
 
-  static fun fromStr(val: Str) -> Str {
+  static fun fromStringPart(val: String, offset: int, len: int) throws -> String {
+    let str = String::fromStringPartOrNull(val, offset, len);
+
+    if str === nil {
+      throw "invalid utf-8 encoding.";
+    }
+
+    return str;
+  }
+
+  static fun fromString(val: String) -> String {
     return val.clone();
   }
 
@@ -70,12 +70,12 @@ internal class Str {
       return self.len() == 0;
   }
 
-  fun codePoints() -> StrCodePointIterator {
-    return StrCodePointIterator(self, 0);
+  fun codePoints() -> StringCodePointIterator {
+    return StringCodePointIterator(self, 0);
   }
 }
 
-class StrCodePointIterator(let value: Str, var ind: int) {
+class StringCodePointIterator(let value: String, var ind: int) {
     fun hasNext() -> bool {
         return self.ind < self.value.len();
     }
@@ -130,7 +130,7 @@ class StrCodePointIterator(let value: Str, var ind: int) {
         return i;
     }
 
-    fun toString() -> Str {
-        return try! Str::fromStrPart(self.value, self.ind, self.value.len() - self.ind);
+    fun toString() -> String {
+        return try! String::fromStringPart(self.value, self.ind, self.value.len() - self.ind);
     }
 }

--- a/stdlib/utils.dora
+++ b/stdlib/utils.dora
@@ -297,7 +297,7 @@ class StringBuf(var buf: Array<byte>, var length: int) {
     return self;
   }
 
-  fun appendString(value: Str) -> StringBuf {
+  fun appendString(value: String) -> StringBuf {
     self.reserve(value.len());
     var i = 0;
 
@@ -310,7 +310,7 @@ class StringBuf(var buf: Array<byte>, var length: int) {
     return self;
   }
 
-  fun toString() -> Str {
-    return try! Str::fromBytesPart(self.buf, 0, self.len());
+  fun toString() -> String {
+    return try! String::fromBytesPart(self.buf, 0, self.len());
   }
 }

--- a/tests/array14.dora
+++ b/tests/array14.dora
@@ -1,4 +1,4 @@
 fun main() {
-    let x = Array::<Str>(1);
+    let x = Array::<String>(1);
     x[0] = nil;
 }

--- a/tests/array5.dora
+++ b/tests/array5.dora
@@ -7,7 +7,7 @@ fun main() {
 }
 
 class A {
-  fun get(index: Str) -> int {
+  fun get(index: String) -> int {
     return 1;
   }
 }

--- a/tests/ctor1.dora
+++ b/tests/ctor1.dora
@@ -1,7 +1,7 @@
 //= output "xyz"
 
 class X {
-    init(msg: Str) { print(msg); }
+    init(msg: String) { print(msg); }
 }
 
 fun main() {

--- a/tests/default-value1.dora
+++ b/tests/default-value1.dora
@@ -20,7 +20,7 @@ fun main() {
   let x = defaultValue::<double>();
   assert(x == 0.0);
 
-  let x = defaultValue::<Str>();
+  let x = defaultValue::<String>();
   assert(x === nil);
 
   let x = defaultValue::<Array<int> >();

--- a/tests/eh1.dora
+++ b/tests/eh1.dora
@@ -3,7 +3,7 @@ fun main() {
 
   do {
     a = 2;
-  } catch x: Str {
+  } catch x: String {
     a = 3;
   }
 

--- a/tests/eh10.dora
+++ b/tests/eh10.dora
@@ -3,7 +3,7 @@
 fun main() {
   do {
     foo();
-  } catch x: Str {
+  } catch x: String {
     println(x);
   }
 }

--- a/tests/eh11.dora
+++ b/tests/eh11.dora
@@ -3,7 +3,7 @@
 fun main() {
   do {
     try foo();
-  } catch x: Str {
+  } catch x: String {
     println(x);
   }
 }

--- a/tests/eh2.dora
+++ b/tests/eh2.dora
@@ -3,7 +3,7 @@ fun main() {
 
   do {
     a = 2;
-  } catch x: Str {
+  } catch x: String {
     a = 3;
   } finally {
     a = 4;

--- a/tests/eh7.dora
+++ b/tests/eh7.dora
@@ -11,7 +11,7 @@ fun main() {
     println("unreachable");
     a = 4;
 
-  } catch x: Str {
+  } catch x: String {
     a = 5;
     println(x);
   }

--- a/tests/eh9.dora
+++ b/tests/eh9.dora
@@ -3,7 +3,7 @@
 fun main() {
   do {
     try foo();
-  } catch x: Str {
+  } catch x: String {
     println(x);
   }
 }

--- a/tests/fn6.dora
+++ b/tests/fn6.dora
@@ -28,8 +28,8 @@ fun f(a: int, b: int, c: int, d: int,
    assert(h == 8);
 }
 
-fun g(a: Str, b: Str, c: Str, d: Str,
-     e: Str, f: Str, g: Str, h: Str) {
+fun g(a: String, b: String, c: String, d: String,
+     e: String, f: String, g: String, h: String) {
    assert(a == "a");
    assert(b == "b");
    assert(c == "c");

--- a/tests/generic-array-get.dora
+++ b/tests/generic-array-get.dora
@@ -15,7 +15,7 @@ fun main() {
   assert(x[0] == 2.0);
   assert(double_array_get(x, 3) == 2.0);
 
-  let x = Array::<Str>(3, "hello");
+  let x = Array::<String>(3, "hello");
   assert(x[0] == "hello");
   assert(str_array_get(x, 2) == "hello");
 
@@ -46,7 +46,7 @@ fun double_array_get(x: Array<double>, idx: int) -> double {
   return x[idx];
 }
 
-fun str_array_get(x: Array<Str>, idx: int) -> Str {
+fun str_array_get(x: Array<String>, idx: int) -> String {
   return x[idx];
 }
 

--- a/tests/generic-array-len.dora
+++ b/tests/generic-array-len.dora
@@ -31,11 +31,11 @@ fun main() {
   assert(x.len() == 4);
   assert(double_array_len(x) == 4);
 
-  let x = Array::<Str>();
+  let x = Array::<String>();
   assert(x.len() == 0);
   assert(str_array_len(x) == 0);
 
-  let x = Array::<Str>(3, "hello");
+  let x = Array::<String>(3, "hello");
   assert(x.len() == 3);
   assert(str_array_len(x) == 3);
 
@@ -64,7 +64,7 @@ fun double_array_len(x: Array<double>) -> int {
   return x.len();
 }
 
-fun str_array_len(x: Array<Str>) -> int {
+fun str_array_len(x: Array<String>) -> int {
   return x.len();
 }
 

--- a/tests/generic-array-set.dora
+++ b/tests/generic-array-set.dora
@@ -19,7 +19,7 @@ fun main() {
   assert(x[0] == 2.0);
   assert(x[1] == 1.0);
 
-  let x = Array::<Str>(2, "hello");
+  let x = Array::<String>(2, "hello");
   str_array_set(x, 1, "abc");
   assert(x[0] == "hello");
   assert(x[1] == "abc");
@@ -46,7 +46,7 @@ fun double_array_set(x: Array<double>, idx: int, val: double) {
   x[idx] = val;
 }
 
-fun str_array_set(x: Array<Str>, idx: int, val: Str) {
+fun str_array_set(x: Array<String>, idx: int, val: String) {
   x[idx] = val;
 }
 

--- a/tests/generic10.dora
+++ b/tests/generic10.dora
@@ -3,7 +3,7 @@ fun main() {
     assert(bar.x.fst == 11);
     assert(bar.x.snd == 10);
 
-    let bar = Bar::<Str>("hello");
+    let bar = Bar::<String>("hello");
     assert(bar.x.fst == "hello");
     assert(bar.x.snd == 10);
 }

--- a/tests/generic11.dora
+++ b/tests/generic11.dora
@@ -1,6 +1,6 @@
 fun main() {
   assert(Foo::id::<int>(1) == 1);
-  assert(Foo::id::<Str>("hello") == "hel" + "lo");
+  assert(Foo::id::<String>("hello") == "hel" + "lo");
 }
 
 class Foo {

--- a/tests/generic12.dora
+++ b/tests/generic12.dora
@@ -2,7 +2,7 @@ fun main() {
   let foo = Foo::<int>(10);
   assert(foo.x == 10);
 
-  let foo = Foo::<Str>("hey");
+  let foo = Foo::<String>("hey");
   assert(foo.x == "hey");
 }
 

--- a/tests/generic2.dora
+++ b/tests/generic2.dora
@@ -1,13 +1,13 @@
 //= output "hello1"
 
 fun main() {
-  let a = A::<Str>(foo(1));
+  let a = A::<String>(foo(1));
   forceCollect();
   print(a.x);
 }
 
 class A<T>(let x: T)
 
-fun foo(a: int) -> Str {
+fun foo(a: int) -> String {
   return "hello" + a.toString();
 }

--- a/tests/generic4.dora
+++ b/tests/generic4.dora
@@ -1,7 +1,7 @@
 //= output "hello1"
 
 fun main() {
-  let a = A::<Str>(foo(1));
+  let a = A::<String>(foo(1));
   forceCollect();
   print(a.getx());
 }
@@ -12,6 +12,6 @@ class A<T>(let x: T) {
     }
 }
 
-fun foo(a: int) -> Str {
+fun foo(a: int) -> String {
   return "hello" + a.toString();
 }

--- a/tests/generic6.dora
+++ b/tests/generic6.dora
@@ -1,7 +1,7 @@
 fun main() {
     foo::<int>(1);
     foo::<float>(3F);
-    foo::<Str>("hello");
+    foo::<String>("hello");
 }
 
 fun foo<T>(val: T) {}

--- a/tests/generic7.dora
+++ b/tests/generic7.dora
@@ -1,7 +1,7 @@
 fun main() {
     assert(1 == foo::<int>(1));
     assert(3F == foo::<float>(3F));
-    assert("hel" + "lo" == foo::<Str>("hello"));
+    assert("hel" + "lo" == foo::<String>("hello"));
 }
 
 fun foo<T>(val: T) -> T { return val; }

--- a/tests/generic9.dora
+++ b/tests/generic9.dora
@@ -2,7 +2,7 @@ fun main() {
     let a = A::<int>();
     consume(a.x);
 
-    let b = A::<Str>();
+    let b = A::<String>();
     consume2(b.x);
 }
 
@@ -18,6 +18,6 @@ fun consume(x: Array<int>) {
     assert(x[9] == 0);
 }
 
-fun consume2(x: Array<Str>) {
+fun consume2(x: Array<String>) {
     assert(x[9] === nil);
 }

--- a/tests/nil2.dora
+++ b/tests/nil2.dora
@@ -1,5 +1,5 @@
 fun main() {
-  let x: Str = nil;
+  let x: String = nil;
 
   assert(x === nil);
   assert(!(x !== nil));

--- a/tests/nil4.dora
+++ b/tests/nil4.dora
@@ -1,6 +1,6 @@
 //= error nil
 
 fun main() {
-  let x: Str = nil;
+  let x: String = nil;
   assert(x.len() == 0);
 }

--- a/tests/stdlib/call-assert.dora
+++ b/tests/stdlib/call-assert.dora
@@ -1,5 +1,5 @@
 //= error assert
-//= output "assert failed\n0: foo(): 9\n1: call(Str): 22\n2: main(): 5\n"
+//= output "assert failed\n0: foo(): 9\n1: call(String): 22\n2: main(): 5\n"
 
 fun main() {
     call("foo");

--- a/tests/stdlib/string.dora
+++ b/tests/stdlib/string.dora
@@ -15,7 +15,7 @@ fun test_multiple_ascii_chars() {
     bytes[1] = 'b'.toInt().toByte();
     bytes[2] = 'c'.toInt().toByte();
 
-    let val = try! Str::fromBytes(bytes);
+    let val = try! String::fromBytes(bytes);
     let it = val.codePoints();
 
     assert(it.hasNext() == true);
@@ -31,7 +31,7 @@ fun test_1byte() {
     let bytes = Array::<byte>(1);
     bytes[0] = 0x24Y;
 
-    let val = try! Str::fromBytes(bytes);
+    let val = try! String::fromBytes(bytes);
     let it = val.codePoints();
 
     assert(it.hasNext() == true);
@@ -44,7 +44,7 @@ fun test_2bytes() {
     bytes[0] = 0xC2Y;
     bytes[1] = 0xA2Y;
 
-    let val = try! Str::fromBytes(bytes);
+    let val = try! String::fromBytes(bytes);
     let it = val.codePoints();
 
     assert(it.hasNext() == true);
@@ -58,7 +58,7 @@ fun test_3bytes() {
     bytes[1] = 0x82Y;
     bytes[2] = 0xACY;
 
-    let val = try! Str::fromBytes(bytes);
+    let val = try! String::fromBytes(bytes);
     let it = val.codePoints();
 
     assert(it.hasNext() == true);
@@ -73,7 +73,7 @@ fun test_4bytes() {
     bytes[2] = 0x8DY;
     bytes[3] = 0x88Y;
 
-    let val = try! Str::fromBytes(bytes);
+    let val = try! String::fromBytes(bytes);
     let it = val.codePoints();
 
     assert(it.hasNext() == true);
@@ -86,9 +86,9 @@ fun test_invalid() {
     bytes[0] = 0x80Y;
 
     do {
-        try Str::fromBytes(bytes);
+        try String::fromBytes(bytes);
         assert(false);
-    } catch x: Str {
+    } catch x: String {
         assert(true);
     }
 }

--- a/tests/str/from-bytes.dora
+++ b/tests/str/from-bytes.dora
@@ -15,7 +15,7 @@ fun test_multiple_ascii_chars() {
     bytes[1] = 'b'.toInt().toByte();
     bytes[2] = 'c'.toInt().toByte();
 
-    let val = try! Str::fromBytes(bytes);
+    let val = try! String::fromBytes(bytes);
     assert(val == "abc");
 }
 
@@ -23,7 +23,7 @@ fun test_1byte() {
     let bytes = Array::<byte>(1);
     bytes[0] = 0x24Y;
 
-    try! Str::fromBytes(bytes);
+    try! String::fromBytes(bytes);
 }
 
 fun test_2bytes() {
@@ -31,7 +31,7 @@ fun test_2bytes() {
     bytes[0] = 0xC2Y;
     bytes[1] = 0xA2Y;
 
-    try! Str::fromBytes(bytes);
+    try! String::fromBytes(bytes);
 }
 
 fun test_3bytes() {
@@ -40,7 +40,7 @@ fun test_3bytes() {
     bytes[1] = 0x82Y;
     bytes[2] = 0xACY;
 
-    try! Str::fromBytes(bytes);
+    try! String::fromBytes(bytes);
 }
 
 fun test_4bytes() {
@@ -50,7 +50,7 @@ fun test_4bytes() {
     bytes[2] = 0x8DY;
     bytes[3] = 0x88Y;
 
-    try! Str::fromBytes(bytes);
+    try! String::fromBytes(bytes);
 }
 
 fun test_invalid() {
@@ -58,9 +58,9 @@ fun test_invalid() {
     bytes[0] = 0x80Y;
 
     do {
-        try Str::fromBytes(bytes);
+        try String::fromBytes(bytes);
         assert(false);
-    } catch x: Str {
+    } catch x: String {
         assert(true);
     }
 }

--- a/tests/str3.dora
+++ b/tests/str3.dora
@@ -3,6 +3,6 @@ fun main() {
   assert(!eq("aa"));
 }
 
-fun eq(a: Str) -> bool {
+fun eq(a: String) -> bool {
   return "ab" == a + "b";
 }

--- a/tests/str7.dora
+++ b/tests/str7.dora
@@ -1,10 +1,10 @@
 //= output "abxy\n"
 
 fun main() {
-    let x = Array::<Str>();
+    let x = Array::<String>();
     assert(x.len() == 0);
 
-    let x = Array::<Str>(10, nil);
+    let x = Array::<String>(10, nil);
     assert(x.len() == 10);
 
     x[0] = "a" + "b";

--- a/tests/throw1.dora
+++ b/tests/throw1.dora
@@ -1,6 +1,6 @@
 //= error nil
 
 fun main() {
-  let x: Str = nil;
+  let x: String = nil;
   throw x;
 }

--- a/tests/vec2.dora
+++ b/tests/vec2.dora
@@ -1,7 +1,7 @@
 //= output "321"
 
 fun main() {
-    let x = Vec::<Str>();
+    let x = Vec::<String>();
     x.push(1.toString());
     x.push(2.toString());
     x.push(3.toString());

--- a/tests/whiteboard/simple-map.dora
+++ b/tests/whiteboard/simple-map.dora
@@ -1,5 +1,5 @@
 fun main() {
-    let m = SlowMap::<int, Str>();
+    let m = SlowMap::<int, String>();
     assert(m.insert(1, "hello"));
     assert(m.insert(2, "world"));
 


### PR DESCRIPTION
It's more consistent with the toString function, and in general avoiding
abbreviations makes things slightly more approachable as there are often
multiple hypothetical abbreviations, but usually only one way to write
the full name.

My mid-term view is that I would like to prefer consistent, non-
abbreviated names everywhere, while allowing users to rename these names
to shorter ones as required on import.

All of this, of course, within reasons: The rule of thumb I propose for
abbreviations in Dora is this:

> If more people know the abbreviation than the full name,
> or if the abbreviations is used so overwhelmingly such
> that some people have issues coming up with the correct
> full name, then these abbreviations have become names of
> their own – they are fine to use.

Examples:
- Http instead of Hypertext Transfer Protocol
- Html instead of Hypertext Markup Language
- Css  instead of Cascading Style Sheets