### PR TITLE
Turn modifier keywords into annotations

### DIFF
--- a/bench/alloc/alloc.dora
+++ b/bench/alloc/alloc.dora
@@ -11,7 +11,7 @@ fun main() {
 }
 
 class MyThread() : Thread {
-    override fun run() {
+    @override fun run() {
         allocator();
     }
 }

--- a/bench/falsesharing/falsesharing.dora
+++ b/bench/falsesharing/falsesharing.dora
@@ -49,7 +49,7 @@ fun construct(size: Int) -> Array<Foo> {
 }
 
 class MyThread(let thread_idx: Int, let threads: Int, let iters: Int, let objects: Array<Foo>) : Thread {
-    override fun run() {
+    @override fun run() {
 	let size = self.objects.length();
 	let objects_per_thread = size / self.threads;
 	assert(size % self.threads == 0);

--- a/bench/gcbench/gcbench.dora
+++ b/bench/gcbench/gcbench.dora
@@ -4,7 +4,7 @@ class Node(left: Node, right: Node) {
     var left: Node = left;
     var right: Node = right;
 
-    static fun leaf() -> Node = Node(nil, nil);
+    @static fun leaf() -> Node = Node(nil, nil);
 }
 
 var stretchTreeDepth: Int;

--- a/bench/nbody/nbody.dora
+++ b/bench/nbody/nbody.dora
@@ -135,7 +135,7 @@ class Body {
     var vz: Double;
     var mass: Double;
 
-    static fun jupiter() -> Body {
+    @static fun jupiter() -> Body {
         let p = Body();
         p.x = 4.84143144246472090e+00;
         p.y = -1.16032004402742839e+00;
@@ -147,7 +147,7 @@ class Body {
         return p;
     }
 
-   static fun saturn() -> Body {
+   @static fun saturn() -> Body {
       let p = Body();
       p.x = 8.34336671824457987e+00;
       p.y = 4.12479856412430479e+00;
@@ -159,7 +159,7 @@ class Body {
       return p;
    }
 
-   static fun uranus() -> Body {
+   @static fun uranus() -> Body {
       let p = Body();
       p.x = 1.28943695621391310e+01;
       p.y = -1.51111514016986312e+01;
@@ -171,7 +171,7 @@ class Body {
       return p;
    }
 
-   static fun neptune() -> Body {
+   @static fun neptune() -> Body {
       let p = Body();
       p.x = 1.53796971148509165e+01;
       p.y = -2.59193146099879641e+01;
@@ -183,7 +183,7 @@ class Body {
       return p;
    }
 
-   static fun sun() -> Body {
+   @static fun sun() -> Body {
       let p = Body();
       p.mass = SOLAR_MASS;
       return p;

--- a/bench/raytracer/barrier.dora
+++ b/bench/raytracer/barrier.dora
@@ -3,6 +3,6 @@ class Barrier {
         self.numThreads = n;
     }
 
-    abstract fun doBarrier(myid: Int);
+    @abstract fun doBarrier(myid: Int);
     var numThreads: Int;
 }

--- a/bench/raytracer/primitive.dora
+++ b/bench/raytracer/primitive.dora
@@ -1,4 +1,4 @@
-open abstract class Primitive {
+@open @abstract class Primitive {
     var surf: Surface;
 
     init() {
@@ -9,9 +9,9 @@ open abstract class Primitive {
         self.surf.color = Vec3(r, g, b);
     }
 
-    abstract fun normal(pnt: Vec3) -> Vec3;
-    abstract fun intersect(ry: Ray) -> Isect;
-    abstract fun toString() -> String;
-    abstract fun getCenter() -> Vec3;
-    abstract fun setCenter(c: Vec3);
+    @abstract fun normal(pnt: Vec3) -> Vec3;
+    @abstract fun intersect(ry: Ray) -> Isect;
+    @abstract fun toString() -> String;
+    @abstract fun getCenter() -> Vec3;
+    @abstract fun setCenter(c: Vec3);
 }

--- a/bench/raytracer/vec.dora
+++ b/bench/raytracer/vec.dora
@@ -27,7 +27,7 @@ class Vec3 {
         self.z = self.z + a.z;
     }
 
-    static adds(s: Double, a: Vec3, b: Vec3) -> Vec {
+    @static adds(s: Double, a: Vec3, b: Vec3) -> Vec {
         return Vec3(s * a.x + b.x, s * a.y + b.y, s * a.z + b.z);
     }
 
@@ -47,21 +47,21 @@ class Vec3 {
         self.z = a.z - b.z;
     }
 
-    static fun mult(a: Vec3, b: Vec3) -> Vec3 {
+    @static fun mult(a: Vec3, b: Vec3) -> Vec3 {
         return Vec3(a.x * b.x, a.y * b.y, a.z * b.z);
     }
 
-    static fun cross(a: Vec3, b: Vec3) -> Vec3 {
+    @static fun cross(a: Vec3, b: Vec3) -> Vec3 {
         return Vec3(a.y * b.z - a.z * b.y,
                     a.z * b.x - a.x * b.z,
                     a.x * b.y - a.y * b.x);
     }
 
-    static fun dot(a: Vec3, b: Vec3) -> Double {
+    @static fun dot(a: Vec3, b: Vec3) -> Double {
         return a.x * b.x + a.y * b.y + a.z * b.z;
     }
 
-    static fun com(a: Double, av: Vec3, b: Double, bv: Vec3) -> Vec3 {
+    @static fun com(a: Double, av: Vec3, b: Double, bv: Vec3) -> Vec3 {
         return Vec3(
             a * av.x + b * bv.x,
             a * av.y + b * bv.y,

--- a/bench/splunc/splunc.dora
+++ b/bench/splunc/splunc.dora
@@ -1,10 +1,10 @@
-open abstract class Node {
+@open @abstract class Node {
     var birthday: Int;
     var value: Int;
     var left: Node;
     var right: Node;
 
-    static fun splay(var tree: Node, node: Node) -> Node {
+    @static fun splay(var tree: Node, node: Node) -> Node {
         if tree === nil {
             return tree;
         }
@@ -70,7 +70,7 @@ open abstract class Node {
         return tree;
     }
 
-    static fun insert(var tree: Node, node: Node) -> Node {
+    @static fun insert(var tree: Node, node: Node) -> Node {
         if tree === nil {
             return node;
         }
@@ -90,7 +90,7 @@ open abstract class Node {
         return node;
     }
 
-    static fun trunc(date: Int, tree: Node, depth: Int) {
+    @static fun trunc(date: Int, tree: Node, depth: Int) {
         if tree === nil {
             return;
         }
@@ -148,7 +148,7 @@ open abstract class Node {
         }
     }
 
-    static fun countNodes(node: Node) -> Int {
+    @static fun countNodes(node: Node) -> Int {
         if node === nil {
             return 0;
         }

--- a/lib/dora-parser/src/error/msg.rs
+++ b/lib/dora-parser/src/error/msg.rs
@@ -78,8 +78,9 @@ pub enum Msg {
     MisplacedElse,
     IoError,
     ExpectedClassElement(String),
-    RedundantModifier(String),
-    MisplacedModifier(String),
+    MisplacedAnnotation(String),
+    RedundantAnnotation(String),
+    UnknownAnnotation(String),
     InvalidEscapeSequence(char),
     MissingFctBody,
     FctCallExpected,
@@ -251,14 +252,15 @@ impl Msg {
             ExpectedType(ref got) => format!("type expected but got {}.", got),
             ExpectedIdentifier(ref tok) => format!("identifier expected but got {}.", tok),
             ExpectedSomeIdentifier => "identifier expected".into(),
-            MisplacedModifier(ref modifier) => format!("misplaced modifier `{}`.", modifier),
             ExpectedTopLevelElement(ref token) => {
                 format!("expected function or class but got {}.", token)
             }
             ExpectedClassElement(ref token) => {
                 format!("field or method expected but got {}.", token)
             }
-            RedundantModifier(ref token) => format!("redundant modifier {}.", token),
+            MisplacedAnnotation(ref modifier) => format!("misplaced annotation `{}`.", modifier),
+            RedundantAnnotation(ref token) => format!("redundant annotation {}.", token),
+            UnknownAnnotation(ref token) => format!("unknown annotation {}.", token),
             UnknownChar(ch) => format!("unknown character {} (codepoint {}).", ch, ch as usize),
             UnclosedComment => "unclosed comment.".into(),
             InvalidEscapeSequence(ch) => format!("unknown escape sequence `\\{}`.", ch),

--- a/lib/dora-parser/src/lexer.rs
+++ b/lib/dora-parser/src/lexer.rs
@@ -363,7 +363,8 @@ impl Lexer {
                 } else {
                     TokenKind::Not
                 }
-            }
+            },
+            '@' => TokenKind::At,
 
             _ => {
                 return Err(MsgWithPos::new(
@@ -542,7 +543,7 @@ fn is_char_quote(ch: Option<char>) -> bool {
 }
 
 fn is_operator(ch: Option<char>) -> bool {
-    ch.map(|ch| "^+-*/%&|,=!~;:.()[]{}<>".contains(ch))
+    ch.map(|ch| "^+-*/%&|,=!~;:.()[]{}<>@".contains(ch))
         .unwrap_or(false)
 }
 
@@ -591,17 +592,9 @@ fn keywords_in_map() -> HashMap<&'static str, TokenKind> {
     keywords.insert("do", TokenKind::Do);
     keywords.insert("catch", TokenKind::Catch);
     keywords.insert("finally", TokenKind::Finally);
-    keywords.insert("abstract", TokenKind::Abstract);
-    keywords.insert("open", TokenKind::Open);
-    keywords.insert("override", TokenKind::Override);
     keywords.insert("defer", TokenKind::Defer);
-    keywords.insert("final", TokenKind::Final);
     keywords.insert("is", TokenKind::Is);
     keywords.insert("as", TokenKind::As);
-    keywords.insert("internal", TokenKind::Internal);
-    keywords.insert("optimize", TokenKind::Optimize);
-    keywords.insert("pub", TokenKind::Pub);
-    keywords.insert("static", TokenKind::Static);
     keywords.insert("spawn", TokenKind::Spawn);
     keywords.insert("const", TokenKind::Const);
 
@@ -1051,25 +1044,20 @@ mod tests {
         assert_tok(&mut reader, TokenKind::Trait, 1, 24);
         assert_tok(&mut reader, TokenKind::Const, 1, 30);
 
-        let mut reader = Lexer::from_str("pub static for in impl Self spawn");
-        assert_tok(&mut reader, TokenKind::Pub, 1, 1);
-        assert_tok(&mut reader, TokenKind::Static, 1, 5);
-        assert_tok(&mut reader, TokenKind::For, 1, 12);
-        assert_tok(&mut reader, TokenKind::In, 1, 16);
-        assert_tok(&mut reader, TokenKind::Impl, 1, 19);
-        assert_tok(&mut reader, TokenKind::CapitalThis, 1, 24);
-        assert_tok(&mut reader, TokenKind::Spawn, 1, 29);
+        let mut reader = Lexer::from_str("for in impl Self spawn");
+        assert_tok(&mut reader, TokenKind::For, 1, 1);
+        assert_tok(&mut reader, TokenKind::In, 1, 5);
+        assert_tok(&mut reader, TokenKind::Impl, 1, 8);
+        assert_tok(&mut reader, TokenKind::CapitalThis, 1, 13);
+        assert_tok(&mut reader, TokenKind::Spawn, 1, 18);
 
-        let mut reader = Lexer::from_str("abstract open override defer");
-        assert_tok(&mut reader, TokenKind::Abstract, 1, 1);
-        assert_tok(&mut reader, TokenKind::Open, 1, 10);
-        assert_tok(&mut reader, TokenKind::Override, 1, 15);
-        assert_tok(&mut reader, TokenKind::Defer, 1, 24);
+        let mut reader = Lexer::from_str("defer");
+        assert_tok(&mut reader, TokenKind::Defer, 1, 1);
     }
 
     #[test]
     fn test_operators() {
-        let mut reader = Lexer::from_str("==+=-*/%~.");
+        let mut reader = Lexer::from_str("==+=-*/%~.@");
         assert_tok(&mut reader, TokenKind::EqEq, 1, 1);
         assert_tok(&mut reader, TokenKind::Add, 1, 3);
         assert_tok(&mut reader, TokenKind::Eq, 1, 4);
@@ -1079,6 +1067,7 @@ mod tests {
         assert_tok(&mut reader, TokenKind::Mod, 1, 8);
         assert_tok(&mut reader, TokenKind::Tilde, 1, 9);
         assert_tok(&mut reader, TokenKind::Dot, 1, 10);
+        assert_tok(&mut reader, TokenKind::At, 1, 11);
 
         let mut reader = Lexer::from_str("<=<>=><");
         assert_tok(&mut reader, TokenKind::Le, 1, 1);

--- a/lib/dora-parser/src/lexer/token.rs
+++ b/lib/dora-parser/src/lexer/token.rs
@@ -40,10 +40,8 @@ pub enum TokenKind {
     Do,
     Catch,
     Finally,
-    Final,
-    Pub,
-    Static,
     Spawn,
+    At,
 
     Enum,
     Type,
@@ -55,12 +53,6 @@ pub enum TokenKind {
 
     Underscore,
     Defer,
-
-    // Modifiers
-    Abstract,
-    Open,
-    Override,
-    Optimize,
 
     // Operators
     Add,
@@ -87,7 +79,6 @@ pub enum TokenKind {
     Caret,
     And,
     Or,
-    Internal,
 
     Eq,
     EqEq,
@@ -158,10 +149,8 @@ impl TokenKind {
             TokenKind::Do => "do",
             TokenKind::Catch => "catch",
             TokenKind::Finally => "finally",
-            TokenKind::Final => "final",
-            TokenKind::Pub => "pub",
-            TokenKind::Static => "static",
             TokenKind::Spawn => "spawn",
+            TokenKind::At => "@",
 
             TokenKind::Enum => "enum",
             TokenKind::Type => "type",
@@ -173,12 +162,6 @@ impl TokenKind {
 
             TokenKind::Underscore => "_",
             TokenKind::Defer => "defer",
-
-            // Modifiers
-            TokenKind::Abstract => "abstract",
-            TokenKind::Open => "open",
-            TokenKind::Override => "override",
-            TokenKind::Optimize => "optimize",
 
             // Operators
             TokenKind::Add => "+",
@@ -205,7 +188,6 @@ impl TokenKind {
             TokenKind::Caret => "^",
             TokenKind::And => "&&",
             TokenKind::Or => "||",
-            TokenKind::Internal => "internal",
 
             TokenKind::Eq => "=",
             TokenKind::EqEq => "==",

--- a/src/semck/abstractck.rs
+++ b/src/semck/abstractck.rs
@@ -123,26 +123,26 @@ mod tests {
 
     #[test]
     fn test_abstract_class_without_abstract_methods() {
-        ok("open abstract class A class B: A");
+        ok("@open @abstract class A class B: A");
     }
 
     #[test]
     fn test_override_abstract_method() {
-        ok("open abstract class A { abstract fun foo(); }
-            class B: A { override fun foo() {} }");
+        ok("@open @abstract class A { @abstract fun foo(); }
+            class B: A { @override fun foo() {} }");
     }
 
     #[test]
     fn test_override_abstract_method_in_super_class() {
-        ok("open abstract class A { abstract fun foo(); }
-            open abstract class B: A { override fun foo() {} }
+        ok("@open @abstract class A { @abstract fun foo(); }
+            @open @abstract class B: A { @override fun foo() {} }
             class C: B { }");
     }
 
     #[test]
     fn test_missing_abstract_override() {
         err(
-            "open abstract class A { abstract fun foo(); }
+            "@open @abstract class A { @abstract fun foo(); }
             class B: A { }",
             pos(2, 13),
             Msg::MissingAbstractOverride("A".into(), "foo".into()),
@@ -152,8 +152,8 @@ mod tests {
     #[test]
     fn test_missing_abstract_override_indirect() {
         err(
-            "open abstract class A { abstract fun foo(); }
-            open abstract class B: A {}
+            "@open @abstract class A { @abstract fun foo(); }
+            @open @abstract class B: A {}
             class C: B { }",
             pos(3, 13),
             Msg::MissingAbstractOverride("A".into(), "foo".into()),

--- a/src/semck/clsdefck.rs
+++ b/src/semck/clsdefck.rs
@@ -351,8 +351,8 @@ mod tests {
     fn class_with_unknown_super_class() {
         err("class B : A {}", pos(1, 11), Msg::UnknownClass("A".into()));
         err(
-            "open class B : A {}",
-            pos(1, 16),
+            "@open class B : A {}",
+            pos(1, 17),
             Msg::UnknownClass("A".into()),
         );
         err(
@@ -364,8 +364,8 @@ mod tests {
 
     #[test]
     fn class_with_open_modifier() {
-        ok("open class A {}");
-        ok("open class A {} class B : A {}");
+        ok("@open class A {}");
+        ok("@open class A {} class B : A {}");
         err(
             "class A {} class B : A {}",
             pos(1, 22),
@@ -488,7 +488,7 @@ mod tests {
     fn test_super_class_with_superfluous_type_params() {
         err(
             "
-            open class A
+            @open class A
             class B: A[Int] {}",
             pos(3, 22),
             Msg::WrongNumberTypeParams(0, 1),

--- a/src/semck/fctdefck.rs
+++ b/src/semck/fctdefck.rs
@@ -345,7 +345,7 @@ mod tests {
     #[test]
     fn allow_same_method_as_static_and_non_static() {
         ok("class Foo {
-                static fun foo() {}
+                @static fun foo() {}
                 fun foo() {}
             }");
     }
@@ -370,8 +370,8 @@ mod tests {
     #[test]
     fn abstract_method_in_non_abstract_class() {
         err(
-            "class A { abstract fun foo(); }",
-            pos(1, 20),
+            "class A { @abstract fun foo(); }",
+            pos(1, 21),
             Msg::AbstractMethodNotInAbstractClass,
         );
     }
@@ -379,8 +379,8 @@ mod tests {
     #[test]
     fn abstract_method_with_implementation() {
         err(
-            "abstract class A { abstract fun foo() {} }",
-            pos(1, 29),
+            "@abstract class A { @abstract fun foo() {} }",
+            pos(1, 31),
             Msg::AbstractMethodWithImplementation,
         );
     }
@@ -388,8 +388,8 @@ mod tests {
     #[test]
     fn abstract_static_method() {
         err(
-            "abstract class A { static abstract fun foo(); }",
-            pos(1, 36),
+            "@abstract class A { @static @abstract fun foo(); }",
+            pos(1, 39),
             Msg::ModifierNotAllowedForStaticMethod("abstract".into()),
         );
     }
@@ -397,8 +397,8 @@ mod tests {
     #[test]
     fn open_static_method() {
         err(
-            "abstract class A { static open fun foo() {} }",
-            pos(1, 32),
+            "@abstract class A { @static @open fun foo() {} }",
+            pos(1, 35),
             Msg::ModifierNotAllowedForStaticMethod("open".into()),
         );
     }
@@ -406,8 +406,8 @@ mod tests {
     #[test]
     fn override_static_method() {
         err(
-            "abstract class A { static override fun foo() {} }",
-            pos(1, 36),
+            "@abstract class A { @static @override fun foo() {} }",
+            pos(1, 39),
             Msg::ModifierNotAllowedForStaticMethod("override".into()),
         );
     }
@@ -415,8 +415,8 @@ mod tests {
     #[test]
     fn final_static_method() {
         err(
-            "abstract class A { final static fun foo() {} }",
-            pos(1, 33),
+            "@abstract class A { @final @static fun foo() {} }",
+            pos(1, 36),
             Msg::ModifierNotAllowedForStaticMethod("final".into()),
         );
     }

--- a/src/semck/implck.rs
+++ b/src/semck/implck.rs
@@ -127,9 +127,9 @@ mod tests {
             trait Foo {}
             class A
             impl Foo for A {
-                static fun bar() {}
+                @static fun bar() {}
             }",
-            pos(5, 24),
+            pos(5, 25),
             Msg::StaticMethodNotInTrait("Foo".into(), "bar".into(), vec![]),
         );
     }
@@ -139,7 +139,7 @@ mod tests {
         err(
             "
             trait Foo {
-                static fun bar();
+                @static fun bar();
             }
             class A
             impl Foo for A {}",

--- a/src/typeck/expr.rs
+++ b/src/typeck/expr.rs
@@ -3203,61 +3203,61 @@ mod tests {
 
     #[test]
     fn super_class() {
-        ok("open class A class B: A");
-        ok("open class A class B: A()");
-        ok("open class A(a: Int) class B: A(1)");
+        ok("@open class A class B: A");
+        ok("@open class A class B: A()");
+        ok("@open class A(a: Int) class B: A(1)");
         err(
-            "open class A(a: Int) class B: A(true)",
-            pos(1, 31),
+            "@open class A(a: Int) class B: A(true)",
+            pos(1, 32),
             Msg::UnknownCtor("A".into(), vec!["Bool".into()]),
         );
     }
 
     #[test]
     fn access_super_class_field() {
-        ok("open class A(var a: Int) class B(x: Int): A(x*2)
+        ok("@open class A(var a: Int) class B(x: Int): A(x*2)
             fun foo(b: B) { b.a = b.a + 10; }");
     }
 
     #[test]
     fn check_is() {
-        ok("open class A class B: A
+        ok("@open class A class B: A
             fun f(a: A) -> Bool { return a is B; }");
-        ok("open class A class B: A
+        ok("@open class A class B: A
             fun f(b: B) -> Bool { return b is A; }");
         ok("class A
             fun f(a: A) -> Bool { return a is A; }");
         err(
-            "open class A class B: A
+            "@open class A class B: A
              fun f(a: A) -> Bool { return a is String; }",
             pos(2, 45),
             Msg::TypesIncompatible("A".into(), "String".into()),
         );
         err(
-            "open class A class B: A class C
+            "@open class A class B: A class C
              fun f(a: A) -> Bool { return a is C; }",
             pos(2, 45),
             Msg::TypesIncompatible("A".into(), "C".into()),
         );
 
-        ok("open class A() class B(): A() fun f() -> A { return B(); }");
-        ok("open class A() class B(): A() fun f() { let a: A = B(); }");
+        ok("@open class A() class B(): A() fun f() -> A { return B(); }");
+        ok("@open class A() class B(): A() fun f() { let a: A = B(); }");
     }
 
     #[test]
     fn check_as() {
-        ok("open class A class B: A
+        ok("@open class A class B: A
             fun f(a: A) -> B { return a as B; }");
         ok("class A
             fun f(a: A) -> A { return a as A; }");
         err(
-            "open class A class B: A
+            "@open class A class B: A
              fun f(a: A) -> String { return a as String; }",
             pos(2, 47),
             Msg::TypesIncompatible("A".into(), "String".into()),
         );
         err(
-            "open class A class B: A class C
+            "@open class A class B: A class C
              fun f(a: A) -> C { return a as C; }",
             pos(2, 42),
             Msg::TypesIncompatible("A".into(), "C".into()),
@@ -3266,7 +3266,7 @@ mod tests {
 
     #[test]
     fn check_upcast() {
-        ok("open class A class B: A
+        ok("@open class A class B: A
             fun f(b: B) -> A {
                 let a: A = b;
                 return a;
@@ -3288,7 +3288,7 @@ mod tests {
 
     #[test]
     fn super_delegation() {
-        ok("open class A { fun f() {} }
+        ok("@open class A { fun f() {} }
             class B: A { fun g() {} }
 
             fun foo(b: B) {
@@ -3299,14 +3299,14 @@ mod tests {
 
     #[test]
     fn super_method_call() {
-        ok("open class A { open fun f() -> Int { return 1; } }
-            class B: A { override fun f() -> Int { return super.f() + 1; } }");
+        ok("@open class A { @open fun f() -> Int { return 1; } }
+            class B: A { @override fun f() -> Int { return super.f() + 1; } }");
     }
 
     #[test]
     fn super_as_normal_expression() {
         err(
-            "open class A { }
+            "@open class A { }
             class B: A { fun me() { let x = super; } }",
             pos(2, 45),
             Msg::SuperNeedsMethodCall,
@@ -3643,7 +3643,7 @@ mod tests {
     fn test_invoke_static_method_as_instance_method() {
         err(
             "class A {
-                static fun foo() {}
+                @static fun foo() {}
                 fun test() { self.foo(); }
             }",
             pos(3, 34),
@@ -3656,9 +3656,9 @@ mod tests {
         err(
             "class A {
                 fun foo() {}
-                static fun test() { A::foo(); }
+                @static fun test() { A::foo(); }
             }",
-            pos(3, 37),
+            pos(3, 38),
             Msg::UnknownStaticMethod("A".into(), "foo".into(), vec![]),
         );
     }
@@ -3779,7 +3779,7 @@ mod tests {
             class A[T: Foo]
             fun f() -> A[Foo] { return nil; }");
 
-        ok("open class Foo
+        ok("@open class Foo
             class Bar: Foo
             class A[T: Foo]
             fun f() -> A[Bar] { return nil; }");
@@ -3855,7 +3855,7 @@ mod tests {
             Msg::ParamTypesIncompatible("foo".into(), Vec::new(), vec!["Int".into()]),
         );
 
-        ok("class A { static fun foo() {} }
+        ok("class A { @static fun foo() {} }
             trait Foo { fun foo(a: Int); }
             impl Foo for A { fun foo(a:  Int) {} }
             fun test(a: A) { a.foo(1); }");
@@ -3864,7 +3864,7 @@ mod tests {
     #[test]
     fn test_invoke_abstract_class_ctor() {
         err(
-            "abstract class A
+            "@abstract class A
             fun test() -> A { return A(); }",
             pos(2, 38),
             Msg::NewAbstractClass,

--- a/stdlib/Array.dora
+++ b/stdlib/Array.dora
@@ -1,8 +1,8 @@
-internal class Array[T](len: Int) {
+@internal class Array[T](len: Int) {
 
-  internal fun length() -> Int;
-  internal fun get(idx: Int) -> T;
-  internal fun set(idx: Int, val: T);
+  @internal fun length() -> Int;
+  @internal fun get(idx: Int) -> T;
+  @internal fun set(idx: Int, val: T);
 
 }
 

--- a/stdlib/Bool.dora
+++ b/stdlib/Bool.dora
@@ -1,5 +1,5 @@
-internal class Bool {
-  internal fun toInt() -> Int;
+@internal class Bool {
+  @internal fun toInt() -> Int;
 
   fun hash() -> Int = self.toInt();
 
@@ -11,6 +11,6 @@ internal class Bool {
     }
   }
 
-  internal fun equals(rhs: Bool) -> Bool;
-  internal fun not() -> Bool;
+  @internal fun equals(rhs: Bool) -> Bool;
+  @internal fun not() -> Bool;
 }

--- a/stdlib/Byte.dora
+++ b/stdlib/Byte.dora
@@ -1,10 +1,10 @@
-internal class Byte {
-  internal fun toInt() -> Int;
-  internal fun toLong() -> Long;
-  internal fun toString() -> String;
+@internal class Byte {
+  @internal fun toInt() -> Int;
+  @internal fun toLong() -> Long;
+  @internal fun toString() -> String;
 
-  internal fun equals(rhs: Byte) -> Bool;
-  internal fun compareTo(rhs: Byte) -> Int;
+  @internal fun equals(rhs: Byte) -> Bool;
+  @internal fun compareTo(rhs: Byte) -> Int;
 
   fun hash() -> Int = self.toInt();
 }

--- a/stdlib/Char.dora
+++ b/stdlib/Char.dora
@@ -1,10 +1,10 @@
-internal class Char {
-  internal fun toInt() -> Int;
-  internal fun toLong() -> Long;
-  internal fun toString() -> String;
+@internal class Char {
+  @internal fun toInt() -> Int;
+  @internal fun toLong() -> Long;
+  @internal fun toString() -> String;
 
-  internal fun equals(rhs: Char) -> Bool;
-  internal fun compareTo(rhs: Char) -> Int;
+  @internal fun equals(rhs: Char) -> Bool;
+  @internal fun compareTo(rhs: Char) -> Int;
 
   fun hash() -> Int = self.toInt();
 

--- a/stdlib/Default.dora
+++ b/stdlib/Default.dora
@@ -1,31 +1,31 @@
 trait Default {
-  static fun default() -> Self; // should be `let` instead of `fun`
+  @static fun default() -> Self; // should be `let` instead of `fun`
 }
 
 impl Default for Bool {
-  static fun default() -> Bool = false;
+  @static fun default() -> Bool = false;
 }
 
 impl Default for Byte {
-  static fun default() -> Byte = 0Y;
+  @static fun default() -> Byte = 0Y;
 }
 
 impl Default for Int {
-  static fun default() -> Int = 0;
+  @static fun default() -> Int = 0;
 }
 
 impl Default for Long {
-  static fun default() -> Long = 0L;
+  @static fun default() -> Long = 0L;
 }
 
 impl Default for Float {
-  static fun default() -> Float = 0.0F;
+  @static fun default() -> Float = 0.0F;
 }
 
 impl Default for Double {
-  static fun default() -> Double = 0.0;
+  @static fun default() -> Double = 0.0;
 }
 
 impl Default for String {
-  static fun default() -> String = "";
+  @static fun default() -> String = "";
 }

--- a/stdlib/Double.dora
+++ b/stdlib/Double.dora
@@ -1,24 +1,24 @@
-internal class Double {
-  internal fun toInt() -> Int;
-  internal fun toLong() -> Long;
-  internal fun toFloat() -> Float;
-  internal fun toString() -> String;
+@internal class Double {
+  @internal fun toInt() -> Int;
+  @internal fun toLong() -> Long;
+  @internal fun toFloat() -> Float;
+  @internal fun toString() -> String;
 
-  internal fun asLong() -> Long;
+  @internal fun asLong() -> Long;
 
-  internal fun equals(rhs: Double) -> Bool;
-  internal fun compareTo(rhs: Double) -> Int;
+  @internal fun equals(rhs: Double) -> Bool;
+  @internal fun compareTo(rhs: Double) -> Int;
 
-  internal fun plus(rhs: Double) -> Double;
-  internal fun minus(rhs: Double) -> Double;
-  internal fun times(rhs: Double) -> Double;
-  internal fun div(rhs: Double) -> Double;
+  @internal fun plus(rhs: Double) -> Double;
+  @internal fun minus(rhs: Double) -> Double;
+  @internal fun times(rhs: Double) -> Double;
+  @internal fun div(rhs: Double) -> Double;
 
-  internal fun unaryPlus() -> Double;
-  internal fun unaryMinus() -> Double;
+  @internal fun unaryPlus() -> Double;
+  @internal fun unaryMinus() -> Double;
 
-  internal fun isNan() -> Bool;
-  internal fun sqrt() -> Double;
+  @internal fun isNan() -> Bool;
+  @internal fun sqrt() -> Double;
 
   fun hash() -> Int = self.asLong().toInt();
 }

--- a/stdlib/Error.dora
+++ b/stdlib/Error.dora
@@ -1,5 +1,5 @@
-open class Error(msg: String): Throwable(msg) {
-  override fun printStackTrace() {
+@open class Error(msg: String): Throwable(msg) {
+  @override fun printStackTrace() {
     if super.getMessage() !== nil {
       println("Error: " + super.getMessage());
     } else {

--- a/stdlib/Exception.dora
+++ b/stdlib/Exception.dora
@@ -1,5 +1,5 @@
-open class Exception(msg: String): Throwable(msg) {
-  override fun printStackTrace() {
+@open class Exception(msg: String): Throwable(msg) {
+  @override fun printStackTrace() {
     if super.getMessage() !== nil {
       println("Exception: " + super.getMessage());
     } else {

--- a/stdlib/Float.dora
+++ b/stdlib/Float.dora
@@ -1,24 +1,24 @@
-internal class Float {
-  internal fun toInt() -> Int;
-  internal fun toLong() -> Long;
-  internal fun toDouble() -> Double;
-  internal fun toString() -> String;
+@internal class Float {
+  @internal fun toInt() -> Int;
+  @internal fun toLong() -> Long;
+  @internal fun toDouble() -> Double;
+  @internal fun toString() -> String;
 
-  internal fun asInt() -> Int;
+  @internal fun asInt() -> Int;
 
-  internal fun equals(rhs: Float) -> Bool;
-  internal fun compareTo(rhs: Float) -> Int;
+  @internal fun equals(rhs: Float) -> Bool;
+  @internal fun compareTo(rhs: Float) -> Int;
 
-  internal fun plus(rhs: Float) -> Float;
-  internal fun minus(rhs: Float) -> Float;
-  internal fun times(rhs: Float) -> Float;
-  internal fun div(rhs: Float) -> Float;
+  @internal fun plus(rhs: Float) -> Float;
+  @internal fun minus(rhs: Float) -> Float;
+  @internal fun times(rhs: Float) -> Float;
+  @internal fun div(rhs: Float) -> Float;
 
-  internal fun unaryPlus() -> Float;
-  internal fun unaryMinus() -> Float;
+  @internal fun unaryPlus() -> Float;
+  @internal fun unaryMinus() -> Float;
 
-  internal fun isNan() -> Bool;
-  internal fun sqrt() -> Float;
+  @internal fun isNan() -> Bool;
+  @internal fun sqrt() -> Float;
 
   fun hash() -> Int = self.asInt();
 }

--- a/stdlib/Int.dora
+++ b/stdlib/Int.dora
@@ -1,5 +1,5 @@
-internal class Int {
-  internal fun toByte() -> Byte;
+@internal class Int {
+  @internal fun toByte() -> Byte;
   fun toChar() throws -> Char {
     if self >= 0 && self <= 0x10FFFF && (self < 0xD800 || self > 0xDFFF) {
       return self.toCharUnchecked();
@@ -7,35 +7,35 @@ internal class Int {
       throw "invalid code point";
     }
   }
-  internal fun toCharUnchecked() -> Char;
-  internal fun toLong() -> Long;
-  internal fun toString() -> String;
+  @internal fun toCharUnchecked() -> Char;
+  @internal fun toLong() -> Long;
+  @internal fun toString() -> String;
 
-  internal fun toFloat() -> Float;
-  internal fun toDouble() -> Double;
+  @internal fun toFloat() -> Float;
+  @internal fun toDouble() -> Double;
 
-  internal fun asFloat() -> Float;
+  @internal fun asFloat() -> Float;
 
-  internal fun equals(rhs: Int) -> Bool;
-  internal fun compareTo(rhs: Int) -> Int;
+  @internal fun equals(rhs: Int) -> Bool;
+  @internal fun compareTo(rhs: Int) -> Int;
 
-  internal fun plus(rhs: Int) -> Int;
-  internal fun minus(rhs: Int) -> Int;
-  internal fun times(rhs: Int) -> Int;
-  internal fun div(rhs: Int) -> Int;
-  internal fun mod(rhs: Int) -> Int;
+  @internal fun plus(rhs: Int) -> Int;
+  @internal fun minus(rhs: Int) -> Int;
+  @internal fun times(rhs: Int) -> Int;
+  @internal fun div(rhs: Int) -> Int;
+  @internal fun mod(rhs: Int) -> Int;
 
-  internal fun bitwiseOr(rhs: Int) -> Int;
-  internal fun bitwiseAnd(rhs: Int) -> Int;
-  internal fun bitwiseXor(rhs: Int) -> Int;
+  @internal fun bitwiseOr(rhs: Int) -> Int;
+  @internal fun bitwiseAnd(rhs: Int) -> Int;
+  @internal fun bitwiseXor(rhs: Int) -> Int;
 
-  internal fun shiftLeft(rhs: Int) -> Int;
-  internal fun shiftRight(rhs: Int) -> Int;
-  internal fun unsignedShiftRight(rhs: Int) -> Int;
+  @internal fun shiftLeft(rhs: Int) -> Int;
+  @internal fun shiftRight(rhs: Int) -> Int;
+  @internal fun unsignedShiftRight(rhs: Int) -> Int;
 
-  internal fun unaryPlus() -> Int;
-  internal fun unaryMinus() -> Int;
-  internal fun not() -> Int;
+  @internal fun unaryPlus() -> Int;
+  @internal fun unaryMinus() -> Int;
+  @internal fun not() -> Int;
 
   fun hash() -> Int = self;
 
@@ -47,7 +47,7 @@ internal class Int {
     }
   }
 
-  static fun min(lhs: Int, rhs: Int) -> Int {
+  @static fun min(lhs: Int, rhs: Int) -> Int {
     if lhs < rhs {
       return lhs;
     } else {
@@ -55,7 +55,7 @@ internal class Int {
     }
   }
 
-  static fun max(lhs: Int, rhs: Int) -> Int {
+  @static fun max(lhs: Int, rhs: Int) -> Int {
     if lhs < rhs {
       return rhs;
     } else {
@@ -63,11 +63,11 @@ internal class Int {
     }
   }
 
-  static fun max_value() -> Int {
+  @static fun max_value() -> Int {
     return 2147483647;
   }
 
-  static fun min_value() -> Int {
+  @static fun min_value() -> Int {
     return -2147483648;
   }
 }

--- a/stdlib/Long.dora
+++ b/stdlib/Long.dora
@@ -1,5 +1,5 @@
-internal class Long {
-  internal fun toByte() -> Byte;
+@internal class Long {
+  @internal fun toByte() -> Byte;
   fun toChar() throws -> Char {
     if self >= 0L && self <= 0x10FFFFL && (self < 0xD800L || self > 0xDFFFL) {
       return self.toCharUnchecked();
@@ -7,47 +7,47 @@ internal class Long {
       throw "invalid code point";
     }
   }
-  internal fun toCharUnchecked() -> Char;
-  internal fun toInt() -> Int;
-  internal fun toString() -> String;
+  @internal fun toCharUnchecked() -> Char;
+  @internal fun toInt() -> Int;
+  @internal fun toString() -> String;
 
-  internal fun toFloat() -> Float;
-  internal fun toDouble() -> Double;
+  @internal fun toFloat() -> Float;
+  @internal fun toDouble() -> Double;
 
-  internal fun asDouble() -> Double;
+  @internal fun asDouble() -> Double;
 
-  internal fun equals(rhs: Long) -> Bool;
-  internal fun compareTo(rhs: Long) -> Int;
+  @internal fun equals(rhs: Long) -> Bool;
+  @internal fun compareTo(rhs: Long) -> Int;
 
-  internal fun plus(rhs: Long) -> Long;
-  internal fun minus(rhs: Long) -> Long;
-  internal fun times(rhs: Long) -> Long;
-  internal fun div(rhs: Long) -> Long;
-  internal fun mod(rhs: Long) -> Long;
+  @internal fun plus(rhs: Long) -> Long;
+  @internal fun minus(rhs: Long) -> Long;
+  @internal fun times(rhs: Long) -> Long;
+  @internal fun div(rhs: Long) -> Long;
+  @internal fun mod(rhs: Long) -> Long;
 
-  internal fun bitwiseOr(rhs: Long) -> Long;
-  internal fun bitwiseAnd(rhs: Long) -> Long;
-  internal fun bitwiseXor(rhs: Long) -> Long;
+  @internal fun bitwiseOr(rhs: Long) -> Long;
+  @internal fun bitwiseAnd(rhs: Long) -> Long;
+  @internal fun bitwiseXor(rhs: Long) -> Long;
 
-  internal fun shiftLeft(rhs: Long) -> Long;
-  internal fun shiftRight(rhs: Long) -> Long;
-  internal fun unsignedShiftRight(rhs: Long) -> Long;
+  @internal fun shiftLeft(rhs: Long) -> Long;
+  @internal fun shiftRight(rhs: Long) -> Long;
+  @internal fun unsignedShiftRight(rhs: Long) -> Long;
 
-  internal fun unaryPlus() -> Long;
-  internal fun unaryMinus() -> Long;
-  internal fun not() -> Long;
+  @internal fun unaryPlus() -> Long;
+  @internal fun unaryMinus() -> Long;
+  @internal fun not() -> Long;
 
   fun hash() -> Int = self.toInt();
 
-  static fun max_value() -> Long {
+  @static fun max_value() -> Long {
     return 9223372036854775807L;
   }
 
-  static fun min_value() -> Long {
+  @static fun min_value() -> Long {
     return -9223372036854775808L;
   }
 
-  static fun min(lhs: Long, rhs: Long) -> Long {
+  @static fun min(lhs: Long, rhs: Long) -> Long {
     if lhs < rhs {
       return lhs;
     } else {
@@ -55,7 +55,7 @@ internal class Long {
     }
   }
 
-  static fun max(lhs: Long, rhs: Long) -> Long {
+  @static fun max(lhs: Long, rhs: Long) -> Long {
     if lhs < rhs {
       return rhs;
     } else {

--- a/stdlib/Queue.dora
+++ b/stdlib/Queue.dora
@@ -3,7 +3,7 @@ class Queue[T] {
   var front: Int = 0;
   var count: Int = 0;
 
-  pub fun enqueue(value: T) {
+  @pub fun enqueue(value: T) {
     if self.count == self.elements.length() {
       // copy into larger array
       let newelements = Array[T](self.elements.length() * 2);
@@ -24,7 +24,7 @@ class Queue[T] {
     self.count = self.count + 1;
   }
 
-  pub fun dequeue() -> T {
+  @pub fun dequeue() -> T {
     assert(self.count > 0);
 
     let value = self.elements.get(self.front);
@@ -56,11 +56,11 @@ class Queue[T] {
     }
   }
 
-  pub fun length() -> Int {
+  @pub fun length() -> Int {
     return self.count;
   }
 
-  pub fun isEmpty() -> Bool {
+  @pub fun isEmpty() -> Bool {
     return self.count == 0;
   }
 }

--- a/stdlib/String.dora
+++ b/stdlib/String.dora
@@ -1,4 +1,4 @@
-internal class String {
+@internal class String {
   fun equals(rhs: String) -> Bool {
     var i = 0;
 
@@ -19,20 +19,20 @@ internal class String {
     return true;
   }
 
-  internal fun compareTo(rhs: String) -> Int;
+  @internal fun compareTo(rhs: String) -> Int;
 
-  internal fun length() -> Int;
-  internal fun parseInt() -> Int;
-  internal fun parseLong() -> Long;
-  internal fun plus(rhs: String) -> String;
+  @internal fun length() -> Int;
+  @internal fun parseInt() -> Int;
+  @internal fun parseLong() -> Long;
+  @internal fun plus(rhs: String) -> String;
 
-  internal fun getByte(idx: Int) -> Byte;
-  internal fun clone() -> String;
+  @internal fun getByte(idx: Int) -> Byte;
+  @internal fun clone() -> String;
 
-  internal static fun fromBytesPartOrNull(val: Array[Byte], offset: Int, len: Int) -> String;
-  internal static fun fromStringPartOrNull(val: String, offset: Int, len: Int) -> String;
+  @internal @static fun fromBytesPartOrNull(val: Array[Byte], offset: Int, len: Int) -> String;
+  @internal @static fun fromStringPartOrNull(val: String, offset: Int, len: Int) -> String;
 
-  static fun fromBytesPart(val: Array[Byte], offset: Int, len: Int) throws -> String {
+  @static fun fromBytesPart(val: Array[Byte], offset: Int, len: Int) throws -> String {
     let str = String::fromBytesPartOrNull(val, offset, len);
 
     if str === nil {
@@ -42,7 +42,7 @@ internal class String {
     return str;
   }
 
-  static fun fromBytes(val: Array[Byte]) throws -> String {
+  @static fun fromBytes(val: Array[Byte]) throws -> String {
     let str = String::fromBytesPartOrNull(val, 0, val.length());
 
     if str === nil {
@@ -52,7 +52,7 @@ internal class String {
     return str;
   }
 
-  static fun fromStringPart(val: String, offset: Int, len: Int) throws -> String {
+  @static fun fromStringPart(val: String, offset: Int, len: Int) throws -> String {
     let str = String::fromStringPartOrNull(val, offset, len);
 
     if str === nil {
@@ -62,7 +62,7 @@ internal class String {
     return str;
   }
 
-  static fun fromString(val: String) -> String = val.clone();
+  @static fun fromString(val: String) -> String = val.clone();
 
   fun isEmpty() -> Bool = self.length() == 0;
 

--- a/stdlib/StringBuf.dora
+++ b/stdlib/StringBuf.dora
@@ -1,5 +1,5 @@
 class StringBuf(var buf: Array[Byte], var length: Int) {
-  static fun empty() -> StringBuf = StringBuf(Array[Byte](0), 0);
+  @static fun empty() -> StringBuf = StringBuf(Array[Byte](0), 0);
 
   fun length() -> Int {
     return self.length;

--- a/stdlib/Thread.dora
+++ b/stdlib/Thread.dora
@@ -1,5 +1,5 @@
-open abstract class Thread {
-  internal fun start();
+@open @abstract class Thread {
+  @internal fun start();
 
-  abstract fun run();
+  @abstract fun run();
 }

--- a/stdlib/Throwable.dora
+++ b/stdlib/Throwable.dora
@@ -1,4 +1,4 @@
-open abstract class Throwable(let msg: String) {
+@open @abstract class Throwable(let msg: String) {
   var backtrace: Array[Int] = nil;
   var elements: Array[StackTraceElement] = nil;
 
@@ -30,10 +30,10 @@ open abstract class Throwable(let msg: String) {
     return self.msg;
   }
 
-  abstract fun printStackTrace();
+  @abstract fun printStackTrace();
 
-  internal fun retrieveStackTrace();
-  internal fun getStackTraceElement(idx: Int) -> StackTraceElement;
+  @internal fun retrieveStackTrace();
+  @internal fun getStackTraceElement(idx: Int) -> StackTraceElement;
 }
 
 class StackTraceElement(let name: String, let line: Int) {

--- a/stdlib/prelude.dora
+++ b/stdlib/prelude.dora
@@ -1,27 +1,27 @@
-internal fun fatalError(msg: String);
-internal fun abort();
-internal fun exit(status: Int);
+@internal fun fatalError(msg: String);
+@internal fun abort();
+@internal fun exit(status: Int);
 fun unreachable() {
   fatalError("unreachable code");
 }
 
 fun unimplemented() = fatalError("not yet implemented");
 
-internal fun print(text: String);
-internal fun println(text: String);
-internal fun addressOf(object: Object) -> Long;
-internal fun assert(val: Bool);
-internal fun debug();
-internal fun argc() -> Int;
-internal fun argv(idx: Int) -> String;
-internal fun forceCollect();
-internal fun forceMinorCollect();
+@internal fun print(text: String);
+@internal fun println(text: String);
+@internal fun addressOf(object: Object) -> Long;
+@internal fun assert(val: Bool);
+@internal fun debug();
+@internal fun argc() -> Int;
+@internal fun argv(idx: Int) -> String;
+@internal fun forceCollect();
+@internal fun forceMinorCollect();
 
-internal fun call(fct: String);
-internal fun throwFromNative(val: Bool) throws;
-internal fun throwFromNativeButNotThrows(val: Bool);
+@internal fun call(fct: String);
+@internal fun throwFromNative(val: Bool) throws;
+@internal fun throwFromNativeButNotThrows(val: Bool);
 
-internal fun timestamp() -> Long;
+@internal fun timestamp() -> Long;
 
 class Object
 
@@ -112,17 +112,17 @@ fun isValidUtf8(data: Array[Byte]) -> Bool {
   return true;
 }
 
-internal fun defaultValue[T]() -> T;
+@internal fun defaultValue[T]() -> T;
 
-internal fun loadFunction(name: String) -> Long;
-internal fun call0(fct: Long) -> Long;
-internal fun call1(fct: Long, arg0: Long) -> Long;
-internal fun call2(fct: Long, arg0: Long, arg1: Long) -> Long;
-internal fun call3(fct: Long, arg0: Long, arg1: Long, arg2: Long) -> Long;
+@internal fun loadFunction(name: String) -> Long;
+@internal fun call0(fct: Long) -> Long;
+@internal fun call1(fct: Long, arg0: Long) -> Long;
+@internal fun call2(fct: Long, arg0: Long, arg1: Long) -> Long;
+@internal fun call3(fct: Long, arg0: Long, arg1: Long, arg2: Long) -> Long;
 
-internal fun native_malloc(size: Long) -> Long;
-internal fun native_free(address: Long);
-internal fun set_uint8(address: Long, val: Byte);
+@internal fun native_malloc(size: Long) -> Long;
+@internal fun native_free(address: Long);
+@internal fun set_uint8(address: Long, val: Byte);
 
 fun native_string(val: String) -> Long {
   var i = 0;
@@ -144,7 +144,7 @@ fun getpid() -> Int = call0(loadFunction("getpid")).toInt();
 
 fun getppid() -> Int = call0(loadFunction("getppid")).toInt();
 
-internal fun sleep(seconds: Int);
+@internal fun sleep(seconds: Int);
 
 class IntRange(let lower: Int, let upper: Int) {
   fun makeIterator() -> IntRangeIter {

--- a/tests/as1.dora
+++ b/tests/as1.dora
@@ -15,5 +15,5 @@ fun asa(b: B) -> A {
   return b as A;
 }
 
-open class A {}
+@open class A {}
 class B: A {}

--- a/tests/as2.dora
+++ b/tests/as2.dora
@@ -10,5 +10,5 @@ fun asb(a: A) -> B {
   return a as B;
 }
 
-open class A {}
+@open class A {}
 class B: A {}

--- a/tests/as3.dora
+++ b/tests/as3.dora
@@ -7,11 +7,11 @@ fun asl7(a: L1) -> L7 {
   return a as L7;
 }
 
-open class L1 {}
-open class L2: L1 {}
-open class L3: L2 {}
-open class L4: L3 {}
-open class L5: L4 {}
-open class L6: L5 {}
+@open class L1 {}
+@open class L2: L1 {}
+@open class L3: L2 {}
+@open class L4: L3 {}
+@open class L5: L4 {}
+@open class L6: L5 {}
 class L7: L6 {}
 class LX: L6 {}

--- a/tests/as4.dora
+++ b/tests/as4.dora
@@ -9,11 +9,11 @@ fun asl7(a: L1) -> L7 {
   return a as L7;
 }
 
-open class L1 {}
-open class L2: L1 {}
-open class L3: L2 {}
-open class L4: L3 {}
-open class L5: L4 {}
-open class L6: L5 {}
+@open class L1 {}
+@open class L2: L1 {}
+@open class L3: L2 {}
+@open class L4: L3 {}
+@open class L5: L4 {}
+@open class L6: L5 {}
 class L7: L6 {}
 class LX: L6 {}

--- a/tests/as5.dora
+++ b/tests/as5.dora
@@ -8,5 +8,5 @@ fun test(a: A) -> Bool {
     return a.x != 0;
 }
 
-open class A
+@open class A
 class B(let x: Int): A

--- a/tests/ctor3.dora
+++ b/tests/ctor3.dora
@@ -10,5 +10,5 @@ class X(a: Int, b: Int) {
     var ma: Int = a;
     var mb: Int = b;
 
-    static fun empty() -> X = X(3, 1);
+    @static fun empty() -> X = X(3, 1);
 }

--- a/tests/ctor5.dora
+++ b/tests/ctor5.dora
@@ -10,5 +10,5 @@ class X(a: Int, b: Int) {
     var a: Int = a;
     var b: Int = b;
 
-    static fun empty() -> X = X(3, 1);
+    @static fun empty() -> X = X(3, 1);
 }

--- a/tests/ctor8.dora
+++ b/tests/ctor8.dora
@@ -19,6 +19,6 @@ fun main() {
 }
 
 class X(let a: Int, let b: Int, let c: Int) {
-  static fun one(a: Int) -> X = X(a, 0, 0);
-  static fun two(a: Int, b: Int) -> X = X(a, b, 0);
+  @static fun one(a: Int) -> X = X(a, 0, 0);
+  @static fun two(a: Int, b: Int) -> X = X(a, b, 0);
 }

--- a/tests/ctor9.dora
+++ b/tests/ctor9.dora
@@ -5,5 +5,5 @@ fun main() {
   assert(x.b == 2);
 }
 
-open class Y(let a: Int) {}
+@open class Y(let a: Int) {}
 class X(let b: Int, a: Int) : Y(a) {}

--- a/tests/dyn1.dora
+++ b/tests/dyn1.dora
@@ -1,8 +1,8 @@
 //= output "ABC"
 
-open class A { open fun foo() { print("A"); } }
-class B: A { override fun foo() { print("B"); } }
-class C: A { override fun foo() { print("C"); } }
+@open class A { @open fun foo() { print("A"); } }
+class B: A { @override fun foo() { print("B"); } }
+class C: A { @override fun foo() { print("C"); } }
 
 fun main() {
   test(A());

--- a/tests/exception/print-stack-trace4.dora
+++ b/tests/exception/print-stack-trace4.dora
@@ -14,8 +14,8 @@ class SubException(msg: String, t: Int) : Exception(msg + " " + t.toString()) {
     self.exception = SubException(msg, t-1);
   }
 
-  // currently needed, because of error when a abstract function is overloaded in base class
-  override fun printStackTrace() {
+  // currently needed, because of error when an @abstract function is overloaded in base class
+  @override fun printStackTrace() {
     super.printStackTrace();
   }
 

--- a/tests/generic11.dora
+++ b/tests/generic11.dora
@@ -4,5 +4,5 @@ fun main() {
 }
 
 class Foo {
-  static fun id[T](val: T) -> T = val;
+  @static fun id[T](val: T) -> T = val;
 }

--- a/tests/impl4.dora
+++ b/tests/impl4.dora
@@ -4,13 +4,13 @@ fun main() {
 }
 
 trait DefaultValue {
-    static fun default() -> Self;
+    @static fun default() -> Self;
 }
 
 class A(let a: Int)
 
 impl DefaultValue for A {
-    static fun default() -> A {
+    @static fun default() -> A {
         return nil;
     }
 }

--- a/tests/inh1.dora
+++ b/tests/inh1.dora
@@ -5,4 +5,4 @@ fun main() {
 }
 
 class A(let x: Int): B(x*2)
-open class B(let y: Int)
+@open class B(let y: Int)

--- a/tests/inh2.dora
+++ b/tests/inh2.dora
@@ -9,6 +9,6 @@ class A(x1: Int): B(x1*2) {
   let x: Int = x1;
 }
 
-open class B(y1: Int) {
+@open class B(y1: Int) {
   let y: Int = y1;
 }

--- a/tests/inh3.dora
+++ b/tests/inh3.dora
@@ -7,6 +7,6 @@ fun main() {
 }
 
 class A(let x: Data, d: Data): B(d)
-open class B(let y: Data)
+@open class B(let y: Data)
 
 class Data(let data: Int)

--- a/tests/inh4.dora
+++ b/tests/inh4.dora
@@ -8,15 +8,15 @@ fun main() {
   assert(c.printSpecial() == 1);
 }
 
-open abstract class A {
- abstract fun printSpecial() -> Int;
+@open @abstract class A {
+ @abstract fun printSpecial() -> Int;
  fun printBase() -> Int {
    return 2;
  }
 }
 
-open class B : A {
- override fun printSpecial() -> Int {
+@open class B : A {
+ @override fun printSpecial() -> Int {
    return 1;
  }
 }

--- a/tests/is1.dora
+++ b/tests/is1.dora
@@ -13,5 +13,5 @@ fun isa(b: B) -> Bool {
   return b is A;
 }
 
-open class A {}
+@open class A {}
 class B: A {}

--- a/tests/is2.dora
+++ b/tests/is2.dora
@@ -15,11 +15,11 @@ fun isl7(a: L1) -> Bool {
   return a is L7;
 }
 
-open class L1 {}
-open class L2: L1 {}
-open class L3: L2 {}
-open class L4: L3 {}
-open class L5: L4 {}
-open class L6: L5 {}
+@open class L1 {}
+@open class L2: L1 {}
+@open class L3: L2 {}
+@open class L4: L3 {}
+@open class L5: L4 {}
+@open class L6: L5 {}
 class L7: L6 {}
 class LX: L6 {}

--- a/tests/is3.dora
+++ b/tests/is3.dora
@@ -13,13 +13,13 @@ fun isl7(a: L1) -> Bool {
   return a is L7;
 }
 
-open class L1 {}
-open class L2: L1 {}
-open class L3: L2 {}
-open class L4: L3 {}
-open class L5: L4 {}
-open class L6: L5 {}
-open class L7: L6 {}
-open class L8: L7 {}
-open class L9: L8 {}
+@open class L1 {}
+@open class L2: L1 {}
+@open class L3: L2 {}
+@open class L4: L3 {}
+@open class L5: L4 {}
+@open class L6: L5 {}
+@open class L7: L6 {}
+@open class L8: L7 {}
+@open class L9: L8 {}
 class L10: L9 {}

--- a/tests/let1.dora
+++ b/tests/let1.dora
@@ -7,5 +7,5 @@ fun main() {
 class X(something: Int) {
   let x: Int = something;
 
-  static fun empty() -> X = X(2);
+  @static fun empty() -> X = X(2);
 }

--- a/tests/nil8.dora
+++ b/tests/nil8.dora
@@ -5,8 +5,8 @@ fun main() {
     a.foo();
 }
 
-open class A {
-    open fun foo() {
+@open class A {
+    @open fun foo() {
         println("A::foo");
     }
 }

--- a/tests/obj9.dora
+++ b/tests/obj9.dora
@@ -8,5 +8,5 @@ fun main() {
 fun t(o: Object) {}
 
 class A
-open class B
+@open class B
 class C: B

--- a/tests/pctor3.dora
+++ b/tests/pctor3.dora
@@ -5,5 +5,5 @@ fun main() {
     assert(y.b == 101);
 }
 
-open class X(let a: Int)
+@open class X(let a: Int)
 class Y(let b: Int, a: Int): X(a) {}

--- a/tests/pctor4.dora
+++ b/tests/pctor4.dora
@@ -3,5 +3,5 @@
 
 fun main() {}
 
-open class X(let a: Int)
+@open class X(let a: Int)
 class Y(let b: Int, a: Int): X {}

--- a/tests/static1.dora
+++ b/tests/static1.dora
@@ -4,7 +4,7 @@ fun main() {
 }
 
 class Foo {
-    static fun test(a: Int, b: Int) -> Int {
+    @static fun test(a: Int, b: Int) -> Int {
         return a + b;
     }
 }

--- a/tests/super1.dora
+++ b/tests/super1.dora
@@ -5,14 +5,14 @@ fun main() {
   assert(b.foo(2) == 3);
 }
 
-open class A {
-  open fun foo(a: Int) -> Int {
+@open class A {
+  @open fun foo(a: Int) -> Int {
     return a;
   }
 }
 
 class B: A {
-  override fun foo(a: Int) -> Int {
+  @override fun foo(a: Int) -> Int {
     return super.foo(a) + 1;
   }
 }

--- a/tests/super2.dora
+++ b/tests/super2.dora
@@ -3,7 +3,7 @@
 
 fun main() { }
 
-open class A { }
+@open class A { }
 
 class B: A {
   fun foo() {

--- a/tests/super3.dora
+++ b/tests/super3.dora
@@ -5,16 +5,16 @@ fun main() {
     assert(c.foo(2) == 3);
 }
 
-open class A {
-  open fun foo(a: Int) -> Int {
+@open class A {
+  @open fun foo(a: Int) -> Int {
     return a;
   }
 }
 
-open class B: A {}
+@open class B: A {}
 
 class C: B {
-  override fun foo(a: Int) -> Int {
+  @override fun foo(a: Int) -> Int {
     return super.foo(a) + 1;
   }
 }

--- a/tests/super4.dora
+++ b/tests/super4.dora
@@ -5,20 +5,20 @@ fun main() {
   assert(c.foo(2) == 5);
 }
 
-open class A {
-  open fun foo(a: Int) -> Int {
+@open class A {
+  @open fun foo(a: Int) -> Int {
     return a;
   }
 }
 
-open class B: A {
-  open override fun foo(a: Int) -> Int {
+@open class B: A {
+  @open @override fun foo(a: Int) -> Int {
     return super.foo(a) * 2;
   }
 }
 
 class C: B {
-  override fun foo(a: Int) -> Int {
+  @override fun foo(a: Int) -> Int {
     return super.foo(a) + 1;
   }
 }

--- a/tests/thread/allocate1.dora
+++ b/tests/thread/allocate1.dora
@@ -2,7 +2,7 @@
 //= vm-args "--gc-young-size=64M --max-heap-size=128M"
 
 class MyThread() : Thread {
-    override fun run() {
+    @override fun run() {
         allocator();
         println("done");
     }

--- a/tests/thread/allocate2.dora
+++ b/tests/thread/allocate2.dora
@@ -2,7 +2,7 @@
 //= vm-args "--gc-young-size=64M --max-heap-size=128M"
 
 class MyThread() : Thread {
-    override fun run() {
+    @override fun run() {
         allocator();
         println("done");
     }

--- a/tests/thread/counter1.dora
+++ b/tests/thread/counter1.dora
@@ -1,7 +1,7 @@
 //= output "done\n"
 
 class MyThread(var executed: Bool) : Thread {
-    override fun run() {
+    @override fun run() {
         f(self);
     }
 }

--- a/tests/thread/counter2.dora
+++ b/tests/thread/counter2.dora
@@ -1,7 +1,7 @@
 //= output "done\n"
 
 class MyThread(var executed: Bool) : Thread {
-    override fun run() {
+    @override fun run() {
         self.f();
     }
 

--- a/tests/thread/join1.dora
+++ b/tests/thread/join1.dora
@@ -1,7 +1,7 @@
 //= output "one\ntwo\n"
 
 class MyThread() : Thread {
-    override fun run() {
+    @override fun run() {
         sleep(2);
         println("two");
     }

--- a/tests/thread/native1.dora
+++ b/tests/thread/native1.dora
@@ -1,5 +1,5 @@
 class MyThread() : Thread {
-    override fun run() {
+    @override fun run() {
         nativeCalls();
     }
 }

--- a/tests/whiteboard/bst-check-balance.dora
+++ b/tests/whiteboard/bst-check-balance.dora
@@ -1,5 +1,5 @@
 class Node(let val: Int, var left: Node, var right: Node) {
-  static fun val(val: Int) -> Node = Node(val, nil, nil);
+  @static fun val(val: Int) -> Node = Node(val, nil, nil);
 }
 
 fun main() {


### PR DESCRIPTION
This splits the bare minimal set of keywords required to understand the
structure of the code from the larger set of keywords that act as
modifiers.

The core idea is to put as much of the language on equal footing to code
users could write, while also allowing the modifiers to benefit from
all the facilities annotations usually have, like the ability to have
parameters and defaults, as well as allowing migration and deprecation.

This is a limited implementation, as all supported annotations are
hard-coded and no syntax for defining annotations in Dora exists.