### PR TITLE
bytecode: fix calculation of stacksize

### DIFF
--- a/src/bytecode/generate.rs
+++ b/src/bytecode/generate.rs
@@ -905,8 +905,8 @@ fn generate_offset(registers: &Vec<BytecodeType>) -> Vec<i32> {
     let mut offset: Vec<i32> = vec![0; registers.len()];
     let mut stacksize: i32 = 0;
     for (index, ty) in registers.iter().enumerate() {
-        offset[index] = cratemem::align_i32(stacksize - ty.size(), ty.size());
-        stacksize = offset[index];
+        stacksize = cratemem::align_i32(stacksize + ty.size(), ty.size());
+        offset[index] = -stacksize;
     }
 
     offset


### PR DESCRIPTION
`align_i32` seems to not work correctly with negative numbers. Simple solution with some changes of operators and signs.