### PR TITLE
cannon: emit code for char, string, int and float constants

### DIFF
--- a/src/bytecode/generate.rs
+++ b/src/bytecode/generate.rs
@@ -928,6 +928,10 @@ impl BytecodeFunction {
         &self.string_pool
     }
 
+    pub fn string(&self, sp: StrConstPoolIdx) -> &String {
+        self.string_pool().get(sp.0).expect("string not found")
+    }
+
     pub fn registers(&self) -> &[BytecodeType] {
         &self.registers
     }


### PR DESCRIPTION
I added support for literal values in cannon for Char, Byte, Int, Long, Float, Double and String. Tests are currently not possible, because most rely heavily on assert. But with `--emit-asm=all` it is possible to compare the output of both baseline-compiler. (#86 is needed)