### PR TITLE
vscode: fixed watcher exclude to match absolute path (fixes #83)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,6 @@
         "target/**": true
     },
     "files.watcherExclude": {
-        "experiments/raise/target/**": true,
-        "lib/dora-parser/target/**": true,
-        "target/**": true
+        "**/target/**": true
     }
 }


### PR DESCRIPTION
The changes in #83 didn't work as I thought. After I restarted my computer and Visual Code the message came up again. I digged a little deeper into the matter and realized, that the pattern has to match the absolute path. I changed it accordingly to match all target folders. This is naturally not perfect, but as long we don't create a folder named target, this should be unproblematic.