### PR TITLE
Add Nothing type

### DIFF
--- a/src/baseline/expr.rs
+++ b/src/baseline/expr.rs
@@ -1958,7 +1958,8 @@ fn result_reg(mode: MachineMode) -> ExprStore {
 fn check_for_nil(ty: BuiltinType) -> bool {
     match ty {
         BuiltinType::Error => panic!("error shouldn't occur in code generation."),
-        BuiltinType::Unit => false,
+        BuiltinType::Nothing
+        | BuiltinType::Unit => false,
         BuiltinType::Byte
         | BuiltinType::Char
         | BuiltinType::Int

--- a/src/ctxt.rs
+++ b/src/ctxt.rs
@@ -129,6 +129,7 @@ impl<'ast> SemContext<'ast> {
                 long_class: empty_class_id,
                 float_class: empty_class_id,
                 double_class: empty_class_id,
+                nothing_class: empty_class_id,
                 object_class: empty_class_id,
                 string_class: empty_class_id,
 
@@ -555,6 +556,7 @@ pub struct KnownElements {
     pub long_class: ClassId,
     pub float_class: ClassId,
     pub double_class: ClassId,
+    pub nothing_class: ClassId,
     pub object_class: ClassId,
     pub string_class: ClassId,
     pub array_class: ClassId,

--- a/src/semck/prelude.rs
+++ b/src/semck/prelude.rs
@@ -15,6 +15,8 @@ pub fn internal_classes<'ast>(ctxt: &mut SemContext<'ast>) {
     ctxt.vips.float_class = internal_class(ctxt, "float", Some(BuiltinType::Float));
     ctxt.vips.double_class = internal_class(ctxt, "double", Some(BuiltinType::Double));
 
+    ctxt.vips.nothing_class = internal_class(ctxt, "Nothing", Some(BuiltinType::Nothing));
+
     ctxt.vips.object_class = internal_class(ctxt, "Object", None);
     ctxt.vips.string_class = internal_class(ctxt, "String", None);
 

--- a/src/semck/typeck.rs
+++ b/src/semck/typeck.rs
@@ -1420,6 +1420,7 @@ fn arg_allows(
 ) -> bool {
     match def {
         BuiltinType::Error => panic!("error shouldn't occur in fct definition."),
+        BuiltinType::Nothing => false,
         BuiltinType::Unit
         | BuiltinType::Bool
         | BuiltinType::Byte

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -12,6 +12,9 @@ pub enum BuiltinType {
     // couldn't determine type because of error
     Error,
 
+    // bottom type, used for functions that never return
+    Nothing,
+
     // type with only one value: ()
     Unit,
 
@@ -185,6 +188,7 @@ impl BuiltinType {
     pub fn name(&self, vm: &VM) -> String {
         match *self {
             BuiltinType::Error => "<error>".into(),
+            BuiltinType::Nothing => "Nothing".into(),
             BuiltinType::Unit => "()".into(),
             BuiltinType::Byte => "byte".into(),
             BuiltinType::Char => "char".into(),
@@ -270,7 +274,8 @@ impl BuiltinType {
             // allow all types for Error, there is already an error,
             // don't report too many messages for the same error
             BuiltinType::Error => true,
-
+            // nothing is a subtype of everything
+            BuiltinType::Nothing => true,
             BuiltinType::Unit
             | BuiltinType::Bool
             | BuiltinType::Byte
@@ -310,6 +315,7 @@ impl BuiltinType {
     pub fn size(&self, vm: &VM) -> i32 {
         match *self {
             BuiltinType::Error => panic!("no size for error."),
+            BuiltinType::Nothing => panic!("no size for nothing."),
             BuiltinType::Unit => 0,
             BuiltinType::Bool => 1,
             BuiltinType::Byte => 1,
@@ -341,6 +347,7 @@ impl BuiltinType {
     pub fn align(&self, vm: &VM) -> i32 {
         match *self {
             BuiltinType::Error => panic!("no alignment for error."),
+            BuiltinType::Nothing => panic!("no alignment for nothing."),
             BuiltinType::Unit => 0,
             BuiltinType::Bool => 1,
             BuiltinType::Byte => 1,
@@ -372,6 +379,7 @@ impl BuiltinType {
     pub fn mode(&self) -> MachineMode {
         match *self {
             BuiltinType::Error => panic!("no machine mode for error."),
+            BuiltinType::Nothing => panic!("no machine mode for nothing."),
             BuiltinType::Unit => panic!("no machine mode for ()."),
             BuiltinType::Bool => MachineMode::Int8,
             BuiltinType::Byte => MachineMode::Int8,

--- a/stdlib/prelude.dora
+++ b/stdlib/prelude.dora
@@ -25,6 +25,8 @@ internal fun throwFromNativeButNotThrows(val: bool);
 
 internal fun timestamp() -> long;
 
+internal class Nothing
+
 internal class bool {
   internal fun toInt() -> int;
   fun toString() -> String {

--- a/tests/nothing.dora
+++ b/tests/nothing.dora
@@ -1,0 +1,5 @@
+fun main() {
+  fail();
+}
+
+fun fail() -> Nothing = throw "failed";


### PR DESCRIPTION
This allows a more precise typing and a distinction between functions
that return no value of interest (Unit) and functions that never return
(Nothing), due to throwing exceptions, looping forever.

This allows making `throw ""` and `fun f() -> Nothing = throw ""; f()`
behave consistently from a typing perspective, which is required to
gracefully deal with e. g. if-expressions' definite assignment rules.