### PR TITLE
cannon: copy function arguments to local stack

### DIFF
--- a/tests/cannon/abi1.dora
+++ b/tests/cannon/abi1.dora
@@ -1,0 +1,31 @@
+//= ignore
+fun main() {
+    assert(testInt(3) == 3);
+    assert(testInt(122) == 122);
+
+    assert(testFloat(3F) == 3F);
+    assert(testFloat(122F) == 122F);
+
+    let foo = Foo();
+    assert(testPtr(foo) === foo);
+
+    assert(foo.testSelf() === foo);
+}
+
+@cannon fun testInt(x: Int) -> Int {
+    return x;
+}
+
+@cannon fun testFloat(x: Float) -> Float {
+    return x;
+}
+
+@cannon fun testPtr(x: Foo) -> Foo {
+    return x;
+}
+
+class Foo() {
+    @cannon fun testSelf() -> Foo {
+        return self;
+    }
+}

--- a/tests/cannon/abi2.dora
+++ b/tests/cannon/abi2.dora
@@ -1,0 +1,17 @@
+//= ignore
+fun main() {
+    assert(add(1, 2, 1, 2, 1, 2, 1, 2, 1) == 5);
+
+    let float_result = add_float(1F, 2F, 1F, 2F, 1F, 2F, 1F, 2F, 1F);
+    let epsilon = 0.1F;
+    assert(float_result >= (5F-epsilon) && float_result <= (5F+epsilon));
+}
+
+@cannon fun add(x: Int, y: Int, z: Int, a: Int, b: Int, c: Int, i: Int, j: Int, k: Int) -> Int {
+    return x+y-z+a-b+c-i+j-k;
+}
+
+@cannon fun add_float(x: Float, y: Float, z: Float, a: Float, b: Float, c: Float, i: Float, j: Float, k: Float) -> Float {
+    return x+ y- z+ a- b+ c- i+ j- k;
+    // return 1F+2F-1F+2F-1F+2F-1F+2F-1F;
+}


### PR DESCRIPTION
Because of PR #105 we can now call functions, which are run with cannon. As a consequence cannon has to handle function arguments. 

As every argument gets its own Register assigned when the bytecode is generated, I copy stack arguments to their respective local stack.

Additionally, I added some tests. Currently they are ignored, as some functionality is missing.