### PR TITLE
added check in determine_vtable to skip already processed class

### DIFF
--- a/src/semck/superck.rs
+++ b/src/semck/superck.rs
@@ -46,7 +46,9 @@ fn determine_vtables<'ast>(ctxt: &SemContext<'ast>) {
 
     for cls in ctxt.classes.iter() {
         let mut cls = cls.write();
-        determine_vtable(ctxt, &mut lens, &mut *cls);
+        if !lens.contains(&cls.id) {
+            determine_vtable(ctxt, &mut lens, &mut *cls);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes the build errors in Travis seen in #71.

Error happened, when a class was processed after a subclass of it was processed. `determine_vtable` was called for the subclass, which recursivle called `determine_vtable` for the parent. After that, in `determine_vtables` the loop at some point also called `determine_vtable` for the parent. Because the vtable was already created, the assertion in line number 72 failed.

If the order of the classes was different (as on my local system), the `determine_vtable` was first called for the parent class. When now `determine_vtable` was called for the subclass, it correctly checked the HashSet, if we already processed the parent and skipped the call.

I added a check before calling `determine_vtable` in `determine_vtables`.