### PR TITLE
Generic syntax overhaul

### DIFF
--- a/bench/fannkuchredux/fannkuchredux.dora
+++ b/bench/fannkuchredux/fannkuchredux.dora
@@ -5,16 +5,16 @@ fun main() {
 }
 
 fun fannkuch(n: Int) -> Int {
-  let perm = arrayFill::<Int>(n, 0);
-  let perm1 = arrayFill::<Int>(n, 0);
-  let count = arrayFill::<Int>(n, 0);
+  let perm = arrayFill[Int](n, 0);
+  let perm1 = arrayFill[Int](n, 0);
+  let count = arrayFill[Int](n, 0);
   var maxFlipsCount = 0;
   var permCount = 0;
   var checksum = 0;
 
   var i = 0;
   while i < n {
-    perm1[i] = i;
+    perm1.set(i, i);
     i = i + 1;
   }
 
@@ -22,33 +22,33 @@ fun fannkuch(n: Int) -> Int {
 
   while true {
     while r != 1 {
-      count[r-1] = r;
+      count.set(r-1, r);
       r = r - 1;
     }
 
     var i = 0;
     while i < n {
-      perm[i] = perm1[i];
+      perm.set(i, perm1.get(i));
       i = i + 1;
     }
 
     var flipsCount = 0;
-    var k = perm[0];
+    var k = perm.get(0);
 
     while k != 0 {
       let k2 = (k+1) / 2;
 
       var i = 0;
       while i < k2 {
-        let temp = perm[i];
-        perm[i] = perm[k-i];
-        perm[k-i] = temp;
+        let temp = perm.get(i);
+        perm.set(i, perm.get(k-i));
+        perm.set(k-i, temp);
 
         i = i + 1;
       }
 
       flipsCount = flipsCount + 1;
-      k = perm[0];
+      k = perm.get(0);
     }
 
     maxFlipsCount = max(maxFlipsCount, flipsCount);
@@ -65,20 +65,20 @@ fun fannkuch(n: Int) -> Int {
         return maxFlipsCount;
       }
 
-      let perm0 = perm1[0];
+      let perm0 = perm1.get(0);
       var i = 0;
 
       while i < r {
         let j = i + 1;
-        perm1[i] = perm1[j];
+        perm1.set(i, perm1.get(j));
         i = j;
       }
 
-      perm1[r] = perm0;
+      perm1.set(r, perm0);
 
-      count[r] = count[r] - 1;
+      count.set(r, count.get(r) - 1);
 
-      if count[r] > 0 { break; }
+      if count.get(r) > 0 { break; }
 
       r = r + 1;
     }

--- a/bench/gcbench/gcbench.dora
+++ b/bench/gcbench/gcbench.dora
@@ -93,12 +93,12 @@ fun main() {
     populate(longLivedTreeDepth, longLivedTree);
 
     println("Creating a long-lived array of " + kArraySize.toString() + " doubles");
-    let array = arrayFill::<Double>(kArraySize, 0.0);
+    let array = arrayFill[Double](kArraySize, 0.0);
 
     var i = 0;
 
     while i < kArraySize / 2 {
-        array[i] = 1.0/i.toDouble();
+        array.set(i, 1.0/i.toDouble());
         i = i + 1;
     }
 
@@ -109,7 +109,7 @@ fun main() {
         d = d + 2;
     }
 
-    assert(longLivedTree !== nil && array[1000] == 1.0/1000.0);
+    assert(longLivedTree !== nil && array.get(1000) == 1.0/1000.0);
     let finish = timestamp();
     let elapsed = (finish - start).toFloat() / 1000.0F / 1000.0F;
     println("Completed in " + elapsed.toString() + "ms.");

--- a/bench/gcold/gcold.dora
+++ b/bench/gcold/gcold.dora
@@ -13,9 +13,9 @@ var youngBytes: Long;
 var nodes: Long;
 var actuallyMut: Long;
 var mutatorSum: Long;
-var aexport: Array<Int>;
+var aexport: Array[Int];
 
-var trees: Array<TreeNode>;
+var trees: Array[TreeNode];
 var where: Int;
 var rnd: Random;
 
@@ -91,7 +91,7 @@ fun makeTree(h: Int) -> TreeNode {
 
 fun initialize() {
     let ntrees = ((size * MEG).toLong() / treeSize).toInt();
-    trees = Array::<TreeNode>(ntrees);
+    trees = Array[TreeNode](ntrees);
 
     println("Allocating " + ntrees.toString() + " trees.");
     println("  (" + (ntrees.toLong() * treeSize).toString() + " bytes)");
@@ -99,7 +99,7 @@ fun initialize() {
     var i = 0;
 
     while i < ntrees {
-        trees[i] = makeTree(treeHeight);
+        trees.set(i, makeTree(treeHeight));
         i = i + 1;
     }
 
@@ -112,7 +112,7 @@ fun checkTrees() {
     var i = 0;
 
     while i < ntrees {
-        let t = trees[i];
+        let t = trees.get(i);
 
         let h1 = height(t);
         let h2 = shortestPath(t);
@@ -160,7 +160,7 @@ fun oldGenAlloc(n: Long) {
 
     var i = 0;
     while i < full {
-        trees[where] = makeTree(treeHeight);
+        trees.set(where, makeTree(treeHeight));
         where = where + 1;
 
         if where == trees.length() {
@@ -173,7 +173,7 @@ fun oldGenAlloc(n: Long) {
     while partial > INSIGNIFICANT {
         let h = bytesToHeight(partial);
         let newTree = makeTree(h);
-        replaceTree(trees[where], newTree);
+        replaceTree(trees.get(where), newTree);
         where = where + 1;
 
         if where == trees.length() {
@@ -190,8 +190,8 @@ fun oldGenSwapSubtrees() {
     let depth = rnd.nextIntWithBound(treeHeight);
     var path = rnd.nextInt();
 
-    var tn1 = trees[index1];
-    var tn2 = trees[index2];
+    var tn1 = trees.get(index1);
+    var tn2 = trees.get(index2);
 
     var i = 0;
 
@@ -248,7 +248,7 @@ fun doYoungGenAlloc(n: Long, nwords: Int) {
     var allocated = 0L;
 
     while allocated < n {
-        aexport = Array::<Long>(nwords);
+        aexport = Array[Long](nwords);
         allocated = allocated + nbytes.toLong();
     }
 

--- a/bench/mandelbrot/mandelbrot.dora
+++ b/bench/mandelbrot/mandelbrot.dora
@@ -7,7 +7,7 @@ const BUFFER_SIZE: Int = 8192;
 class Mandelbrot(let size: Int) {
     let fac: Double = 2.0 / size.toDouble();
     var shift: Int;
-    let buf: Array<Byte> = Array::<Byte>(BUFFER_SIZE);
+    let buf: Array[Byte] = Array[Byte](BUFFER_SIZE);
     var bufLen: Int;
 
     init(size: Int): self(size) {
@@ -99,6 +99,6 @@ class Mandelbrot(let size: Int) {
     }
 }
 
-fun write(buf: Array<Byte>, offset: Int, len: Int) {
+fun write(buf: Array[Byte], offset: Int, len: Int) {
     unimplemented();
 }

--- a/bench/nbody/nbody.dora
+++ b/bench/nbody/nbody.dora
@@ -15,14 +15,14 @@ fun main() {
 }
 
 class NBodySystem {
-    let bodies: Array<Body> = Array::<Body>(5);
+    let bodies: Array[Body] = Array[Body](5);
 
     init() {
-        bodies[0] = Body::sun();
-        bodies[1] = Body::jupiter();
-        bodies[2] = Body::saturn();
-        bodies[3] = Body::uranus();
-        bodies[4] = Body::neptune();
+        bodies.set(0, Body::sun());
+        bodies.set(1, Body::jupiter());
+        bodies.set(2, Body::saturn());
+        bodies.set(3, Body::uranus());
+        bodies.set(4, Body::neptune());
 
         var px = 0.0;
         var py = 0.0;
@@ -38,14 +38,14 @@ class NBodySystem {
             i = i + 1;
         }
 
-        bodies[0].offsetMomentum(px, py, pz);
+        bodies.get(0).offsetMomentum(px, py, pz);
     }
 
     fun advance(dt: Double) {
         var i = 0;
 
         while i < self.bodies.length() {
-            let iBody = self.bodies[i];
+            let iBody = self.bodies.get(i);
             var j = i + 1;
 
             while j < self.bodies.length() {
@@ -74,7 +74,7 @@ class NBodySystem {
         var i = 0;
 
         while i < self.bodies.length() {
-            let body = self.bodies[i];
+            let body = self.bodies.get(i);
 
             body.x = body.x + dt * body.vx;
             body.y = body.y + dt * body.vy;
@@ -94,7 +94,7 @@ class NBodySystem {
       var i = 0;
 
       while i < self.bodies.length() {
-         let iBody = bodies[i];
+         let iBody = bodies.get(i);
          e = e + 0.5 * iBody.mass *
             ( iBody.vx * iBody.vx
                 + iBody.vy * iBody.vy
@@ -103,7 +103,7 @@ class NBodySystem {
         var j = i+1;
 
         while j < self.bodies.length() {
-            let jBody = bodies[j];
+            let jBody = bodies.get(j);
 
             dx = iBody.x - jBody.x;
             dy = iBody.y - jBody.y;

--- a/bench/raytracer/raytracer.dora
+++ b/bench/raytracer/raytracer.dora
@@ -2,15 +2,15 @@ const alpha: Int = 255<24;
 
 class RayTracer {
     var scene: Scence;
-    var lights: Array<Light>;
-    var prim: Array<Primitive>;
+    var lights: Array[Light];
+    var prim: Array[Primitive];
     var view: View;
     var tRay: Ray;
     var L: Vec3;
     var inter: Isect;
     var height: Int;
     var width: Int;
-    var datasizes: Array<Int>;
+    var datasizes: Array[Int];
     var checksum: Long;
     var size: Int;
     var numobjects: Int;

--- a/bench/raytracer/scene.dora
+++ b/bench/raytracer/scene.dora
@@ -1,11 +1,11 @@
 class Scene {
-    let lights: Vec<Light>;
-    let objects: Vec<Primitive>;
+    let lights: Vec[Light];
+    let objects: Vec[Primitive];
     var view: View;
 
     init() {
-        self.lights = Vec::<Light>();
-        self.objects = Vec::<Primitive>();
+        self.lights = Vec[Light]();
+        self.objects = Vec[Primitive]();
     }
 
     fun addLight(l: Light) {

--- a/bench/splay/splay.dora
+++ b/bench/splay/splay.dora
@@ -70,7 +70,7 @@ class Benchmark {
         var i = 0;
 
         while i < length - 1 {
-            if keys[i] >= keys[i+1] {
+            if keys.get(i) >= keys.get(i+1) {
                 fatalError("Splay tree not sorted");
             }
 
@@ -128,11 +128,11 @@ class Benchmark {
 
 fun generatePayloadTree(depth: Int, tag: String) -> PayloadNode {
     if depth == 0 {
-        let arr = Array::<Int>(10);
+        let arr = Array[Int](10);
         var i = 0;
 
         while i < 10 {
-            arr[i] = i;
+            arr.set(i, i);
             i = i + 1;
         }
 
@@ -256,8 +256,8 @@ class SplayTree {
         }
     }
 
-    fun exportKeys() -> Vec<Int> {
-        let keys = Vec::<Int>();
+    fun exportKeys() -> Vec[Int] {
+        let keys = Vec[Int]();
         exportKeysTraverse(keys, self.root);
         return keys;
     }
@@ -330,7 +330,7 @@ class SplayTree {
     }
 }
 
-fun exportKeysTraverse(list: Vec<Int>, node: SplayNode) {
+fun exportKeysTraverse(list: Vec[Int], node: SplayNode) {
     var current = node;
 
     while current !== nil {
@@ -348,4 +348,4 @@ class SplayNode(var key: Int, var value: PayloadNode) {
     var right: SplayNode;
 }
 
-class PayloadNode(let array: Array<Int>, let text: String, let left: PayloadNode, let right: PayloadNode)
+class PayloadNode(let array: Array[Int], let text: String, let left: PayloadNode, let right: PayloadNode)

--- a/lib/dora-parser/src/ast.rs
+++ b/lib/dora-parser/src/ast.rs
@@ -1230,7 +1230,6 @@ pub enum Expr {
     ExprSelf(ExprSelfType),
     ExprSuper(ExprSuperType),
     ExprNil(ExprNilType),
-    ExprArray(ExprArrayType),
     ExprConv(ExprConvType),
     ExprTry(ExprTryType),
     ExprLambda(ExprLambdaType),
@@ -1283,15 +1282,6 @@ impl Expr {
                            data_type: data_type,
                            is: is,
                        })
-    }
-
-    pub fn create_array(id: NodeId, pos: Position, object: Box<Expr>, index: Box<Expr>) -> Expr {
-        Expr::ExprArray(ExprArrayType {
-                            id: id,
-                            pos: pos,
-                            object: object,
-                            index: index,
-                        })
     }
 
     pub fn create_lit_char(id: NodeId, pos: Position, value: char) -> Expr {
@@ -1674,20 +1664,6 @@ impl Expr {
         }
     }
 
-    pub fn to_array(&self) -> Option<&ExprArrayType> {
-        match *self {
-            Expr::ExprArray(ref val) => Some(val),
-            _ => None,
-        }
-    }
-
-    pub fn is_array(&self) -> bool {
-        match *self {
-            Expr::ExprArray(_) => true,
-            _ => false,
-        }
-    }
-
     pub fn to_delegation(&self) -> Option<&ExprDelegationType> {
         match *self {
             Expr::ExprDelegation(ref val) => Some(val),
@@ -1793,7 +1769,6 @@ impl Expr {
             Expr::ExprSelf(ref val) => val.pos,
             Expr::ExprSuper(ref val) => val.pos,
             Expr::ExprNil(ref val) => val.pos,
-            Expr::ExprArray(ref val) => val.pos,
             Expr::ExprConv(ref val) => val.pos,
             Expr::ExprTry(ref val) => val.pos,
             Expr::ExprLambda(ref val) => val.pos,
@@ -1821,7 +1796,6 @@ impl Expr {
             Expr::ExprSelf(ref val) => val.id,
             Expr::ExprSuper(ref val) => val.id,
             Expr::ExprNil(ref val) => val.id,
-            Expr::ExprArray(ref val) => val.id,
             Expr::ExprConv(ref val) => val.id,
             Expr::ExprTry(ref val) => val.id,
             Expr::ExprLambda(ref val) => val.id,
@@ -1947,15 +1921,6 @@ pub struct ExprBinType {
     pub op: BinOp,
     pub lhs: Box<Expr>,
     pub rhs: Box<Expr>,
-}
-
-#[derive(Clone, Debug)]
-pub struct ExprArrayType {
-    pub id: NodeId,
-    pub pos: Position,
-
-    pub object: Box<Expr>,
-    pub index: Box<Expr>,
 }
 
 #[derive(Clone, Debug)]

--- a/lib/dora-parser/src/ast/dump.rs
+++ b/lib/dora-parser/src/ast/dump.rs
@@ -409,7 +409,6 @@ impl<'a> AstDumper<'a> {
             ExprUn(ref un) => self.dump_expr_un(un),
             ExprBin(ref bin) => self.dump_expr_bin(bin),
             ExprField(ref field) => self.dump_expr_field(field),
-            ExprArray(ref array) => self.dump_expr_array(array),
             ExprLitChar(ref lit) => self.dump_expr_lit_char(lit),
             ExprLitInt(ref lit) => self.dump_expr_lit_int(lit),
             ExprLitFloat(ref lit) => self.dump_expr_lit_float(lit),
@@ -519,12 +518,6 @@ impl<'a> AstDumper<'a> {
         self.indent(|d| d.dump_expr(&expr.rhs));
         dump!(self, "binary {:?} @ {} {}", expr.op, expr.pos, expr.id);
         self.indent(|d| d.dump_expr(&expr.lhs));
-    }
-
-    fn dump_expr_array(&mut self, expr: &ExprArrayType) {
-        self.indent(|d| d.dump_expr(&expr.object));
-        dump!(self, "[] @ {} {}", expr.pos, expr.id);
-        self.indent(|d| d.dump_expr(&expr.index));
     }
 
     fn dump_expr_lambda(&mut self, expr: &ExprLambdaType) {

--- a/lib/dora-parser/src/ast/visit.rs
+++ b/lib/dora-parser/src/ast/visit.rs
@@ -289,11 +289,6 @@ pub fn walk_expr<'v, V: Visitor<'v>>(v: &mut V, e: &'v Expr) {
             v.visit_expr(&value.rhs);
         }
 
-        ExprArray(ref value) => {
-            v.visit_expr(&value.object);
-            v.visit_expr(&value.index);
-        }
-
         ExprAssign(ref value) => {
             v.visit_expr(&value.lhs);
             v.visit_expr(&value.rhs);

--- a/lib/dora-parser/src/lexer/token.rs
+++ b/lib/dora-parser/src/lexer/token.rs
@@ -12,9 +12,6 @@ pub enum TokenKind {
     Identifier(String),
     End,
 
-    LQuote,
-    RQuote,
-
     // Keywords
     Class,
     This,
@@ -132,9 +129,6 @@ impl TokenKind {
 
             TokenKind::Identifier(_) => "identifier",
             TokenKind::End => "<<EOF>>",
-
-            TokenKind::LQuote => "<",
-            TokenKind::RQuote => ">",
 
             // Keywords
             TokenKind::Class => "class",

--- a/src/ctxt.rs
+++ b/src/ctxt.rs
@@ -840,7 +840,7 @@ impl<'ast> Fct<'ast> {
         repr.push_str(&ctxt.interner.str(self.name));
 
         if self.type_params.len() > 0 {
-            repr.push_str("<");
+            repr.push('[');
 
             repr.push_str(
                 &self
@@ -850,7 +850,7 @@ impl<'ast> Fct<'ast> {
                     .collect::<Vec<_>>()
                     .join(", "),
             );
-            repr.push_str(">");
+            repr.push(']');
         }
 
         repr.push_str("(");

--- a/src/semck.rs
+++ b/src/semck.rs
@@ -409,7 +409,7 @@ mod tests {
 
             println!("errors = {:?}", errors);
 
-            assert_eq!(1, errors.len());
+            assert_eq!(1, errors.len(), "found {} errors instead", errors.len());
             assert_eq!(pos, errors[0].pos);
             assert_eq!(msg, errors[0].msg);
         });

--- a/src/semck/clsdefck.rs
+++ b/src/semck/clsdefck.rs
@@ -445,39 +445,39 @@ mod tests {
 
     #[test]
     fn test_generic_class() {
-        ok("class A<T>");
-        ok("class A<X, Y>");
+        ok("class A[T]");
+        ok("class A[X, Y]");
         err(
-            "class A<T, T>",
+            "class A[T, T]",
             pos(1, 12),
             Msg::TypeParamNameNotUnique("T".into()),
         );
-        err("class A<>", pos(1, 1), Msg::TypeParamsExpected);
+        err("class A[]", pos(1, 1), Msg::TypeParamsExpected);
     }
 
     #[test]
     fn test_generic_argument() {
-        ok("class A<T>(val: T)");
-        ok("class A<T>(var val: T)");
-        ok("class A<T>(let val: T)");
+        ok("class A[T](val: T)");
+        ok("class A[T](var val: T)");
+        ok("class A[T](let val: T)");
     }
 
     #[test]
     fn test_generic_bound() {
         err(
-            "class A<T: Foo>",
+            "class A[T: Foo]",
             pos(1, 12),
             Msg::UnknownType("Foo".into()),
         );
-        ok("class Foo class A<T: Foo>");
-        ok("trait Foo {} class A<T: Foo>");
+        ok("class Foo class A[T: Foo]");
+        ok("trait Foo {} class A[T: Foo]");
     }
 
     #[test]
     fn test_generic_multiple_class_bounds() {
         err(
             "class Foo class Bar
-            class A<T: Foo + Bar>",
+            class A[T: Foo + Bar]",
             pos(2, 21),
             Msg::MultipleClassBounds,
         );
@@ -487,7 +487,7 @@ mod tests {
     fn test_duplicate_trait_bound() {
         err(
             "trait Foo {}
-            class A<T: Foo + Foo>",
+            class A[T: Foo + Foo]",
             pos(2, 21),
             Msg::DuplicateTraitBound,
         );
@@ -498,7 +498,7 @@ mod tests {
         err(
             "
             open class A
-            class B: A<Int> {}",
+            class B: A[Int] {}",
             pos(3, 22),
             Msg::WrongNumberTypeParams(0, 1),
         );

--- a/src/semck/fctdefck.rs
+++ b/src/semck/fctdefck.rs
@@ -352,19 +352,19 @@ mod tests {
 
     #[test]
     fn fct_with_type_params() {
-        ok("fun f<T>() {}");
-        ok("fun f<X, Y>() {}");
+        ok("fun f[T]() {}");
+        ok("fun f[X, Y]() {}");
         err(
-            "fun f<T, T>() {}",
+            "fun f[T, T]() {}",
             pos(1, 10),
             Msg::TypeParamNameNotUnique("T".into()),
         );
-        err("fun f<>() {}", pos(1, 1), Msg::TypeParamsExpected);
+        err("fun f[]() {}", pos(1, 1), Msg::TypeParamsExpected);
     }
 
     #[test]
     fn fct_with_type_param_in_annotation() {
-        ok("fun f<T>(val: T) {}");
+        ok("fun f[T](val: T) {}");
     }
 
     #[test]
@@ -442,22 +442,22 @@ mod tests {
     #[test]
     fn generic_bounds() {
         err(
-            "fun f<T: Foo>() {}",
+            "fun f[T: Foo]() {}",
             pos(1, 10),
             Msg::UnknownType("Foo".into()),
         );
-        ok("class Foo fun f<T: Foo>() {}");
-        ok("trait Foo {} fun f<T: Foo>() {}");
+        ok("class Foo fun f[T: Foo]() {}");
+        ok("trait Foo {} fun f[T: Foo]() {}");
 
         err(
             "class A class B
-            fun f<T: A + B>() {  }",
+            fun f[T: A + B]() {  }",
             pos(2, 19),
             Msg::MultipleClassBounds,
         );
         err(
             "trait Foo {}
-            fun f<T: Foo + Foo>() {  }",
+            fun f[T: Foo + Foo]() {  }",
             pos(2, 19),
             Msg::DuplicateTraitBound,
         );

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -211,7 +211,7 @@ impl BuiltinType {
                         .collect::<Vec<_>>()
                         .join(", ");
 
-                    format!("{}<{}>", base, params)
+                    format!("{}[{}]", base, params)
                 }
             }
             BuiltinType::Struct(sid, list_id) => {

--- a/stdlib/Array.dora
+++ b/stdlib/Array.dora
@@ -1,17 +1,17 @@
-internal class Array<T>(len: Int) {
+internal class Array[T](len: Int) {
 
   internal fun length() -> Int;
   internal fun get(idx: Int) -> T;
   internal fun set(idx: Int, val: T);
 
-  fun contains(value: T /* : Equals*/) -> Bool {
+  fun contains[T /*: Equals*/](value: T) -> Bool {
     var i = 0;
 
     while i < self.length() {
-      let x = self[i];
-      if /*x.equals(value) ||*/ x === value {
-        return true;
-      }
+      let x = self.get(i);
+      //if x.equals(value) || x === value { // TypesIncompatible("T", "T")
+      //  return true;
+      //}
       i = i + 1;
     }
 
@@ -22,12 +22,34 @@ internal class Array<T>(len: Int) {
     var i = 0;
 
     while i < self.length() {
-      if self[i] === value {
+      if self.get(i) === value {
         return true;
       }
       i = i + 1;
     }
 
     return false;
+  }
+}
+
+fun arrayEmpty[T]() -> Array[T] = Array[T](0);
+
+fun arrayFill[T](len: Int, value: T) -> Array[T] {
+  let array = Array[T](len);
+  var i = 0;
+
+  while i < len {
+    array.set(i, value);
+      i = i + 1;
+  }
+  return array;
+}
+
+fun arrayCopy[T](src: Array[T], srcPos: Int, dest: Array[T], destPos: Int, len: Int) {
+  var i = 0;
+
+  while i < len {
+    dest.set(destPos+i, src.get(srcPos+i));
+    i = i + 1;
   }
 }

--- a/stdlib/Char.dora
+++ b/stdlib/Char.dora
@@ -8,23 +8,23 @@ internal class Char {
 
   fun hash() -> Int = self.toInt();
 
-  fun encodeUtf8(bytes: Array<Byte>, offset: Int) {
+  fun encodeUtf8(bytes: Array[Byte], offset: Int) {
     let val = self.toInt();
 
     if val < 0x80 {
-      bytes[offset] = val.toByte();
+      bytes.set(offset, val.toByte());
     } else if val < 0x800 {
-      bytes[offset] = (0xC0 | ((val >> 6) & 0x1F)).toByte();
-      bytes[offset+1] = (0x80 | (val & 0x3F)).toByte();
+      bytes.set(offset, (0xC0 | ((val >> 6) & 0x1F)).toByte());
+      bytes.set(offset+1, (0x80 | (val & 0x3F)).toByte());
     } else if val < 0x10000 {
-      bytes[offset] = (0xE0 | ((val >> 12) & 0x0F)).toByte();
-      bytes[offset+1] = (0x80 | ((val >> 6) & 0x3F)).toByte();
-      bytes[offset+2] = (0x80 | (val & 0x3F)).toByte();
+      bytes.set(offset, (0xE0 | ((val >> 12) & 0x0F)).toByte());
+      bytes.set(offset+1, (0x80 | ((val >> 6) & 0x3F)).toByte());
+      bytes.set(offset+2, (0x80 | (val & 0x3F)).toByte());
     } else {
-      bytes[offset] = (0xF0 | ((val >> 18) & 0x07)).toByte();
-      bytes[offset+1] = (0x80 | ((val >> 12) & 0x3F)).toByte();
-      bytes[offset+2] = (0x80 | ((val >> 6) & 0x3F)).toByte();
-      bytes[offset+3] = (0x80 | (val & 0x3F)).toByte();
+      bytes.set(offset, (0xF0 | ((val >> 18) & 0x07)).toByte());
+      bytes.set(offset+1, (0x80 | ((val >> 12) & 0x3F)).toByte());
+      bytes.set(offset+2, (0x80 | ((val >> 6) & 0x3F)).toByte());
+      bytes.set(offset+3, (0x80 | (val & 0x3F)).toByte());
     }
   }
 

--- a/stdlib/Exception.dora
+++ b/stdlib/Exception.dora
@@ -1,26 +1,26 @@
 class Exception(msg: String) {
   var msg: String = msg;
-  var backtrace: Array<Int> = nil;
-  var elements: Array<StackTraceElement> = nil;
+  var backtrace: Array[Int] = nil;
+  var elements: Array[StackTraceElement] = nil;
 
   self.retrieveStackTrace();
 
-  fun getStackTrace() -> Array<StackTraceElement> {
+  fun getStackTrace() -> Array[StackTraceElement] {
     if self.elements !== nil {
       return self.elements;
     }
 
     if self.backtrace === nil {
-      self.elements = arrayEmpty::<StackTraceElement>();
+      self.elements = arrayEmpty[StackTraceElement]();
       return self.elements;
     }
 
     var i = 0;
     let len = self.backtrace.length() / 2;
-    self.elements = Array::<StackTraceElement>(len);
+    self.elements = Array[StackTraceElement](len);
 
     while i < len {
-      self.elements[i] = self.getStackTraceElement(i);
+      self.elements.set(i, self.getStackTraceElement(i));
       i = i + 1;
     }
 
@@ -39,7 +39,7 @@ class Exception(msg: String) {
     var i = 0;
 
     while i < x.length() {
-      println(i.toString() + ": " + x[i].toString());
+      println(i.toString() + ": " + x.get(i).toString());
       i = i + 1;
     }
   }

--- a/stdlib/FileDescriptor.dora
+++ b/stdlib/FileDescriptor.dora
@@ -4,7 +4,7 @@ class FileDescriptor(var fd: Int) {
     return 0Y;
   }
 
-  fun readBytes(array: Array<Byte>, off: Int, len: Int) {
+  fun readBytes(array: Array[Byte], off: Int, len: Int) {
     // TODO
   }
 
@@ -12,7 +12,7 @@ class FileDescriptor(var fd: Int) {
     // TODO
   }
 
-  fun writeBytes(array: Array<Byte>, off: Int, len: Int) {
+  fun writeBytes(array: Array[Byte], off: Int, len: Int) {
     // TODO
   }
 }

--- a/stdlib/Queue.dora
+++ b/stdlib/Queue.dora
@@ -1,17 +1,17 @@
-class Queue<T> {
-  var elements: Array<T> = Array::<T>(4);
+class Queue[T] {
+  var elements: Array[T] = Array[T](4);
   var front: Int = 0;
   var count: Int = 0;
 
   pub fun enqueue(value: T) {
     if self.count == self.elements.length() {
       // copy into larger array
-      let newelements = Array::<T>(self.elements.length() * 2);
+      let newelements = Array[T](self.elements.length() * 2);
       let len = self.elements.length() - self.front;
-      arraycopy::<T>(self.elements, self.front, newelements, 0, len);
+      arrayCopy[T](self.elements, self.front, newelements, 0, len);
 
       if len < self.count {
-        arraycopy::<T>(self.elements, 0, newelements, len, self.count - len);
+        arrayCopy[T](self.elements, 0, newelements, len, self.count - len);
       }
 
       self.front = 0;
@@ -20,15 +20,15 @@ class Queue<T> {
     }
 
     let end = self.getEnd();
-    self.elements[end] = value;
+    self.elements.set(end, value);
     self.count = self.count + 1;
   }
 
   pub fun dequeue() -> T {
     assert(self.count > 0);
 
-    let value = self.elements[self.front];
-    self.elements[self.front] = defaultValue::<T>();
+    let value = self.elements.get(self.front);
+    self.elements.set(self.front, defaultValue[T]());
 
     self.moveFront();
     self.count = self.count - 1;

--- a/stdlib/String.dora
+++ b/stdlib/String.dora
@@ -29,10 +29,10 @@ internal class String {
   internal fun getByte(idx: Int) -> Byte;
   internal fun clone() -> String;
 
-  internal static fun fromBytesPartOrNull(val: Array<Byte>, offset: Int, len: Int) -> String;
+  internal static fun fromBytesPartOrNull(val: Array[Byte], offset: Int, len: Int) -> String;
   internal static fun fromStringPartOrNull(val: String, offset: Int, len: Int) -> String;
 
-  static fun fromBytesPart(val: Array<Byte>, offset: Int, len: Int) throws -> String {
+  static fun fromBytesPart(val: Array[Byte], offset: Int, len: Int) throws -> String {
     let str = String::fromBytesPartOrNull(val, offset, len);
 
     if str === nil {
@@ -42,7 +42,7 @@ internal class String {
     return str;
   }
 
-  static fun fromBytes(val: Array<Byte>) throws -> String {
+  static fun fromBytes(val: Array[Byte]) throws -> String {
     let str = String::fromBytesPartOrNull(val, 0, val.length());
 
     if str === nil {

--- a/stdlib/StringBuf.dora
+++ b/stdlib/StringBuf.dora
@@ -1,5 +1,5 @@
-class StringBuf(var buf: Array<Byte>, var length: Int) {
-  static fun empty() -> StringBuf = StringBuf(Array::<Byte>(0), 0);
+class StringBuf(var buf: Array[Byte], var length: Int) {
+  static fun empty() -> StringBuf = StringBuf(Array[Byte](0), 0);
 
   fun length() -> Int {
     return self.length;
@@ -17,11 +17,11 @@ class StringBuf(var buf: Array<Byte>, var length: Int) {
     }
 
     let newcap = self.newCapacity(elements);
-    let newbuf = Array::<Byte>(newcap);
+    let newbuf = Array[Byte](newcap);
     var i = 0;
 
     while i < self.buf.length() {
-      newbuf[i] = self.buf[i];
+      newbuf.set(i, self.buf.get(i));
       i = i + 1;
     }
 
@@ -60,7 +60,7 @@ class StringBuf(var buf: Array<Byte>, var length: Int) {
     var i = 0;
 
     while i < value.length() {
-      self.buf[self.length + i] = value.getByte(i);
+      self.buf.set(self.length + i, value.getByte(i));
       i = i + 1;
     }
 

--- a/stdlib/Vec.dora
+++ b/stdlib/Vec.dora
@@ -1,5 +1,5 @@
-class Vec<T> {
-  var array: Array<T> = nil;
+class Vec[T] {
+  var array: Array[T] = nil;
   var length: Int = 0;
 
   fun get(idx: Int) -> T {
@@ -7,7 +7,7 @@ class Vec<T> {
       fatalError("index out of bounds for vector");
     }
 
-    return self.array[idx];
+    return self.array.get(idx);
   }
 
   fun set(idx: Int, val: T) {
@@ -15,7 +15,7 @@ class Vec<T> {
       fatalError("index out of bounds for vector");
     }
 
-    self.array[idx] = val;
+    self.array.set(idx, val);
   }
 
   fun push(val: T) {
@@ -28,12 +28,12 @@ class Vec<T> {
         newcap = newcap * 2;
       }
 
-      let newarray = Array::<T>(newcap);
-      arraycopy::<T>(self.array, 0, newarray, 0, self.length);
+      let newarray = Array[T](newcap);
+      arrayCopy[T](self.array, 0, newarray, 0, self.length);
       self.array = newarray;
     }
 
-    self.array[self.length] = val;
+    self.array.set(self.length, val);
     self.length = self.length + 1;
   }
 
@@ -43,11 +43,11 @@ class Vec<T> {
     }
 
     let newlength = self.length - 1;
-    let temp = self.array[newlength];
+    let temp = self.array.get(newlength);
 
     // set popped element to nil so that GC can collect object
     // not necessary for primitive types
-    self.array[newlength] = defaultValue::<T>();
+    self.array.set(newlength, defaultValue[T]());
 
     self.length = newlength;
 
@@ -59,8 +59,8 @@ class Vec<T> {
       if self.length == 0 {
         self.array = nil;
       } else {
-        let newarray = Array::<T>(self.length);
-        arraycopy::<T>(self.array, 0, newarray, 0, self.length);
+        let newarray = Array[T](self.length);
+        arrayCopy[T](self.array, 0, newarray, 0, self.length);
         self.array = newarray;
       }
     }
@@ -68,15 +68,15 @@ class Vec<T> {
 
   fun removeAt(var ind: Int) -> T {
     assert(ind < self.length);
-    let temp = self[ind];
+    let temp = self.get(ind);
     let len = self.length;
 
     while ind < len - 1 {
-      self[ind] = self[ind+1];
+      self.set(ind, self.get(ind+1));
       ind = ind + 1;
     }
 
-    self[ind] = defaultValue::<T>();
+    self.set(ind, defaultValue[T]());
     self.length = ind;
 
     return temp;
@@ -95,11 +95,11 @@ class Vec<T> {
   }
 }
 
-fun removeItem<T: Equals>(vec: Vec<T>, elem: T) {
+fun removeItem[T: Equals](vec: Vec[T], elem: T) {
   var i = 0;
 
   while i < vec.length() {
-    if vec[i].equals(elem) {
+    if vec.get(i).equals(elem) {
       vec.removeAt(i);
     } else {
       i = i + 1;

--- a/stdlib/prelude.dora
+++ b/stdlib/prelude.dora
@@ -25,29 +25,7 @@ internal fun timestamp() -> Long;
 
 class Object
 
-fun arrayEmpty<T>() -> Array<T> = Array::<T>(0);
-
-fun arrayFill<T>(len: Int, value: T) -> Array<T> {
-  let array = Array::<T>(len);
-  var i = 0;
-
-  while i < len {
-    array[i] = value;
-      i = i + 1;
-  }
-  return array;
-}
-
-fun arraycopy<T>(src: Array<T>, srcPos: Int, dest: Array<T>, destPos: Int, len: Int) {
-  var i = 0;
-
-  while i < len {
-    dest[destPos+i] = src[srcPos+i];
-    i = i + 1;
-  }
-}
-
-fun bubbleSort<T: Comparable>(array: Array<T>) {
+fun bubbleSort[T: Comparable](array: Array[T]) {
   let len = array.length();
   var swapped = true;
 
@@ -57,10 +35,10 @@ fun bubbleSort<T: Comparable>(array: Array<T>) {
     var i = 1;
 
     while i < len {
-      if array[i-1].compareTo(array[i]) > 0 {
-        let temp = array[i-1];
-        array[i-1] = array[i];
-        array[i] = temp;
+      if array.get(i-1).compareTo(array.get(i)) > 0 {
+        let temp = array.get(i-1);
+        array.set(i-1, array.get(i));
+        array.set(i, temp);
 
         swapped = true;
       }
@@ -70,11 +48,11 @@ fun bubbleSort<T: Comparable>(array: Array<T>) {
   }
 }
 
-fun isValidUtf8(data: Array<Byte>) -> Bool {
+fun isValidUtf8(data: Array[Byte]) -> Bool {
   var i = 0;
 
   while i < data.length() {
-    let by = data[i].toInt();
+    let by = data.get(i).toInt();
     var codePoint = 0;
     var nextBytes = 0;
     var min = 0;
@@ -115,7 +93,7 @@ fun isValidUtf8(data: Array<Byte>) -> Bool {
         return false;
       }
 
-      let by = data[i].toInt();
+      let by = data.get(i).toInt();
 
       if by & 0xC0 != 0x80 {
         return false;
@@ -134,7 +112,7 @@ fun isValidUtf8(data: Array<Byte>) -> Bool {
   return true;
 }
 
-internal fun defaultValue<T>() -> T;
+internal fun defaultValue[T]() -> T;
 
 internal fun loadFunction(name: String) -> Long;
 internal fun call0(fct: Long) -> Long;

--- a/tests/array1.dora
+++ b/tests/array1.dora
@@ -2,4 +2,4 @@ fun main() {
   foo(nil);
 }
 
-fun foo(a: Array<Int>) {}
+fun foo(a: Array[Int]) {}

--- a/tests/array10.dora
+++ b/tests/array10.dora
@@ -1,6 +1,6 @@
 //= error array
 
 fun main() {
-  let array = arrayEmpty::<Int>();
-  array[-1];
+  let array = arrayEmpty[Int]();
+  array.get(-1);
 }

--- a/tests/array11.dora
+++ b/tests/array11.dora
@@ -4,6 +4,6 @@ fun main() {
     first(nil);
 }
 
-fun first(f: Array<Int>) -> Int {
-    return f[0];
+fun first(f: Array[Int]) -> Int {
+    return f.get(0);
 }

--- a/tests/array12.dora
+++ b/tests/array12.dora
@@ -4,6 +4,6 @@ fun main() {
     set_first(nil);
 }
 
-fun set_first(f: Array<Int>) {
-    f[0] = 0;
+fun set_first(f: Array[Int]) {
+    f.set(0, 0);
 }

--- a/tests/array13.dora
+++ b/tests/array13.dora
@@ -1,6 +1,6 @@
 fun main() {
-    let x = Array::<Int>(100);
+    let x = Array[Int](100);
     assert(x.length() == 100);
-    assert(x[0] == 0);
-    assert(x[99] == 0);
+    assert(x.get(0) == 0);
+    assert(x.get(99) == 0);
 }

--- a/tests/array14.dora
+++ b/tests/array14.dora
@@ -1,4 +1,4 @@
 fun main() {
-    let x = Array::<String>(1);
-    x[0] = nil;
+    let x = Array[String](1);
+    x.set(0, nil);
 }

--- a/tests/array15.dora
+++ b/tests/array15.dora
@@ -1,35 +1,35 @@
 fun main() {
 
-    let x = arrayFill::<Bool>(3, true);
-    assert(arrayContains::<Bool>(x, true));
-    assert(arrayHas::<Bool>(x, true));
+    let x = arrayFill[Bool](3, true);
+    assert(arrayContains[Bool](x, true));
+    assert(arrayHas[Bool](x, true));
 
-    let x = arrayFill::<Int>(3, 3);
-    assert(arrayContains::<Int>(x, 3));
-    assert(arrayHas::<Int>(x, 3));
+    let x = arrayFill[Int](3, 3);
+    assert(arrayContains[Int](x, 3));
+    assert(arrayHas[Int](x, 3));
 
-    let x = arrayFill::<Long>(3, 3L);
-    assert(arrayContains::<Long>(x, 3L));
-    assert(arrayHas::<Long>(x, 3L));
+    let x = arrayFill[Long](3, 3L);
+    assert(arrayContains[Long](x, 3L));
+    assert(arrayHas[Long](x, 3L));
 
-    // let x = arrayFill::<Double>(3, 0.0/0.0);
+    // let x = arrayFill[Double](3, 0.0/0.0);
     // BUG: thread 'main' panicked at 'fp-register accessed as gp-register.', src/baseline/expr.rs:52:18
-    //assert(arrayContains::<Double>(x, 0.0/0.0));
-    //assert(arrayHas::<Double>(x, 0.0/0.0));
+    //assert(arrayContains[Double](x, 0.0/0.0));
+    //assert(arrayHas[Double](x, 0.0/0.0));
 
     // “target/debug/dora tests/array15…” terminated by signal SIGSEGV (Address boundary error)
     // hash is not implemented (yet) for String, so this should be a compile-time error, not a crash
-    // hash::<String>("foo");
+    // hash[String]("foo");
 
 }
 
-fun hash<T : Hash>(val: T) -> Int = val.hash();
+fun hash[T : Hash](val: T) -> Int = val.hash();
 
-fun arrayContains<T : Identity + Equals>(array: Array<T>, value: T) -> Bool {
+fun arrayContains[T : Identity + Equals](array: Array[T], value: T) -> Bool {
   var i = 0;
 
   while i < array.length() {
-    let x = array[i];
+    let x = array.get(i);
     if x.identicalTo(value) || x.equals(value) {
       return true;
     }
@@ -39,11 +39,11 @@ fun arrayContains<T : Identity + Equals>(array: Array<T>, value: T) -> Bool {
   return false;
 }
 
-fun arrayHas<T : Identity>(array: Array<T>, value: T) -> Bool {
+fun arrayHas[T : Identity](array: Array[T], value: T) -> Bool {
   var i = 0;
 
   while i < array.length() {
-    if array[i].identicalTo(value) {
+    if array.get(i).identicalTo(value) {
       return true;
     }
     i = i + 1;

--- a/tests/array2.dora
+++ b/tests/array2.dora
@@ -1,5 +1,5 @@
 fun main() {
-  assert(0 == len(arrayEmpty::<Int>()));
+  assert(0 == len(arrayEmpty[Int]()));
 }
 
-fun len(a: Array<Int>) -> Int { return a.length(); }
+fun len(a: Array[Int]) -> Int { return a.length(); }

--- a/tests/array3.dora
+++ b/tests/array3.dora
@@ -1,5 +1,5 @@
 fun main() {
-  assert(1 == len(arrayFill::<Int>(1, 0)));
+  assert(1 == len(arrayFill[Int](1, 0)));
 }
 
-fun len(a: Array<Int>) -> Int { return a.length(); }
+fun len(a: Array[Int]) -> Int { return a.length(); }

--- a/tests/array4.dora
+++ b/tests/array4.dora
@@ -1,4 +1,4 @@
 fun main() {
-  let array = arrayFill::<Int>(5, 2);
-  assert(2 == array[0]);
+  let array = arrayFill[Int](5, 2);
+  assert(2 == array.get(0));
 }

--- a/tests/array5.dora
+++ b/tests/array5.dora
@@ -1,9 +1,8 @@
 fun main() {
   assert(1 == A().get("hello"));
-  assert(1 == A()["hello"]);
 
-  assert(B()[true]);
-  assert(!B()[false]);
+  assert(B().get(true));
+  assert(!B().get(false));
 }
 
 class A {

--- a/tests/array6.dora
+++ b/tests/array6.dora
@@ -1,6 +1,6 @@
 fun main() {
-  let array = arrayFill::<Int>(5, 1);
-  array[0] = 2;
-  assert(array[0] == 2);
-  assert(array[1] == 1);
+  let array = arrayFill[Int](5, 1);
+  array.set(0, 2);
+  assert(array.get(0) == 2);
+  assert(array.get(1) == 1);
 }

--- a/tests/array7.dora
+++ b/tests/array7.dora
@@ -1,6 +1,6 @@
 //= error array
 
 fun main() {
-  let array = arrayEmpty::<Int>();
-  array[0];
+  let array = arrayEmpty[Int]();
+  array.get(0);
 }

--- a/tests/array8.dora
+++ b/tests/array8.dora
@@ -1,6 +1,6 @@
 //= error array
 
 fun main() {
-  let array = Array::<Int>(0);
-  array[0] = 10;
+  let array = Array[Int](0);
+  array.set(0, 10);
 }

--- a/tests/array9.dora
+++ b/tests/array9.dora
@@ -1,6 +1,6 @@
 //= error array
 
 fun main() {
-  let array = arrayEmpty::<Int>();
-  array[-1] = 10;
+  let array = arrayEmpty[Int]();
+  array.set(-1, 10);
 }

--- a/tests/bool2.dora
+++ b/tests/bool2.dora
@@ -1,13 +1,13 @@
 fun main() {
-    let x = arrayEmpty::<Bool>();
+    let x = arrayEmpty[Bool]();
     assert(x.length() == 0);
 
-    let y = arrayFill::<Bool>(10, true);
+    let y = arrayFill[Bool](10, true);
     assert(y.length() == 10);
-    assert(y[0] == true);
-    assert(y[9] == true);
+    assert(y.get(0) == true);
+    assert(y.get(9) == true);
 
-    y[0] = false;
-    assert(y[0] == false);
-    assert(y[1] == true);
+    y.set(0, false);
+    assert(y.get(0) == false);
+    assert(y.get(1) == true);
 }

--- a/tests/byte3.dora
+++ b/tests/byte3.dora
@@ -1,16 +1,16 @@
 fun main() {
-    let ba = arrayEmpty::<Byte>();
+    let ba = arrayEmpty[Byte]();
     assert(ba.length() == 0);
 
-    let ba = arrayFill::<Byte>(10, 2Y);
+    let ba = arrayFill[Byte](10, 2Y);
     assert(ba.length() == 10);
 
-    ba[0] = 10Y;
-    ba[1] = 11Y;
-    ba[2] = 12Y;
+    ba.set(0, 10Y);
+    ba.set(1, 11Y);
+    ba.set(2, 12Y);
 
-    assert(10Y == ba[0]);
-    assert(11Y == ba[1]);
-    assert(12Y == ba[2]);
-    assert(2Y == ba[9]);
+    assert(10Y == ba.get(0));
+    assert(11Y == ba.get(1));
+    assert(12Y == ba.get(2));
+    assert(2Y == ba.get(9));
 }

--- a/tests/char2.dora
+++ b/tests/char2.dora
@@ -1,19 +1,21 @@
 fun main() {
-    let x = arrayEmpty::<Char>();
+    let x = arrayEmpty[Char]();
     assert(x.length() == 0);
 
-    let x = arrayFill::<Char>(10, '\0');
-    assert(x[0] == '\0');
-    assert(x[9] == '\0');
+    let x = arrayFill[Char](10, '\0');
+    assert(x.get(0) == '\0');
+    assert(x.get(9) == '\0');
 
-    x[0] = 'a';
-    x[1] = 'b';
-    x[2] = 'c';
-    x[3] = 'd';
-    x[9] = 'z';
+    x.set(0, 'a');
+    x.set(1, 'b');
+    x.set(2, 'c');
+    x.set(3, 'd');
+    x.set(9, 'z');
 
-    assert(x[3] == 'd');
-    assert(x[4] == '\0');
-    assert(x[8] == '\0');
-    assert(x[9] == 'z');
+    println(x.get(3).toString());
+
+    assert(x.get(3) == 'd');
+    assert(x.get(4) == '\0');
+    assert(x.get(8) == '\0');
+    assert(x.get(9) == 'z');
 }

--- a/tests/default-value1.dora
+++ b/tests/default-value1.dora
@@ -1,31 +1,31 @@
 fun main() {
-  let x = defaultValue::<Bool>();
+  let x = defaultValue[Bool]();
   assert(x == false);
 
-  let x = defaultValue::<Byte>();
+  let x = defaultValue[Byte]();
   assert(x == 0Y);
 
-  let x = defaultValue::<Char>();
+  let x = defaultValue[Char]();
   assert(x == '\0');
 
-  let x = defaultValue::<Int>();
+  let x = defaultValue[Int]();
   assert(x == 0);
 
-  let x = defaultValue::<Long>();
+  let x = defaultValue[Long]();
   assert(x == 0L);
 
-  let x = defaultValue::<Float>();
+  let x = defaultValue[Float]();
   assert(x == 0.0F);
 
-  let x = defaultValue::<Double>();
+  let x = defaultValue[Double]();
   assert(x == 0.0);
 
-  let x = defaultValue::<String>();
+  let x = defaultValue[String]();
   assert(x === nil);
 
-  let x = defaultValue::<Array<Int> >();
+  let x = defaultValue[Array[Int] ]();
   assert(x === nil);
 
-  let x = defaultValue::<Array<Float> >();
+  let x = defaultValue[Array[Float] ]();
   assert(x === nil);
 }

--- a/tests/eh12.dora
+++ b/tests/eh12.dora
@@ -3,7 +3,7 @@
 fun main() {
   do {
     try foo();
-  } catch x: Array<Int> {
+  } catch x: Array[Int] {
     assert(x.length() == 5);
     println("DONE");
   }
@@ -11,7 +11,7 @@ fun main() {
 
 fun foo() throws {
   do {
-    throw arrayFill::<Int>(5, 1);
+    throw arrayFill[Int](5, 1);
   } finally {
     forceCollect();
   }

--- a/tests/eh13.dora
+++ b/tests/eh13.dora
@@ -3,7 +3,7 @@
 fun main() {
   do {
     try foo();
-  } catch x: Array<Bar> {
+  } catch x: Array[Bar] {
     assert(x.length() == 5);
     println("DONE");
   }
@@ -11,8 +11,8 @@ fun main() {
 
 fun foo() throws {
   do {
-    throw arrayFill::<Bar>(5, nil);
-  } catch x: Array<Foo> {
+    throw arrayFill[Bar](5, nil);
+  } catch x: Array[Foo] {
     fatalError("should not be caught");
   }
 }

--- a/tests/eh3.dora
+++ b/tests/eh3.dora
@@ -5,7 +5,7 @@ fun main() {
 fun f() -> Int {
   do {
     return 6;
-  } catch e: Array<Int> {
+  } catch e: Array[Int] {
     return 4;
   }
 }

--- a/tests/eh4.dora
+++ b/tests/eh4.dora
@@ -5,7 +5,7 @@ fun main() {
 fun f() -> Int {
   do {
     return 6;
-  } catch e: Array<Int> {
+  } catch e: Array[Int] {
     return 4;
   } finally {
     return 1;

--- a/tests/eh5.dora
+++ b/tests/eh5.dora
@@ -8,7 +8,7 @@ fun f() -> Int {
   do {
     print("hello ");
     return 6;
-  } catch e: Array<Int> {
+  } catch e: Array[Int] {
     return 4;
   } finally {
     println("world!");

--- a/tests/eh6.dora
+++ b/tests/eh6.dora
@@ -7,7 +7,7 @@ fun main() {
 fun f() -> Int {
   do {
     print("hello ");
-  } catch e: Array<Int> {
+  } catch e: Array[Int] {
     return 4;
   } finally {
     println("world!");

--- a/tests/eh7.dora
+++ b/tests/eh7.dora
@@ -7,7 +7,7 @@ fun main() {
     a = 3;
     throw "abc";
 
-  } catch y: Array<Int> {
+  } catch y: Array[Int] {
     println("unreachable");
     a = 4;
 

--- a/tests/eh8.dora
+++ b/tests/eh8.dora
@@ -1,8 +1,8 @@
 fun main() {
   do {
-    throw arrayFill::<Int>(5, 1);
+    throw arrayFill[Int](5, 1);
 
-  } catch x: Array<Int> {
+  } catch x: Array[Int] {
     forceCollect();
     assert(x.length() == 5);
   }

--- a/tests/exception/print-stack-trace3.dora
+++ b/tests/exception/print-stack-trace3.dora
@@ -4,7 +4,7 @@ fun main() {
   let e = a();
 
   // this should test if backtrace in Exception is created the right way
-  // by retrieveStackTrace (as Array<Int>)
+  // by retrieveStackTrace (as Array[Int])
   forceCollect();
 
   e.printStackTrace();

--- a/tests/float7.dora
+++ b/tests/float7.dora
@@ -1,17 +1,17 @@
 fun main() {
-    let array = arrayEmpty::<Float>();
+    let array = arrayEmpty[Float]();
     assert(0 == array.length());
 
-    let array = arrayFill::<Float>(10, 2F);
+    let array = arrayFill[Float](10, 2F);
     assert(10 == array.length());
-    assert(2F == array[0]);
-    assert(2F == array[9]);
+    assert(2F == array.get(0));
+    assert(2F == array.get(9));
 
-    let array = arrayEmpty::<Double>();
+    let array = arrayEmpty[Double]();
     assert(0 == array.length());
 
-    let array = arrayFill::<Double>(12, 3D);
+    let array = arrayFill[Double](12, 3D);
     assert(12 == array.length());
-    assert(3D == array[0]);
-    assert(3D == array[11]);
+    assert(3D == array.get(0));
+    assert(3D == array.get(11));
 }

--- a/tests/generic-array-gc.dora
+++ b/tests/generic-array-gc.dora
@@ -1,10 +1,10 @@
 fun main() {
-  let x = arrayFill::<Foo>(5, nil);
-  x[0] = Foo(1);
-  x[4] = Foo(2);
+  let x = arrayFill[Foo](5, nil);
+  x.set(0, Foo(1));
+  x.set(4, Foo(2));
   forceCollect();
-  assert(x[0].x == 1);
-  assert(x[4].x == 2);
+  assert(x.get(0).x == 1);
+  assert(x.get(4).x == 2);
 }
 
 class Foo(let x: Int)

--- a/tests/generic-array-get.dora
+++ b/tests/generic-array-get.dora
@@ -1,57 +1,57 @@
 fun main() {
-  let x = arrayFill::<Int>(5, 100);
-  assert(x[0] == 100);
+  let x = arrayFill[Int](5, 100);
+  assert(x.get(0) == 100);
   assert(int_array_get(x, 4) == 100);
 
-  let x = arrayFill::<Long>(7, 200L);
-  assert(x[6] == 200L);
+  let x = arrayFill[Long](7, 200L);
+  assert(x.get(6) == 200L);
   assert(long_array_get(x, 0) == 200L);
 
-  let x = arrayFill::<Float>(6, 1.0F);
-  assert(x[0] == 1.0F);
+  let x = arrayFill[Float](6, 1.0F);
+  assert(x.get(0) == 1.0F);
   assert(float_array_get(x, 5) == 1.0F);
 
-  let x = arrayFill::<Double>(4, 2.0);
-  assert(x[0] == 2.0);
+  let x = arrayFill[Double](4, 2.0);
+  assert(x.get(0) == 2.0);
   assert(double_array_get(x, 3) == 2.0);
 
-  let x = arrayFill::<String>(3, "hello");
-  assert(x[0] == "hello");
+  let x = arrayFill[String](3, "hello");
+  assert(x.get(0) == "hello");
   assert(str_array_get(x, 2) == "hello");
 
-  let x = arrayFill::<Foo>(1, Foo(1));
-  assert(x[0] !== nil);
-  assert(x[0].y == 1);
+  let x = arrayFill[Foo](1, Foo(1));
+  assert(x.get(0) !== nil);
+  assert(x.get(0).y == 1);
   assert(foo_array_get(x, 0) !== nil);
   assert(foo_array_get(x, 0).y == 1);
 
-  let x = arrayFill::<Foo>(2, nil);
-  assert(x[0] === nil);
+  let x = arrayFill[Foo](2, nil);
+  assert(x.get(0) === nil);
   assert(foo_array_get(x, 0) === nil);
 }
 
-fun int_array_get(x: Array<Int>, idx: Int) -> Int {
-  return x[idx];
+fun int_array_get(x: Array[Int], idx: Int) -> Int {
+  return x.get(idx);
 }
 
-fun long_array_get(x: Array<Long>, idx: Int) -> Long {
-  return x[idx];
+fun long_array_get(x: Array[Long], idx: Int) -> Long {
+  return x.get(idx);
 }
 
-fun float_array_get(x: Array<Float>, idx: Int) -> Float {
-  return x[idx];
+fun float_array_get(x: Array[Float], idx: Int) -> Float {
+  return x.get(idx);
 }
 
-fun double_array_get(x: Array<Double>, idx: Int) -> Double {
-  return x[idx];
+fun double_array_get(x: Array[Double], idx: Int) -> Double {
+  return x.get(idx);
 }
 
-fun str_array_get(x: Array<String>, idx: Int) -> String {
-  return x[idx];
+fun str_array_get(x: Array[String], idx: Int) -> String {
+  return x.get(idx);
 }
 
-fun foo_array_get(x: Array<Foo>, idx: Int) -> Foo {
-  return x[idx];
+fun foo_array_get(x: Array[Foo], idx: Int) -> Foo {
+  return x.get(idx);
 }
 
 class Foo(let y: Int)

--- a/tests/generic-array-has.dora
+++ b/tests/generic-array-has.dora
@@ -1,9 +1,9 @@
 fun main() {
-  let ais = arrayFill::<Int>(100, 2);
-  ais[99] = 23;
+  let ais = arrayFill[Int](100, 2);
+  ais.set(99, 23);
   assert(ais.has(23));
 
-  let ads = arrayFill::<Double>(100, 2.0);
-  ads[99] = 0.0/0.0;
+  let ads = arrayFill[Double](100, 2.0);
+  ads.set(99, 0.0/0.0);
   assert(ads.has(0.0/0.0));
 }

--- a/tests/generic-array-len.dora
+++ b/tests/generic-array-len.dora
@@ -1,74 +1,74 @@
 fun main() {
-  let x = arrayEmpty::<Int>();
+  let x = arrayEmpty[Int]();
   assert(x.length() == 0);
   assert(int_array_len(x) == 0);
 
-  let x = arrayFill::<Int>(5, 100);
+  let x = arrayFill[Int](5, 100);
   assert(x.length() == 5);
   assert(int_array_len(x) == 5);
 
-  let x = arrayEmpty::<Long>();
+  let x = arrayEmpty[Long]();
   assert(x.length() == 0);
   assert(long_array_len(x) == 0);
 
-  let x = arrayFill::<Long>(7, 100L);
+  let x = arrayFill[Long](7, 100L);
   assert(x.length() == 7);
   assert(long_array_len(x) == 7);
 
-  let x = arrayEmpty::<Float>();
+  let x = arrayEmpty[Float]();
   assert(x.length() == 0);
   assert(float_array_len(x) == 0);
 
-  let x = arrayFill::<Float>(6, 1.0F);
+  let x = arrayFill[Float](6, 1.0F);
   assert(x.length() == 6);
   assert(float_array_len(x) == 6);
 
-  let x = arrayEmpty::<Double>();
+  let x = arrayEmpty[Double]();
   assert(x.length() == 0);
   assert(double_array_len(x) == 0);
 
-  let x = arrayFill::<Double>(4, 1.0);
+  let x = arrayFill[Double](4, 1.0);
   assert(x.length() == 4);
   assert(double_array_len(x) == 4);
 
-  let x = arrayEmpty::<String>();
+  let x = arrayEmpty[String]();
   assert(x.length() == 0);
   assert(str_array_len(x) == 0);
 
-  let x = arrayFill::<String>(3, "hello");
+  let x = arrayFill[String](3, "hello");
   assert(x.length() == 3);
   assert(str_array_len(x) == 3);
 
-  let x = arrayEmpty::<Foo>();
+  let x = arrayEmpty[Foo]();
   assert(x.length() == 0);
   assert(foo_array_len(x) == 0);
 
-  let x = arrayFill::<Foo>(1, Foo());
+  let x = arrayFill[Foo](1, Foo());
   assert(x.length() == 1);
   assert(foo_array_len(x) == 1);
 }
 
-fun int_array_len(x: Array<Int>) -> Int {
+fun int_array_len(x: Array[Int]) -> Int {
   return x.length();
 }
 
-fun long_array_len(x: Array<Long>) -> Int {
+fun long_array_len(x: Array[Long]) -> Int {
   return x.length();
 }
 
-fun float_array_len(x: Array<Float>) -> Int {
+fun float_array_len(x: Array[Float]) -> Int {
   return x.length();
 }
 
-fun double_array_len(x: Array<Double>) -> Int {
+fun double_array_len(x: Array[Double]) -> Int {
   return x.length();
 }
 
-fun str_array_len(x: Array<String>) -> Int {
+fun str_array_len(x: Array[String]) -> Int {
   return x.length();
 }
 
-fun foo_array_len(x: Array<Foo>) -> Int {
+fun foo_array_len(x: Array[Foo]) -> Int {
   return x.length();
 }
 

--- a/tests/generic-array-set.dora
+++ b/tests/generic-array-set.dora
@@ -1,57 +1,57 @@
 fun main() {
-  let x = arrayFill::<Int>(2, 100);
+  let x = arrayFill[Int](2, 100);
   int_array_set(x, 1, 200);
-  assert(x[0] == 100);
-  assert(x[1] == 200);
+  assert(x.get(0) == 100);
+  assert(x.get(1) == 200);
 
-  let x = arrayFill::<Long>(2, 200L);
+  let x = arrayFill[Long](2, 200L);
   long_array_set(x, 1, 100L);
-  assert(x[0] == 200L);
-  assert(x[1] == 100L);
+  assert(x.get(0) == 200L);
+  assert(x.get(1) == 100L);
 
-  let x = arrayFill::<Float>(2, 1.0F);
+  let x = arrayFill[Float](2, 1.0F);
   float_array_set(x, 1, 2.0F);
-  assert(x[0] == 1.0F);
-  assert(x[1] == 2.0F);
+  assert(x.get(0) == 1.0F);
+  assert(x.get(1) == 2.0F);
 
-  let x = arrayFill::<Double>(2, 2.0);
+  let x = arrayFill[Double](2, 2.0);
   double_array_set(x, 1, 1.0);
-  assert(x[0] == 2.0);
-  assert(x[1] == 1.0);
+  assert(x.get(0) == 2.0);
+  assert(x.get(1) == 1.0);
 
-  let x = arrayFill::<String>(2, "hello");
+  let x = arrayFill[String](2, "hello");
   str_array_set(x, 1, "abc");
-  assert(x[0] == "hello");
-  assert(x[1] == "abc");
+  assert(x.get(0) == "hello");
+  assert(x.get(1) == "abc");
 
-  let x = arrayFill::<Foo>(2, Foo(1));
+  let x = arrayFill[Foo](2, Foo(1));
   foo_array_set(x, 1, Foo(2));
-  assert(x[0].y == 1);
-  assert(x[1].y == 2);
+  assert(x.get(0).y == 1);
+  assert(x.get(1).y == 2);
 }
 
-fun int_array_set(x: Array<Int>, idx: Int, val: Int) {
-  x[idx] = val;
+fun int_array_set(x: Array[Int], idx: Int, val: Int) {
+  x.set(idx, val);
 }
 
-fun long_array_set(x: Array<Long>, idx: Int, val: Long) {
-  x[idx] = val;
+fun long_array_set(x: Array[Long], idx: Int, val: Long) {
+  x.set(idx, val);
 }
 
-fun float_array_set(x: Array<Float>, idx: Int, val: Float) {
-  x[idx] = val;
+fun float_array_set(x: Array[Float], idx: Int, val: Float) {
+  x.set(idx, val);
 }
 
-fun double_array_set(x: Array<Double>, idx: Int, val: Double) {
-  x[idx] = val;
+fun double_array_set(x: Array[Double], idx: Int, val: Double) {
+  x.set(idx, val);
 }
 
-fun str_array_set(x: Array<String>, idx: Int, val: String) {
-  x[idx] = val;
+fun str_array_set(x: Array[String], idx: Int, val: String) {
+  x.set(idx, val);
 }
 
-fun foo_array_set(x: Array<Foo>, idx: Int, val: Foo) {
-  x[idx] = val;
+fun foo_array_set(x: Array[Foo], idx: Int, val: Foo) {
+  x.set(idx, val);
 }
 
 class Foo(let y: Int)

--- a/tests/generic-call1.dora
+++ b/tests/generic-call1.dora
@@ -4,7 +4,7 @@ trait Foo {
     fun bar();
 }
 
-fun foo<T: Foo>(t: T) {
+fun foo[T: Foo](t: T) {
     t.bar();
 }
 
@@ -17,5 +17,5 @@ impl Foo for X {
 }
 
 fun main() {
-    foo::<X>(X());
+    foo[X](X());
 }

--- a/tests/generic-call2.dora
+++ b/tests/generic-call2.dora
@@ -4,7 +4,7 @@ trait Foo {
     fun bar() -> Int;
 }
 
-fun foo<T: Foo>(t: T) -> Int {
+fun foo[T: Foo](t: T) -> Int {
     return t.bar();
 }
 
@@ -19,5 +19,5 @@ impl Foo for X {
 }
 
 fun main() {
-    assert(4 == foo::<X>(X()));
+    assert(4 == foo[X](X()));
 }

--- a/tests/generic-call3.dora
+++ b/tests/generic-call3.dora
@@ -4,7 +4,7 @@ trait Foo {
     fun bar();
 }
 
-class A<T: Foo>(let t: T) {
+class A[T: Foo](let t: T) {
     fun bar() {
         self.t.bar();
     }
@@ -19,5 +19,5 @@ impl Foo for X {
 }
 
 fun main() {
-    A::<X>(X()).bar();
+    A[X](X()).bar();
 }

--- a/tests/generic-call4.dora
+++ b/tests/generic-call4.dora
@@ -4,7 +4,7 @@ trait Foo {
     fun bar() -> Int;
 }
 
-class A<T: Foo>(let t: T) {
+class A[T: Foo](let t: T) {
     fun bar() -> Int {
         return self.t.bar();
     }
@@ -20,5 +20,5 @@ impl Foo for X {
 }
 
 fun main() {
-    assert(2 == A::<X>(X()).bar());
+    assert(2 == A[X](X()).bar());
 }

--- a/tests/generic1.dora
+++ b/tests/generic1.dora
@@ -1,8 +1,8 @@
 //= output "1"
 
 fun main() {
-    let a = A::<Int>(1);
+    let a = A[Int](1);
     print(a.x.toString());
 }
 
-class A<T>(let x: T)
+class A[T](let x: T)

--- a/tests/generic10.dora
+++ b/tests/generic10.dora
@@ -1,15 +1,15 @@
 fun main() {
-    let bar = Bar::<Int>(11);
+    let bar = Bar[Int](11);
     assert(bar.x.fst == 11);
     assert(bar.x.snd == 10);
 
-    let bar = Bar::<String>("hello");
+    let bar = Bar[String]("hello");
     assert(bar.x.fst == "hello");
     assert(bar.x.snd == 10);
 }
 
-class Bar<T>(val: T) {
-    let x: Pair<T, Int> = Pair::<T, Int>(val, 10);
+class Bar[T](val: T) {
+    let x: Pair[T, Int] = Pair[T, Int](val, 10);
 }
 
-class Pair<A, B>(let fst: A, let snd: B)
+class Pair[A, B](let fst: A, let snd: B)

--- a/tests/generic11.dora
+++ b/tests/generic11.dora
@@ -1,8 +1,8 @@
 fun main() {
-  assert(Foo::id::<Int>(1) == 1);
-  assert(Foo::id::<String>("hello") == "hel" + "lo");
+  assert(Foo::id[Int](1) == 1);
+  assert(Foo::id[String]("hello") == "hel" + "lo");
 }
 
 class Foo {
-  static fun id<T>(val: T) -> T = val;
+  static fun id[T](val: T) -> T = val;
 }

--- a/tests/generic12.dora
+++ b/tests/generic12.dora
@@ -1,15 +1,15 @@
 fun main() {
-  let foo = Foo::<Int>(10);
+  let foo = Foo[Int](10);
   assert(foo.x == 10);
 
-  let foo = Foo::<String>("hey");
+  let foo = Foo[String]("hey");
   assert(foo.x == "hey");
 }
 
-class Foo<T>(let x: T) {
+class Foo[T](let x: T) {
   fun getx() -> T {
-    return id::<T>(self.x);
+    return id[T](self.x);
   }
 }
 
-fun id<T>(val: T) -> T { return val; }
+fun id[T](val: T) -> T { return val; }

--- a/tests/generic13.dora
+++ b/tests/generic13.dora
@@ -1,10 +1,10 @@
 fun main() {
-    let x = SomeTest::<Int>(1);
+    let x = SomeTest[Int](1);
     assert(+x == 1);
     assert(-x == 1);
 }
 
-class SomeTest<T>(let x: T) {
+class SomeTest[T](let x: T) {
     fun unaryPlus() -> T {
         return self.x;
     }

--- a/tests/generic14.dora
+++ b/tests/generic14.dora
@@ -1,10 +1,10 @@
 fun main() {
-    let x = SomeTest::<Int>(1);
+    let x = SomeTest[Int](1);
     assert(x+0 == 1);
     assert(x-0 == 1);
 }
 
-class SomeTest<T>(let x: T) {
+class SomeTest[T](let x: T) {
     fun plus(y: Int) -> T {
         return self.x;
     }

--- a/tests/generic2.dora
+++ b/tests/generic2.dora
@@ -1,12 +1,12 @@
 //= output "hello1"
 
 fun main() {
-  let a = A::<String>(foo(1));
+  let a = A[String](foo(1));
   forceCollect();
   print(a.x);
 }
 
-class A<T>(let x: T)
+class A[T](let x: T)
 
 fun foo(a: Int) -> String {
   return "hello" + a.toString();

--- a/tests/generic3.dora
+++ b/tests/generic3.dora
@@ -1,14 +1,14 @@
 fun main() {
   assert(is_nil(nil));
   assert(get_x_or_default(nil, 10) == 10);
-  assert(get_x_or_default(A::<Int>(9), 10) == 9);
+  assert(get_x_or_default(A[Int](9), 10) == 9);
 }
 
-fun is_nil(a: A<Int>) -> Bool {
+fun is_nil(a: A[Int]) -> Bool {
   return a === nil;
 }
 
-fun get_x_or_default(a: A<Int>, val: Int) -> Int {
+fun get_x_or_default(a: A[Int], val: Int) -> Int {
   if a === nil {
     return val;
   } else {
@@ -16,4 +16,4 @@ fun get_x_or_default(a: A<Int>, val: Int) -> Int {
   }
 }
 
-class A<T>(let x: T)
+class A[T](let x: T)

--- a/tests/generic4.dora
+++ b/tests/generic4.dora
@@ -1,12 +1,12 @@
 //= output "hello1"
 
 fun main() {
-  let a = A::<String>(foo(1));
+  let a = A[String](foo(1));
   forceCollect();
   print(a.getx());
 }
 
-class A<T>(let x: T) {
+class A[T](let x: T) {
     fun getx() -> T {
         return self.x;
     }

--- a/tests/generic5.dora
+++ b/tests/generic5.dora
@@ -1,6 +1,6 @@
 fun main() {
-    let x: A<Int> = nil;
+    let x: A[Int] = nil;
     assert(x === nil);
 }
 
-class A<T>(let x: T)
+class A[T](let x: T)

--- a/tests/generic6.dora
+++ b/tests/generic6.dora
@@ -1,7 +1,7 @@
 fun main() {
-    foo::<Int>(1);
-    foo::<Float>(3F);
-    foo::<String>("hello");
+    foo[Int](1);
+    foo[Float](3F);
+    foo[String]("hello");
 }
 
-fun foo<T>(val: T) {}
+fun foo[T](val: T) {}

--- a/tests/generic7.dora
+++ b/tests/generic7.dora
@@ -1,7 +1,7 @@
 fun main() {
-    assert(1 == foo::<Int>(1));
-    assert(3F == foo::<Float>(3F));
-    assert("hel" + "lo" == foo::<String>("hello"));
+    assert(1 == foo[Int](1));
+    assert(3F == foo[Float](3F));
+    assert("hel" + "lo" == foo[String]("hello"));
 }
 
-fun foo<T>(val: T) -> T { return val; }
+fun foo[T](val: T) -> T { return val; }

--- a/tests/generic8.dora
+++ b/tests/generic8.dora
@@ -1,12 +1,12 @@
 fun main() {
-    let a = A::<Int>();
+    let a = A[Int]();
     consume(a.x);
 }
 
-class A<T> {
-    let x: Array<T> = nil;
+class A[T] {
+    let x: Array[T] = nil;
 }
 
-fun consume(x: Array<Int>) {
+fun consume(x: Array[Int]) {
     assert(x === nil);
 }

--- a/tests/generic9.dora
+++ b/tests/generic9.dora
@@ -1,19 +1,19 @@
 fun main() {
-    let a = A::<Int>();
+    let a = A[Int]();
     consume(a.x);
 
-    let b = A::<String>();
+    let b = A[String]();
     consume2(b.x);
 }
 
-class A<T> {
-    var x: Array<T> = Array::<T>(10);
+class A[T] {
+    var x: Array[T] = Array[T](10);
 }
 
-fun consume(x: Array<Int>) {
-    assert(x[9] == 0);
+fun consume(x: Array[Int]) {
+    assert(x.get(9) == 0);
 }
 
-fun consume2(x: Array<String>) {
-    assert(x[9] === nil);
+fun consume2(x: Array[String]) {
+    assert(x.get(9) === nil);
 }

--- a/tests/identity.dora
+++ b/tests/identity.dora
@@ -33,21 +33,21 @@ fun main() {
     assert(f1 === f1);
     assert(f1 !== f2);
 
-    assert(bar::<Int>(1, 1));
-    assert(!bar::<Int>(1, 2));
+    assert(bar[Int](1, 1));
+    assert(!bar[Int](1, 2));
 
-    assert(bar::<Double>(1.0, 1.0));
-    assert(!bar::<Double>(1.0, 2.0));
-    assert(!bar::<Double>(0.0, (-0.0)));
-    assert(bar::<Double>(0.0/0.0, 0.0/0.0));
+    assert(bar[Double](1.0, 1.0));
+    assert(!bar[Double](1.0, 2.0));
+    assert(!bar[Double](0.0, (-0.0)));
+    assert(bar[Double](0.0/0.0, 0.0/0.0));
 
-    assert(bar::<Foo>(f1, f1));
-    assert(!bar::<Foo>(f1, Foo(1)));
-    assert(!bar::<Foo>(f1, f2));
+    assert(bar[Foo](f1, f1));
+    assert(!bar[Foo](f1, Foo(1)));
+    assert(!bar[Foo](f1, f2));
 }
 
 class Foo(i: Int) {}
 
-fun bar<T>(a: T, b: T) -> Bool {
+fun bar[T](a: T, b: T) -> Bool {
     return a === b;
 }

--- a/tests/long5.dora
+++ b/tests/long5.dora
@@ -1,16 +1,16 @@
 fun main() {
-    let ba = Array::<Long>(0);
+    let ba = Array[Long](0);
     assert(ba.length() == 0);
 
-    let ba = arrayFill::<Long>(10, 2L);
+    let ba = arrayFill[Long](10, 2L);
     assert(ba.length() == 10);
 
-    ba[0] = 10L;
-    ba[1] = 11L;
-    ba[2] = 12L;
+    ba.set(0, 10L);
+    ba.set(1, 11L);
+    ba.set(2, 12L);
 
-    assert(10L == ba[0]);
-    assert(11L == ba[1]);
-    assert(12L == ba[2]);
-    assert(2L == ba[9]);
+    assert(10L == ba.get(0));
+    assert(11L == ba.get(1));
+    assert(12L == ba.get(2));
+    assert(2L == ba.get(9));
 }

--- a/tests/queue1.dora
+++ b/tests/queue1.dora
@@ -1,5 +1,5 @@
 fun main() {
-    let q = Queue::<Int>();
+    let q = Queue[Int]();
     assert(q.length() == 0);
     assert(q.isEmpty());
     q.enqueue(1);

--- a/tests/queue2.dora
+++ b/tests/queue2.dora
@@ -1,5 +1,5 @@
 fun main() {
-    let q = Queue::<Int>();
+    let q = Queue[Int]();
 
     for i in range(0, 100) {
         q.enqueue(i);

--- a/tests/stdlib/bubble-sort1.dora
+++ b/tests/stdlib/bubble-sort1.dora
@@ -1,14 +1,14 @@
 fun main() {
-    let x = Array::<Int>(4);
-    x[0] = 2;
-    x[1] = 3;
-    x[2] = 0;
-    x[3] = 4;
+    let x = Array[Int](4);
+    x.set(0, 2);
+    x.set(1, 3);
+    x.set(2, 0);
+    x.set(3, 4);
 
-    bubbleSort::<Int>(x);
+    bubbleSort[Int](x);
 
-    assert(x[0] == 0);
-    assert(x[1] == 2);
-    assert(x[2] == 3);
-    assert(x[3] == 4);
+    assert(x.get(0) == 0);
+    assert(x.get(1) == 2);
+    assert(x.get(2) == 3);
+    assert(x.get(3) == 4);
 }

--- a/tests/stdlib/bubble-sort2.dora
+++ b/tests/stdlib/bubble-sort2.dora
@@ -1,16 +1,16 @@
 fun main() {
-    let x = Array::<Int>(5);
-    x[0] = 5;
-    x[1] = 1;
-    x[2] = 4;
-    x[3] = 2;
-    x[4] = 8;
+    let x = Array[Int](5);
+    x.set(0, 5);
+    x.set(1, 1);
+    x.set(2, 4);
+    x.set(3, 2);
+    x.set(4, 8);
 
-    bubbleSort::<Int>(x);
+    bubbleSort[Int](x);
 
-    assert(x[0] == 1);
-    assert(x[1] == 2);
-    assert(x[2] == 4);
-    assert(x[3] == 5);
-    assert(x[4] == 8);
+    assert(x.get(0) == 1);
+    assert(x.get(1) == 2);
+    assert(x.get(2) == 4);
+    assert(x.get(3) == 5);
+    assert(x.get(4) == 8);
 }

--- a/tests/stdlib/char-encode-utf8.dora
+++ b/tests/stdlib/char-encode-utf8.dora
@@ -1,29 +1,29 @@
 fun main() {
     let buffer = write('$');
-    assert(buffer[0] == 0x24Y);
-    assert(buffer[1] == 0Y);
+    assert(buffer.get(0) == 0x24Y);
+    assert(buffer.get(1) == 0Y);
 
     let buffer = write('¢');
-    assert(buffer[0] == 0xC2Y);
-    assert(buffer[1] == 0xA2Y);
-    assert(buffer[2] == 0Y);
+    assert(buffer.get(0) == 0xC2Y);
+    assert(buffer.get(1) == 0xA2Y);
+    assert(buffer.get(2) == 0Y);
 
     let buffer = write('€');
-    assert(buffer[0] == 0xE2Y);
-    assert(buffer[1] == 0x82Y);
-    assert(buffer[2] == 0xACY);
-    assert(buffer[3] == 0Y);
+    assert(buffer.get(0) == 0xE2Y);
+    assert(buffer.get(1) == 0x82Y);
+    assert(buffer.get(2) == 0xACY);
+    assert(buffer.get(3) == 0Y);
 
     let buffer = write('𐍈');
-    assert(buffer[0] == 0xF0Y);
-    assert(buffer[1] == 0x90Y);
-    assert(buffer[2] == 0x8DY);
-    assert(buffer[3] == 0x88Y);
-    assert(buffer[4] == 0Y);
+    assert(buffer.get(0) == 0xF0Y);
+    assert(buffer.get(1) == 0x90Y);
+    assert(buffer.get(2) == 0x8DY);
+    assert(buffer.get(3) == 0x88Y);
+    assert(buffer.get(4) == 0Y);
 }
 
-fun write(ch: Char) -> Array<Byte> {
-    let buffer = Array::<Byte>(5);
+fun write(ch: Char) -> Array[Byte] {
+    let buffer = Array[Byte](5);
     ch.encodeUtf8(buffer, 0);
     return buffer;
 }

--- a/tests/stdlib/string.dora
+++ b/tests/stdlib/string.dora
@@ -10,10 +10,10 @@ fun main() {
 }
 
 fun test_multiple_ascii_chars() {
-    let bytes = Array::<Byte>(3);
-    bytes[0] = 'a'.toInt().toByte();
-    bytes[1] = 'b'.toInt().toByte();
-    bytes[2] = 'c'.toInt().toByte();
+    let bytes = Array[Byte](3);
+    bytes.set(0, 'a'.toInt().toByte());
+    bytes.set(1, 'b'.toInt().toByte());
+    bytes.set(2, 'c'.toInt().toByte());
 
     let val = try! String::fromBytes(bytes);
     let it = val.codePoints();
@@ -28,8 +28,8 @@ fun test_multiple_ascii_chars() {
 }
 
 fun test_1byte() {
-    let bytes = Array::<Byte>(1);
-    bytes[0] = 0x24Y;
+    let bytes = Array[Byte](1);
+    bytes.set(0, 0x24Y);
 
     let val = try! String::fromBytes(bytes);
     let it = val.codePoints();
@@ -40,9 +40,9 @@ fun test_1byte() {
 }
 
 fun test_2bytes() {
-    let bytes = Array::<Byte>(2);
-    bytes[0] = 0xC2Y;
-    bytes[1] = 0xA2Y;
+    let bytes = Array[Byte](2);
+    bytes.set(0, 0xC2Y);
+    bytes.set(1, 0xA2Y);
 
     let val = try! String::fromBytes(bytes);
     let it = val.codePoints();
@@ -53,10 +53,10 @@ fun test_2bytes() {
 }
 
 fun test_3bytes() {
-    let bytes = Array::<Byte>(3);
-    bytes[0] = 0xE2Y;
-    bytes[1] = 0x82Y;
-    bytes[2] = 0xACY;
+    let bytes = Array[Byte](3);
+    bytes.set(0, 0xE2Y);
+    bytes.set(1, 0x82Y);
+    bytes.set(2, 0xACY);
 
     let val = try! String::fromBytes(bytes);
     let it = val.codePoints();
@@ -67,11 +67,11 @@ fun test_3bytes() {
 }
 
 fun test_4bytes() {
-    let bytes = Array::<Byte>(4);
-    bytes[0] = 0xF0Y;
-    bytes[1] = 0x90Y;
-    bytes[2] = 0x8DY;
-    bytes[3] = 0x88Y;
+    let bytes = Array[Byte](4);
+    bytes.set(0, 0xF0Y);
+    bytes.set(1, 0x90Y);
+    bytes.set(2, 0x8DY);
+    bytes.set(3, 0x88Y);
 
     let val = try! String::fromBytes(bytes);
     let it = val.codePoints();
@@ -82,8 +82,8 @@ fun test_4bytes() {
 }
 
 fun test_invalid() {
-    let bytes = Array::<Byte>(1);
-    bytes[0] = 0x80Y;
+    let bytes = Array[Byte](1);
+    bytes.set(0, 0x80Y);
 
     do {
         try String::fromBytes(bytes);

--- a/tests/stdlib/vec-remove-at.dora
+++ b/tests/stdlib/vec-remove-at.dora
@@ -1,17 +1,17 @@
 fun main() {
-    let x = Vec::<Int>();
+    let x = Vec[Int]();
 
     x.push(1);
     x.push(2);
     x.push(3);
 
     assert(3 == x.removeAt(2));
-    assert(x[0] == 1);
-    assert(x[1] == 2);
+    assert(x.get(0) == 1);
+    assert(x.get(1) == 2);
     assert(x.length() == 2);
 
     assert(1 == x.removeAt(0));
-    assert(x[0] == 2);
+    assert(x.get(0) == 2);
     assert(x.length() == 1);
 
     assert(2 == x.removeAt(0));

--- a/tests/stdlib/vec-remove-item.dora
+++ b/tests/stdlib/vec-remove-item.dora
@@ -1,13 +1,13 @@
 fun main() {
-    let vec = Vec::<Int>();
+    let vec = Vec[Int]();
     vec.push(1);
     vec.push(2);
     vec.push(3);
     vec.push(1);
     assert(vec.length() == 4);
 
-    removeItem::<Int>(vec, 1);
+    removeItem[Int](vec, 1);
     assert(vec.length() == 2);
-    assert(vec[0] == 2);
-    assert(vec[1] == 3);
+    assert(vec.get(0) == 2);
+    assert(vec.get(1) == 3);
 }

--- a/tests/stdlib/vec1.dora
+++ b/tests/stdlib/vec1.dora
@@ -1,5 +1,5 @@
 fun main() {
-    let vec = Vec::<Int>();
+    let vec = Vec[Int]();
     assert(vec.length() == 0);
     assert(vec.capacity() == 0);
 
@@ -16,25 +16,25 @@ fun main() {
     vec.push(5);
     assert(vec.length() == 5);
     assert(vec.capacity() == 8);
-    assert(vec[0] == 1);
-    assert(vec[1] == 2);
-    assert(vec[2] == 3);
-    assert(vec[3] == 4);
-    assert(vec[4] == 5);
+    assert(vec.get(0) == 1);
+    assert(vec.get(1) == 2);
+    assert(vec.get(2) == 3);
+    assert(vec.get(3) == 4);
+    assert(vec.get(4) == 5);
 
-    vec[0] = vec[0] + 2;
-    vec[1] = vec[0] - 1;
+    vec.set(0, vec.get(0) + 2);
+    vec.set(1, vec.get(0) - 1);
 
-    assert(vec[0] == 3);
-    assert(vec[1] == 2);
+    assert(vec.get(0) == 3);
+    assert(vec.get(1) == 2);
 
     vec.trimToLen();
     assert(vec.length() == 5);
     assert(vec.capacity() == 5);
 
-    assert(vec[0] == 3);
-    assert(vec[1] == 2);
-    assert(vec[2] == 3);
-    assert(vec[3] == 4);
-    assert(vec[4] == 5);
+    assert(vec.get(0) == 3);
+    assert(vec.get(1) == 2);
+    assert(vec.get(2) == 3);
+    assert(vec.get(3) == 4);
+    assert(vec.get(4) == 5);
 }

--- a/tests/str/from-bytes.dora
+++ b/tests/str/from-bytes.dora
@@ -10,52 +10,52 @@ fun main() {
 }
 
 fun test_multiple_ascii_chars() {
-    let bytes = Array::<Byte>(3);
-    bytes[0] = 'a'.toInt().toByte();
-    bytes[1] = 'b'.toInt().toByte();
-    bytes[2] = 'c'.toInt().toByte();
+    let bytes = Array[Byte](3);
+    bytes.set(0, 'a'.toInt().toByte());
+    bytes.set(1, 'b'.toInt().toByte());
+    bytes.set(2, 'c'.toInt().toByte());
 
     let val = try! String::fromBytes(bytes);
     assert(val == "abc");
 }
 
 fun test_1byte() {
-    let bytes = Array::<Byte>(1);
-    bytes[0] = 0x24Y;
+    let bytes = Array[Byte](1);
+    bytes.set(0, 0x24Y);
 
     try! String::fromBytes(bytes);
 }
 
 fun test_2bytes() {
-    let bytes = Array::<Byte>(2);
-    bytes[0] = 0xC2Y;
-    bytes[1] = 0xA2Y;
+    let bytes = Array[Byte](2);
+    bytes.set(0, 0xC2Y);
+    bytes.set(1, 0xA2Y);
 
     try! String::fromBytes(bytes);
 }
 
 fun test_3bytes() {
-    let bytes = Array::<Byte>(3);
-    bytes[0] = 0xE2Y;
-    bytes[1] = 0x82Y;
-    bytes[2] = 0xACY;
+    let bytes = Array[Byte](3);
+    bytes.set(0, 0xE2Y);
+    bytes.set(1, 0x82Y);
+    bytes.set(2, 0xACY);
 
     try! String::fromBytes(bytes);
 }
 
 fun test_4bytes() {
-    let bytes = Array::<Byte>(4);
-    bytes[0] = 0xF0Y;
-    bytes[1] = 0x90Y;
-    bytes[2] = 0x8DY;
-    bytes[3] = 0x88Y;
+    let bytes = Array[Byte](4);
+    bytes.set(0, 0xF0Y);
+    bytes.set(1, 0x90Y);
+    bytes.set(2, 0x8DY);
+    bytes.set(3, 0x88Y);
 
     try! String::fromBytes(bytes);
 }
 
 fun test_invalid() {
-    let bytes = Array::<Byte>(1);
-    bytes[0] = 0x80Y;
+    let bytes = Array[Byte](1);
+    bytes.set(0, 0x80Y);
 
     do {
         try String::fromBytes(bytes);

--- a/tests/str7.dora
+++ b/tests/str7.dora
@@ -1,22 +1,22 @@
 //= output "abxy\n"
 
 fun main() {
-    let x = arrayEmpty::<String>();
+    let x = arrayEmpty[String]();
     assert(x.length() == 0);
 
-    let x = arrayFill::<String>(10, nil);
+    let x = arrayFill[String](10, nil);
     assert(x.length() == 10);
 
-    x[0] = "a" + "b";
-    x[1] = "x" + "y";
+    x.set(0, "a" + "b");
+    x.set(1, "x" + "y");
 
     forceCollect();
 
-    print(x[0]);
-    println(x[1]);
+    print(x.get(0));
+    println(x.get(1));
 
-    assert(x[0] == "ab");
-    assert(x[1] == "xy");
-    assert(x[2] === nil);
-    assert(x[9] === nil);
+    assert(x.get(0) == "ab");
+    assert(x.get(1) == "xy");
+    assert(x.get(2) === nil);
+    assert(x.get(9) === nil);
 }

--- a/tests/swiper/full1.dora
+++ b/tests/swiper/full1.dora
@@ -1,10 +1,10 @@
 //= vm-args "--max-heap-size=128M --gc-verify"
 
 fun main() {
-    let a = Array::<Foo>(1_000_000);
+    let a = Array[Foo](1_000_000);
     var i = 0;
     while i < a.length() {
-        a[i] = Foo();
+        a.set(i, Foo());
         i = i + 1;
     }
 

--- a/tests/swiper/full2.dora
+++ b/tests/swiper/full2.dora
@@ -2,10 +2,10 @@
 //= vm-args "--max-heap-size=256M --gc-verify"
 
 fun main() {
-    let a = Array::<Foo>(10_000_000);
+    let a = Array[Foo](10_000_000);
     var i = 0;
     while i < a.length() {
-        a[i] = Foo();
+        a.set(i, Foo());
         i = i + 1;
     }
 

--- a/tests/swiper/large1.dora
+++ b/tests/swiper/large1.dora
@@ -1,12 +1,12 @@
 //= vm-args "--gc=swiper --gc-verify"
 
 fun main() {
-    let x = Array::<Object>(16 * 1024);
-    let y = Array::<Object>(16 * 1024);
-    let z = Array::<Object>(16 * 1024);
+    let x = Array[Object](16 * 1024);
+    let y = Array[Object](16 * 1024);
+    let z = Array[Object](16 * 1024);
     forceCollect();
-    assert(x[0] === nil);
-    x[0] = Object();
+    assert(x.get(0) === nil);
+    x.set(0, Object());
     forceCollect();
-    assert(x[0] !== nil);
+    assert(x.get(0) !== nil);
 }

--- a/tests/swiper/large2.dora
+++ b/tests/swiper/large2.dora
@@ -2,14 +2,14 @@
 
 fun main() {
     {
-        let x = Array::<Object>(16 * 1024);
+        let x = Array[Object](16 * 1024);
         forceCollect();
     }
 
     forceCollect();
 
     {
-        let y = Array::<Object>(16 * 1024);
+        let y = Array[Object](16 * 1024);
         forceCollect();
     }
 

--- a/tests/swiper/large3.dora
+++ b/tests/swiper/large3.dora
@@ -3,16 +3,16 @@
 class Foo(let x: Int)
 
 fun main() {
-    let x = Array::<Foo>(16 * 1024);
+    let x = Array[Foo](16 * 1024);
     forceCollect();
-    assert(x[0] === nil);
+    assert(x.get(0) === nil);
 
-    x[0] = Foo(1);
+    x.set(0, Foo(1));
     forceMinorCollect();
-    assert(x[0].x == 1);
+    assert(x.get(0).x == 1);
 
-    x[16 * 1024 - 1] = Foo(2);
+    x.set(16 * 1024 - 1, Foo(2));
     forceMinorCollect();
-    assert(x[0].x == 1);
-    assert(x[16 * 1024 - 1].x == 2);
+    assert(x.get(0).x == 1);
+    assert(x.get(16 * 1024 - 1).x == 2);
 }

--- a/tests/swiper/large5.dora
+++ b/tests/swiper/large5.dora
@@ -2,11 +2,11 @@
 //= error oom
 
 fun main() {
-    var x = Vec::<Array<Int> >();
+    var x = Vec[Array[Int]]();
     var i = 0;
 
     while i < 100_000 {
-        x.push(Array::<Int>(32 * 1024));
+        x.push(Array[Int](32 * 1024));
         i = i + 1;
     }
 }

--- a/tests/swiper/large6.dora
+++ b/tests/swiper/large6.dora
@@ -5,11 +5,11 @@ const STEP: Int = 5;
 const REMOVED: Int = 20;
 
 fun main() {
-    var x = Vec::<Array<Int> >();
+    var x = Vec[Array[Int] ]();
     var i = 0;
 
     while i < SIZE {
-        x.push(Array::<Int>(32 * 1024));
+        x.push(Array[Int](32 * 1024));
         i = i + 1;
     }
 
@@ -18,7 +18,7 @@ fun main() {
     i = 0;
 
     while i < SIZE {
-        x[i] = nil;
+        x.set(i, nil);
         i = i + STEP;
     }
 
@@ -28,7 +28,7 @@ fun main() {
     var nils = 0;
 
     while i < SIZE {
-        if x[i] === nil {
+        if x.get(i) === nil {
             nils = nils + 1;
         }
 

--- a/tests/swiper/marking1.dora
+++ b/tests/swiper/marking1.dora
@@ -1,7 +1,7 @@
 //= ignore
 
 fun main() {
-    let arr = Vec::<Foo>();
+    let arr = Vec[Foo]();
 
     var i = 0;
     while i < 10 {

--- a/tests/swiper/minor3.dora
+++ b/tests/swiper/minor3.dora
@@ -1,17 +1,17 @@
 //= vm-args "--gc-parallel-minor --gc-worker=2 --gc-verify"
 
 fun main() {
-    var x = Vec::<Array<Int> >();
+    var x = Vec[Array[Int] ]();
     var i = 0;
 
     while i < 100 {
         if i % 2 == 0 {
-            x.push(Array::<Int>(2));
+            x.push(Array[Int](2));
         } else {
-            x.push(Array::<Int>(4));
+            x.push(Array[Int](4));
         }
-        x.push(Array::<Int>(512));
-        x.push(Array::<Int>(2048));
+        x.push(Array[Int](512));
+        x.push(Array[Int](2048));
         if i % 5 == 0 {
             forceMinorCollect();
         }

--- a/tests/swiper/objarray1.dora
+++ b/tests/swiper/objarray1.dora
@@ -3,15 +3,15 @@
 fun main() {
   let x = Foo(100);
   let y = Foo(101);
-  let z = Array::<Foo>(512);
+  let z = Array[Foo](512);
   forceMinorCollect();
   forceMinorCollect();
   // write into old object x reference to young object
-  z[0] = Foo(2);
-  z[511] = Foo(3);
+  z.set(0, Foo(2));
+  z.set(511, Foo(3));
   forceMinorCollect();
-  assert(z[0].a == 2);
-  assert(z[511].a == 3);
+  assert(z.get(0).a == 2);
+  assert(z.get(511).a == 3);
 }
 
 class Foo(let a: Int)

--- a/tests/swiper/objarray2.dora
+++ b/tests/swiper/objarray2.dora
@@ -1,15 +1,15 @@
 //= vm-args "--gc=swiper --gc-verify"
 
 fun main() {
-    let a = Array::<Foo>(61);
-    let b = Array::<Foo>(61);
+    let a = Array[Foo](61);
+    let b = Array[Foo](61);
     forceMinorCollect();
     forceMinorCollect();
-    // a[5] = Foo(2);
-    b[5] = Foo(1);
+    // a.set(5, Foo(2));
+    b.set(5, Foo(1));
     forceMinorCollect();
-    // assert(a[5].a == 2);
-    assert(b[5].a == 1);
+    // assert(a.get(5).a == 2);
+    assert(b.get(5).a == 1);
 }
 
 class Foo(let a: Int)

--- a/tests/swiper/objarray3.dora
+++ b/tests/swiper/objarray3.dora
@@ -1,8 +1,8 @@
 //= vm-args "--gc=swiper --gc-verify"
 
 fun main() {
-    let a = Array::<Foo>(16 * 1024);
-    a[16 * 1024 - 1] = Foo();
+    let a = Array[Foo](16 * 1024);
+    a.set(16 * 1024 - 1, Foo());
     forceCollect();
 }
 

--- a/tests/swiper/objarray4.dora
+++ b/tests/swiper/objarray4.dora
@@ -1,15 +1,15 @@
 //= vm-args "--gc=swiper --gc-verify"
 
 fun main() {
-    let a = Array::<Foo>(60);
-    let b = Array::<Foo>(60);
+    let a = Array[Foo](60);
+    let b = Array[Foo](60);
     forceMinorCollect();
     forceMinorCollect();
-    // a[5] = Foo(2);
-    b[5] = Foo(1);
+    // a.set(5, Foo(2));
+    b.set(5, Foo(1));
     forceMinorCollect();
-    // assert(a[5].a == 2);
-    assert(b[5].a == 1);
+    // assert(a.get(5).a == 2);
+    assert(b.get(5).a == 1);
 }
 
 class Foo(let a: Int)

--- a/tests/swiper/old2young2.dora
+++ b/tests/swiper/old2young2.dora
@@ -1,14 +1,14 @@
 //= vm-args "--gc=swiper --gc-verify"
 
 fun main() {
-  let x = Array::<Foo>(2);
+  let x = Array[Foo](2);
   forceMinorCollect();
   forceMinorCollect();
   // array in old generation references object in
   // young generation.
-  x[0] = Foo(2);
+  x.set(0, Foo(2));
   forceMinorCollect();
-  assert(x[0].a == 2);
+  assert(x.get(0).a == 2);
 }
 
 class Foo(let a: Int)

--- a/tests/swiper/promote4.dora
+++ b/tests/swiper/promote4.dora
@@ -1,15 +1,15 @@
 //= vm-args "--gc=swiper --gc-verify"
 
 fun main() {
-  var x = Array::<Foo>(128);
+  var x = Array[Foo](128);
   forceMinorCollect();
-  x[0] = Foo(1);
-  x[127] = Foo(2);
+  x.set(0, Foo(1));
+  x.set(127, Foo(2));
   forceMinorCollect();
-  assert(x[0].a == 1);
-  assert(x[1] === nil);
-  assert(x[126] === nil);
-  assert(x[127].a == 2);
+  assert(x.get(0).a == 1);
+  assert(x.get(1) === nil);
+  assert(x.get(126) === nil);
+  assert(x.get(127).a == 2);
 }
 
 class Foo(let a: Int)

--- a/tests/swiper/promote5.dora
+++ b/tests/swiper/promote5.dora
@@ -3,22 +3,22 @@
 class Foo(let x: Int)
 
 fun main() {
-    let x = Array::<Foo>(64);
+    let x = Array[Foo](64);
     forceMinorCollect();
-    assert(x[0] === nil);
-    assert(x[63] === nil);
+    assert(x.get(0) === nil);
+    assert(x.get(63) === nil);
 
-    x[0] = Foo(1);
+    x.set(0, Foo(1));
     forceMinorCollect();
-    assert(x[0].x == 1);
-    assert(x[63] === nil);
+    assert(x.get(0).x == 1);
+    assert(x.get(63) === nil);
 
-    x[63] = Foo(2);
+    x.set(63, Foo(2));
     forceMinorCollect();
-    assert(x[0].x == 1);
-    assert(x[63].x == 2);
+    assert(x.get(0).x == 1);
+    assert(x.get(63).x == 2);
 
     forceMinorCollect();
-    assert(x[0].x == 1);
-    assert(x[63].x == 2);
+    assert(x.get(0).x == 1);
+    assert(x.get(63).x == 2);
 }

--- a/tests/swiper/promote6.dora
+++ b/tests/swiper/promote6.dora
@@ -3,7 +3,7 @@
 class Foo(let x: Int)
 
 fun main() {
-    let a = Array::<Long>(70);
+    let a = Array[Long](70);
     let x = CardSpanningObject();
     forceMinorCollect();
     assert(x.field0 === nil);

--- a/tests/vec1.dora
+++ b/tests/vec1.dora
@@ -1,5 +1,5 @@
 fun main() {
-    let x = Vec::<Int>();
+    let x = Vec[Int]();
     x.push(1);
     x.push(2);
     x.push(3);

--- a/tests/vec2.dora
+++ b/tests/vec2.dora
@@ -1,7 +1,7 @@
 //= output "321"
 
 fun main() {
-    let x = Vec::<String>();
+    let x = Vec[String]();
     x.push(1.toString());
     x.push(2.toString());
     x.push(3.toString());

--- a/tests/whiteboard/sieve.dora
+++ b/tests/whiteboard/sieve.dora
@@ -5,26 +5,26 @@ fun main() {
     var i = 0;
 
     while i < primes.length() {
-        println(primes[i].toString());
+        println(primes.get(i).toString());
         i = i + 1;
     }
 }
 
-fun sieve(limit: Int) -> Vec<Int> {
-    let primes = Vec::<Int>();
+fun sieve(limit: Int) -> Vec[Int] {
+    let primes = Vec[Int]();
 
     if limit >= 2 {
-        let numbers = arrayFill::<Bool>(limit+1, true);
+        let numbers = arrayFill[Bool](limit+1, true);
         let sqrtLimit = limit.toDouble().sqrt().toInt();
 
         var factor = 2;
 
         while factor <= sqrtLimit {
-            if numbers[factor] {
+            if numbers.get(factor) {
                 var multiple = factor * factor;
 
                 while multiple <= limit {
-                    numbers[multiple] = false;
+                    numbers.set(multiple, false);
                     multiple = multiple + factor;
                 }
             }
@@ -35,7 +35,7 @@ fun sieve(limit: Int) -> Vec<Int> {
         var i = 0;
 
         while i <= limit {
-            if i >= 2 && numbers[i] {
+            if i >= 2 && numbers.get(i) {
                 primes.push(i);
             }
 

--- a/tests/whiteboard/simple-map.dora
+++ b/tests/whiteboard/simple-map.dora
@@ -1,5 +1,5 @@
 fun main() {
-    let m = SlowMap::<Int, String>();
+    let m = SlowMap[Int, String]();
     assert(m.insert(1, "hello"));
     assert(m.insert(2, "world"));
 
@@ -11,15 +11,15 @@ fun main() {
     assert(m.get(2) == "test");
 }
 
-class SlowMap<K: Equals, V> {
-    var entries: Vec<SlowMapEntry<K, V> > = Vec::<SlowMapEntry<K, V> >();
+class SlowMap[K: Equals, V] {
+    var entries: Vec[SlowMapEntry[K, V]] = Vec[SlowMapEntry[K, V]]();
 
     fun insert(key: K, val: V) -> Bool {
         var i = 0;
         var len = self.entries.length();
 
         while i < len {
-            let entry = self.entries[i];
+            let entry = self.entries.get(i);
 
             if entry.key.equals(key) {
                 entry.value = val;
@@ -29,7 +29,7 @@ class SlowMap<K: Equals, V> {
             i = i + 1;
         }
 
-        self.entries.push(SlowMapEntry::<K, V>(key, val));
+        self.entries.push(SlowMapEntry[K, V](key, val));
         return true;
     }
 
@@ -38,7 +38,7 @@ class SlowMap<K: Equals, V> {
         var len = self.entries.length();
 
         while i < len {
-            let entry = self.entries[i];
+            let entry = self.entries.get(i);
 
             if entry.key.equals(key) {
                 return entry.value;
@@ -47,8 +47,8 @@ class SlowMap<K: Equals, V> {
             i = i + 1;
         }
 
-        return defaultValue::<V>();
+        return defaultValue[V]();
     }
 }
 
-class SlowMapEntry<K, V>(let key: K, var value: V)
+class SlowMapEntry[K, V](let key: K, var value: V)


### PR DESCRIPTION
Ok, this is probably the biggest change I ever want to make to Dora (and the one I feel is the most important one), so here is my reasoning:

Why `[]` instead of `<>` for generics?

- It makes function definitions and function calls look consistent:
```
// before
fun foo<T>(x: T) = ....
foo::<Int>(1);
// after
fun foo[T](x: T) = ....
foo[Int](1);
```
- Every language that ever tried to implement generics with `<>` had to deal with ugly workarounds:
  - In Rust there is `::<>` which people dislike to this day and want to fix.
  - C# does some elaborate hacks of parsing it as "less than" comparison, and if they figure out later that it isn't a comparison they go back and parse it as Generics.
  - It took C++ ages until it wouldn't try parsing `>>` as right shift (you had to use `> >`).
  - In Java you have really weird syntax to make parsing easier: `someInstance.<Integer>foo(1);`
  
- I'm very critical of Scala (which uses `[]`) but they got this absolutely right. To this day, no issues with this approach have been found, and I never heard of anyone wanting to go back to `<>`. So there is some practical evidence that this works as well as advertised.

- As a nice side-effect, it forces us to do away with special syntax for array access. It's not implemented in this PR, but I plan to bring array access back as `let x = someArray(1)` and `someArray(0) = 1`. This makes it extremely regular and treats array access simply as a function from some int to the array's element result type.