### PR TITLE
cannon: support for jump

### DIFF
--- a/dora/src/baseline/asm.rs
+++ b/dora/src/baseline/asm.rs
@@ -108,6 +108,10 @@ where
         self.masm.create_label()
     }
 
+    pub fn bind_label_to(&mut self, label: Label, pos: usize) {
+        self.masm.bind_label_to(label, pos);
+    }
+
     pub fn jump(&mut self, label: Label) {
         self.masm.jump(label);
     }

--- a/dora/src/baseline/cannon/codegen.rs
+++ b/dora/src/baseline/cannon/codegen.rs
@@ -657,6 +657,8 @@ where
 
         self.asm
             .load_mem(bytecode_type.mode(), reg, Mem::Local(offset));
+
+        self.emit_epilog();
     }
 
     fn resolve_forward_jumps(&mut self) {
@@ -827,7 +829,7 @@ impl<'a, 'ast> CodeGen<'ast> for CannonCodeGen<'a, 'ast> {
                 | Bytecode::RetLong(src)
                 | Bytecode::RetFloat(src)
                 | Bytecode::RetDouble(src) => self.emit_return_generic(&bytecode, *src),
-                Bytecode::RetVoid => {}
+                Bytecode::RetVoid => self.emit_epilog(),
                 _ => panic!("bytecode {:?} not implemented", btcode),
             }
 
@@ -835,8 +837,6 @@ impl<'a, 'ast> CodeGen<'ast> for CannonCodeGen<'a, 'ast> {
         }
 
         self.resolve_forward_jumps();
-
-        self.emit_epilog();
 
         let jit_fct = self.asm.jit(
             bytecode.stacksize(),

--- a/dora/src/baseline/codegen.rs
+++ b/dora/src/baseline/codegen.rs
@@ -67,27 +67,21 @@ pub fn generate_fct<'ast>(
     let ast = fct.ast;
 
     let jit_fct = match vm.args.bc() {
-        BaselineName::Cannon => CannonCodeGen {
+        BaselineName::Cannon => CannonCodeGen::new(
             vm,
-            fct: &fct,
+            &fct,
             ast,
-            asm: BaselineAssembler::new(vm),
+            BaselineAssembler::new(vm),
             src,
-
-            lbl_break: None,
-            lbl_continue: None,
-
-            active_finallys: Vec::new(),
-            active_upper: None,
-            active_loop: None,
-            lbl_return: None,
-
+            None,
+            None,
+            Vec::new(),
+            None,
+            None,
+            None,
             cls_type_params,
             fct_type_params,
-
-            bytecode_to_address: HashMap::new(),
-            forward_jumps: Vec::new(),
-        }
+        )
         .generate(),
         BaselineName::AstCompiler => {
             let mut jit_info = JitInfo::new();

--- a/dora/src/baseline/codegen.rs
+++ b/dora/src/baseline/codegen.rs
@@ -84,6 +84,9 @@ pub fn generate_fct<'ast>(
 
             cls_type_params,
             fct_type_params,
+
+            bytecode_to_address: HashMap::new(),
+            forward_jumps: Vec::new(),
         }
         .generate(),
         BaselineName::AstCompiler => {

--- a/dora/src/bytecode/astgen.rs
+++ b/dora/src/bytecode/astgen.rs
@@ -186,6 +186,11 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
     }
 
     fn emit_ret_value(&mut self, result_reg: Register) {
+        if BuiltinType::Unit == self.fct.return_type {
+            self.gen.emit_ret_void();
+            return;
+        }
+
         let return_type: BytecodeType = self.specialize_type(self.fct.return_type).into();
 
         match return_type {

--- a/dora/src/bytecode/generate.rs
+++ b/dora/src/bytecode/generate.rs
@@ -40,7 +40,7 @@ impl fmt::Display for Register {
 #[derive(Copy, Clone, PartialEq, Debug, Eq, Hash)]
 pub struct Label(pub usize);
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BytecodeIdx(pub usize);
 
 impl BytecodeIdx {

--- a/dora/src/masm.rs
+++ b/dora/src/masm.rs
@@ -195,10 +195,15 @@ impl MacroAssembler {
     }
 
     pub fn bind_label(&mut self, lbl: Label) {
+        self.bind_label_to(lbl, self.pos());
+    }
+
+    pub fn bind_label_to(&mut self, lbl: Label, pos: usize) {
         let lbl_idx = lbl.index();
 
         assert!(self.labels[lbl_idx].is_none());
-        self.labels[lbl_idx] = Some(self.pos());
+        assert!(pos <= self.pos());
+        self.labels[lbl_idx] = Some(pos);
     }
 
     pub fn emit_bailout(&mut self, lbl: Label, trap: Trap, pos: Position) {


### PR DESCRIPTION
This PR adds support for the bytecodes for Jump, JumpIfTrue & JumpIfFalse. To resolve forward jumps, I added a Map from bytecode index to address, which is then used to create a label at a specific position. 

Additionally I fixed two small errors:
- a if expession, which returns a Unit, crashed the bytecode generator
- a return inside the code did not exit the function
