### PR TITLE
baseline: assert throws Error instead of trap 

### DIFF
--- a/src/baseline/ast/expr.rs
+++ b/src/baseline/ast/expr.rs
@@ -438,7 +438,11 @@ where
     }
 
     fn emit_lit_str(&mut self, lit: &'ast ExprLitStrType, dest: Reg) {
-        let handle = Str::from_buffer_in_perm(self.vm, lit.value.as_bytes());
+        self.emit_lit_str_value(&lit.value, dest);
+    }
+
+    fn emit_lit_str_value(&mut self, lit_value: &String, dest: Reg) {
+        let handle = Str::from_buffer_in_perm(self.vm, lit_value.as_bytes());
 
         let disp = self.asm.add_addr(handle.raw() as *const u8);
         let pos = self.asm.pos() as i32;
@@ -1231,13 +1235,26 @@ where
     }
 
     fn emit_intrinsic_assert(&mut self, e: &'ast ExprCallType, _: Reg) {
-        let lbl_div = self.asm.create_label();
+        // throw Error if assertion failed
+        let lbl_assert = self.asm.create_label();
         self.emit_expr(&e.args[0], REG_RESULT.into());
 
         self.asm.emit_comment(Comment::Lit("check assert"));
         self.asm
-            .test_and_jump_if(CondCode::Zero, REG_RESULT, lbl_div);
-        self.asm.emit_bailout(lbl_div, Trap::ASSERT, e.pos);
+            .test_and_jump_if(CondCode::NonZero, REG_RESULT, lbl_assert);
+        let csite = self.jit_info.map_csites.get(e.id).unwrap().clone();
+
+        match csite.args.get(1).unwrap() {
+            Arg::Stack(offset, _, _) => {
+                self.emit_lit_str_value(&"assert failed".to_string(), REG_RESULT);
+                self.asm
+                    .store_mem(MachineMode::Ptr, Mem::Local(*offset), REG_RESULT.into());
+            }
+            _ => panic!("unexpected argument for assert"),
+        };
+        self.emit_call_site(&csite, e.pos, REG_RESULT.into());
+        self.asm.throw(REG_RESULT, e.pos);
+        self.asm.bind_label(lbl_assert)
     }
 
     fn emit_intrinsic_debug(&mut self) {

--- a/src/baseline/ast/expr.rs
+++ b/src/baseline/ast/expr.rs
@@ -441,7 +441,7 @@ where
         self.emit_lit_str_value(&lit.value, dest);
     }
 
