### PR TITLE
vscode: fixed error "unable to watch for file changes in large work space"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,13 @@
 {
     "files.exclude": {
-        "target/**": true,
         "**/*.un~": true,
-        "experiments/raise/target/**": true
+        "experiments/raise/target/**": true,
+        "lib/dora-parser/target/**": true,
+        "target/**": true
+    },
+    "files.watcherExclude": {
+        "experiments/raise/target/**": true,
+        "lib/dora-parser/target/**": true,
+        "target/**": true
     }
 }


### PR DESCRIPTION
I ran into the following issue on my work station: https://code.visualstudio.com/docs/setup/linux#_visual-studio-code-is-unable-to-watch-for-file-changes-in-this-large-workspace-error-enospc
I added the target folders to the exclude settings of vscode and this fixed the problem for me. 

To be thorough: `cat /proc/sys/fs/inotify/max_user_watches` shows, that I have a maximum of 8192 handles. Currently, after I cleaned my target folders and built the project twice (debug and release), I get the following output:
```
$ find . -type f | wc -l
8168
$ find lib/dora-parser/target -type f | wc -l
2993
$ find target -type f | wc -l
3366
```
So around 75% of the files are related to building the project.