### PR TITLE
bytecode: add assert/throw support to bytecode

### DIFF
--- a/src/bytecode/generate.rs
+++ b/src/bytecode/generate.rs
@@ -848,6 +848,10 @@ impl BytecodeGenerator {
             .push(Bytecode::InvokeStaticPtr(dest, fid, start, num));
     }
 
+    pub fn emit_throw(&mut self, exception: Register) {
+        self.code.push(Bytecode::Throw(exception));
+    }
+
     pub fn emit_new_object(&mut self, dest: Register, cls_id: ClassDefId) {
         self.code.push(Bytecode::NewObject(dest, cls_id));
     }
@@ -1264,6 +1268,9 @@ impl BytecodeFunction {
                         "{}: {} <-ptr invoke static {:?} {} {}",
                         btidx, dest, fct_id, start, num
                     );
+                }
+                Bytecode::Throw(exception) => {
+                    println!("{}: throw {}", btidx, exception);
                 }
                 Bytecode::NewObject(dest, cls_id) => {
                     println!("{}: {} <- new {:?}", btidx, dest, cls_id);

--- a/src/bytecode/opcode.rs
+++ b/src/bytecode/opcode.rs
@@ -113,6 +113,8 @@ pub enum Bytecode {
 
     NewObject(Register, ClassDefId),
 
+    Throw(Register),
+
     RetBool(Register),
     RetByte(Register),
     RetChar(Register),


### PR DESCRIPTION
As discussed, the intrinsic assert is translated into the corresponding code, as it will be executed. This is similar to the approach Java is using.