-    fn emit_lit_str_value(&mut self, lit_value: &String, dest: Reg) {
+    fn emit_lit_str_value(&mut self, lit_value: &str, dest: Reg) {
         let handle = Str::from_buffer_in_perm(self.vm, lit_value.as_bytes());
 
         let disp = self.asm.add_addr(handle.raw() as *const u8);

--- a/src/ctxt.rs
+++ b/src/ctxt.rs
@@ -136,6 +136,8 @@ impl<'ast> SemContext<'ast> {
                 array_class: empty_class_id,
 
                 testing_class: empty_class_id,
+                throwable_class: empty_class_id,
+                error_class: empty_class_id,
                 exception_class: empty_class_id,
                 stack_trace_element_class: empty_class_id,
 
@@ -611,6 +613,8 @@ pub struct KnownElements {
     pub array_class: ClassId,
 
     pub testing_class: ClassId,
+    pub throwable_class: ClassId,
+    pub error_class: ClassId,
     pub exception_class: ClassId,
     pub stack_trace_element_class: ClassId,
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -737,6 +737,22 @@ pub fn alloc(vm: &VM, clsid: ClassDefId) -> Ref<Obj> {
     handle
 }
 
+pub struct Throwable {
+    pub header: Header,
+    pub msg: Ref<Str>,
+    pub backtrace: Ref<IntArray>,
+    pub elements: Ref<Obj>,
+}
+
+// Error is subclass of Throwable, possibly there is a better way to represent that
+pub struct Error {
+    pub header: Header,
+    pub msg: Ref<Str>,
+    pub backtrace: Ref<IntArray>,
+    pub elements: Ref<Obj>,
+}
+
+// Exception is subclass of Throwable, possibly there is a better way to represent that
 pub struct Exception {
     pub header: Header,
     pub msg: Ref<Str>,

--- a/src/semck/prelude.rs
+++ b/src/semck/prelude.rs
@@ -36,6 +36,8 @@ pub fn internal_classes<'ast>(ctxt: &mut SemContext<'ast>) {
 
     ctxt.vips.testing_class = internal_class(ctxt, "Testing", None);
 
+    ctxt.vips.throwable_class = internal_class(ctxt, "Throwable", None);
+    ctxt.vips.error_class = internal_class(ctxt, "Error", None);
     ctxt.vips.exception_class = internal_class(ctxt, "Exception", None);
     ctxt.vips.stack_trace_element_class = internal_class(ctxt, "StackTraceElement", None);
 
@@ -348,7 +350,7 @@ pub fn internal_functions<'ast>(ctxt: &mut SemContext<'ast>) {
     intrinsic_method(ctxt, clsid, "get", Intrinsic::GenericArrayGet);
     intrinsic_method(ctxt, clsid, "set", Intrinsic::GenericArraySet);
 
-    let clsid = ctxt.vips.exception_class;
+    let clsid = ctxt.vips.throwable_class;
     native_method(
         ctxt,
         clsid,

--- a/src/semck/superck.rs
+++ b/src/semck/superck.rs
@@ -46,7 +46,9 @@ fn determine_vtables<'ast>(ctxt: &SemContext<'ast>) {
 
     for cls in ctxt.classes.iter() {
         let mut cls = cls.write();
-        determine_vtable(ctxt, &mut lens, &mut *cls);
+        if !lens.contains(&cls.id) {
+            determine_vtable(ctxt, &mut lens, &mut *cls);
+        }
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -46,6 +46,8 @@ where
         "stdlib/Double.dora",
         "stdlib/Array.dora",
         "stdlib/String.dora",
+        "stdlib/Throwable.dora",
+        "stdlib/Error.dora",
         "stdlib/Exception.dora",
         "stdlib/Thread.dora",
         "stdlib/Comparable.dora",

--- a/stdlib/Error.dora
+++ b/stdlib/Error.dora
@@ -1,9 +1,9 @@
-class Exception(msg: String): Throwable(msg) {
+class Error(msg: String): Throwable(msg) {
   override fun printStackTrace() {
     if super.getMessage() !== nil {
-      println("Exception: " + super.getMessage());
+      println("Error: " + self.getMessage());
     } else {
-      println("Exception");
+      println("Error");
     }
 
     let x = self.getStackTrace();
@@ -11,7 +11,7 @@ class Exception(msg: String): Throwable(msg) {
     var i = 0;
 
     while i < x.length() {
-      println(i.toString() + ": " + x.get(i).toString());
+      println(i.toString() + ": " + x[i].toString());
       i = i + 1;
     }
   }

--- a/stdlib/Error.dora
+++ b/stdlib/Error.dora
@@ -1,7 +1,7 @@
 open class Error(msg: String): Throwable(msg) {
   override fun printStackTrace() {
     if super.getMessage() !== nil {
-      println("Error: " + self.getMessage());
+      println("Error: " + super.getMessage());
     } else {
       println("Error");
     }
@@ -11,7 +11,7 @@ open class Error(msg: String): Throwable(msg) {
     var i = 0;
 
     while i < x.length() {
-      println(i.toString() + ": " + x[i].toString());
+      println(i.toString() + ": " + x.get(i).toString());
       i = i + 1;
     }
   }

--- a/stdlib/Error.dora
+++ b/stdlib/Error.dora
@@ -1,4 +1,4 @@
-class Error(msg: String): Throwable(msg) {
+open class Error(msg: String): Throwable(msg) {
   override fun printStackTrace() {
     if super.getMessage() !== nil {
       println("Error: " + self.getMessage());

--- a/stdlib/Exception.dora
+++ b/stdlib/Exception.dora
@@ -1,4 +1,4 @@
-class Exception(msg: String): Throwable(msg) {
+open class Exception(msg: String): Throwable(msg) {
   override fun printStackTrace() {
     if super.getMessage() !== nil {
       println("Exception: " + super.getMessage());

--- a/stdlib/Throwable.dora
+++ b/stdlib/Throwable.dora
@@ -1,0 +1,41 @@
+open abstract class Throwable(let msg: String) {
+  var backtrace: Array<Int> = nil;
+  var elements: Array<StackTraceElement> = nil;
+
+  self.retrieveStackTrace();
+
+  fun getStackTrace() -> Array<StackTraceElement> {
+    if self.elements !== nil {
+      return self.elements;
+    }
+
+    if self.backtrace === nil {
+      self.elements = arrayEmpty::<StackTraceElement>();
+      return self.elements;
+    }
+
+    var i = 0;
+    let len = self.backtrace.length() / 2;
+    self.elements = Array::<StackTraceElement>(len);
+
+    while i < len {
+      self.elements[i] = self.getStackTraceElement(i);
+      i = i + 1;
+    }
+
+    return self.elements;
+  }
+
+  fun getMessage() -> String {
+    return self.msg;
+  }
+
+  abstract fun printStackTrace();
+
+  internal fun retrieveStackTrace();
+  internal fun getStackTraceElement(idx: Int) -> StackTraceElement;
+}
+
+class StackTraceElement(let name: String, let line: Int) {
+  fun toString() -> String = self.name + ": " + self.line.toString();
+}

--- a/stdlib/Throwable.dora
+++ b/stdlib/Throwable.dora
@@ -1,25 +1,25 @@
 open abstract class Throwable(let msg: String) {
-  var backtrace: Array<Int> = nil;
-  var elements: Array<StackTraceElement> = nil;
+  var backtrace: Array[Int] = nil;
+  var elements: Array[StackTraceElement] = nil;
 
   self.retrieveStackTrace();
 
-  fun getStackTrace() -> Array<StackTraceElement> {
+  fun getStackTrace() -> Array[StackTraceElement] {
     if self.elements !== nil {
       return self.elements;
     }
 
     if self.backtrace === nil {
-      self.elements = arrayEmpty::<StackTraceElement>();
+      self.elements = arrayEmpty[StackTraceElement]();
       return self.elements;
     }
 
     var i = 0;
     let len = self.backtrace.length() / 2;
-    self.elements = Array::<StackTraceElement>(len);
+    self.elements = Array[StackTraceElement](len);
 
     while i < len {
-      self.elements[i] = self.getStackTraceElement(i);
+      self.elements.set(i, self.getStackTraceElement(i));
       i = i + 1;
     }
 

--- a/tests/assert2.dora
+++ b/tests/assert2.dora
@@ -1,4 +1,4 @@
-//= error assert
+//= error exception
 
 fun main() {
   let a = false;

--- a/tests/assert3.dora
+++ b/tests/assert3.dora
@@ -1,4 +1,4 @@
-//= error assert
+//= error exception
 
 fun main() {
   f(false);

--- a/tests/exception/print-stack-trace4.dora
+++ b/tests/exception/print-stack-trace4.dora
@@ -1,0 +1,28 @@
+//= output "Exception: SubException 0\n0: SubException.SubException(String, Int): 14\n1: create_exceptions() -> SubException: 8\n2: main(): 4\nException: SubException 1\n0: create_exceptions() -> SubException: 8\n1: main(): 4\n"
+
+fun main() {
+  create_exceptions().printTraces();
+}
+
+fun create_exceptions() -> SubException {
+  return SubException("SubException", 1);
+}
+
+class SubException(msg: String, t: Int) : Exception(msg + " " + t.toString()) {
+  var exception: SubException;
+  if(t > 0) {
+    self.exception = SubException(msg, t-1);
+  }
+
+  // currently needed, because of error when a abstract function is overloaded in base class
+  override fun printStackTrace() {
+    super.printStackTrace();
+  }
+
+  fun printTraces() {
+    if(self.exception !== nil) {
+      self.exception.printTraces();
+    }
+    self.printStackTrace();
+  }
+}

--- a/tests/stdlib/call-assert.dora
+++ b/tests/stdlib/call-assert.dora
@@ -1,4 +1,4 @@
-//= error assert
+//= error exception
 //= output "uncaught exception\n0: foo(): 9\n1: call(String): 20\n2: main(): 5\n"
 
 fun main() {

--- a/tests/stdlib/call-assert.dora
+++ b/tests/stdlib/call-assert.dora
@@ -1,5 +1,5 @@
 //= error assert
-//= output "assert failed\n0: foo(): 9\n1: call(String): 20\n2: main(): 5\n"
+//= output "uncaught exception\n0: foo(): 9\n1: call(String): 20\n2: main(): 5\n"
 
 fun main() {
     call("foo");

--- a/tools/tester.rb
+++ b/tools/tester.rb
@@ -343,7 +343,6 @@ def parse_test_file(file)
         when "code" then test_case.expectation.code = arguments[2].to_i
         when "message" then test_case.expectation.message = arguments[2].to_s
         when "div0" then test_case.expectation.code = 101
-        when "assert" then test_case.expectation.code = 105
         when "array" then test_case.expectation.code = 103
         when "nil" then test_case.expectation.code = 104
         when "exception" then test_case.expectation.code = 105

--- a/tools/tester.rb
+++ b/tools/tester.rb
@@ -339,17 +339,17 @@ def parse_test_file(file)
         next if arguments.size == 1
 
         case arguments[1]
-        when "at" then test_case.expectation.position = arguments[2]
-        when "code" then test_case.expectation.code = arguments[2].to_i
-        when "message" then test_case.expectation.message = arguments[2].to_s
-        when "div0" then test_case.expectation.code = 101
-        when "assert" then test_case.expectation.code = 102
-        when "array" then test_case.expectation.code = 103
-        when "nil" then test_case.expectation.code = 104
-        when "exception" then test_case.expectation.code = 105
-        when "cast" then test_case.expectation.code = 106
-        when "unexpected" then test_case.expectation.code = 107
-        when "oom" then test_case.expectation.code = 108
+        when "at" then exp.position = arguments[2]
+        when "code" then exp.code = arguments[2].to_i
+        when "message" then exp.message = arguments[2].to_s
+        when "div0" then exp.code = 101
+        when "assert" then exp.code = 105
+        when "array" then exp.code = 103
+        when "nil" then exp.code = 104
+        when "exception" then exp.code = 105
+        when "cast" then exp.code = 106
+        when "unexpected" then exp.code = 107
+        when "oom" then exp.code = 108
         when "fail"
           # do nothing
         else

--- a/tools/tester.rb
+++ b/tools/tester.rb
@@ -339,17 +339,17 @@ def parse_test_file(file)
         next if arguments.size == 1
 
         case arguments[1]
-        when "at" then exp.position = arguments[2]
-        when "code" then exp.code = arguments[2].to_i
-        when "message" then exp.message = arguments[2].to_s
-        when "div0" then exp.code = 101
-        when "assert" then exp.code = 105
-        when "array" then exp.code = 103
-        when "nil" then exp.code = 104
-        when "exception" then exp.code = 105
-        when "cast" then exp.code = 106
-        when "unexpected" then exp.code = 107
-        when "oom" then exp.code = 108
+        when "at" then test_case.expectation.position = arguments[2]
+        when "code" then test_case.expectation.code = arguments[2].to_i
+        when "message" then test_case.expectation.message = arguments[2].to_s
+        when "div0" then test_case.expectation.code = 101
+        when "assert" then test_case.expectation.code = 105
+        when "array" then test_case.expectation.code = 103
+        when "nil" then test_case.expectation.code = 104
+        when "exception" then test_case.expectation.code = 105
+        when "cast" then test_case.expectation.code = 106
+        when "unexpected" then test_case.expectation.code = 107
+        when "oom" then test_case.expectation.code = 108
         when "fail"
           # do nothing
         else


### PR DESCRIPTION
I changed assert so it will throw an Error. Addiotionally, i added abstract Throwable class to stdlib, which is the base class for the existing Exception and the newly introduced Error. This behavior is similar to the behavior of Java.