### PR TITLE
Capstone not needed as external dependency

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,0 +1,60 @@
+name: lint & test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.kind }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, macOS-10.14]
+        kind: ['test', 'lint']
+        exclude:
+          - os: macOS-10.14
+            kind: 'lint'
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Install rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: "nightly"
+
+      - name: Install rustfmt
+        if: matrix.kind == 'lint'
+        run: rustup component add rustfmt
+
+      - name: Install ruby
+        if: matrix.kind == 'test'
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install capstone (mac)
+        if: startsWith(matrix.os, 'macOS')
+        run: |
+          brew install capstone
+          export DYLD_LIBRARY_PATH=/usr/local/opt/capstone/lib/:$DYLD_LIBRARY_PATH
+
+      - name: Install capstone (linux)
+        if: startsWith(matrix.os, 'ubuntu') && matrix.kind != 'lint'
+        run: sudo apt-get install libcapstone-dev
+
+      - name: Cargo Fmt
+        if: matrix.kind == 'lint'
+        run: cargo fmt -- --check
+
+      - name: Test
+        if: matrix.kind == 'test'
+        run: tools/test
+
+      - name: Test Release
+        if: matrix.kind == 'test'
+        run: tools/test-release

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -37,16 +37,6 @@ jobs:
         with:
           ruby-version: 2.6.x
 
-      - name: Install capstone (mac)
-        if: startsWith(matrix.os, 'macOS')
-        run: |
-          brew install capstone
-          export DYLD_LIBRARY_PATH=/usr/local/opt/capstone/lib/:$DYLD_LIBRARY_PATH
-
-      - name: Install capstone (linux)
-        if: startsWith(matrix.os, 'ubuntu') && matrix.kind != 'lint'
-        run: sudo apt-get install libcapstone-dev
-
       - name: Cargo Fmt
         if: matrix.kind == 'lint'
         run: cargo fmt -- --check

--- a/README.md
+++ b/README.md
@@ -11,16 +11,13 @@ You need to install these dependencies:
 
 ```
 # on Fedora
-$ sudo dnf install capstone-devel ruby
+$ sudo dnf install ruby
 
 # on Ubuntu/Debian
-$ sudo apt install libcapstone-dev ruby
-
-# on MacOS capstone can be installed via homebrew
-$ brew install capstone
+$ sudo apt install ruby
 ```
 
-[Ruby](https://www.ruby-lang.org/) is used for running tests, while [capstone](https://github.com/aquynh/capstone) is used for instruction decoding/disassembling machine code.
+[Ruby](https://www.ruby-lang.org/) is used for running tests
 
 
 ## Compilation & Testing


### PR DESCRIPTION
I figured out that capstone is not needed as an external dependency anymore.
we are using capstone-rs, which is compiling capstone for us https://github.com/capstone-rust/capstone-rs/blob/master/capstone-sys/build.rs

The good news is we can also install with `cargo install dora`.
You only have to publish the project on crates.io https://doc.rust-lang.org/cargo/reference/publishing.html