### PR TITLE
cannon: fix load fields

### DIFF
--- a/dora/src/baseline/cannon/codegen.rs
+++ b/dora/src/baseline/cannon/codegen.rs
@@ -1,5 +1,6 @@
 use crate::baseline::asm::BaselineAssembler;
 use crate::baseline::codegen::fct_pattern_match;
+use crate::baseline::codegen::ExprStore;
 use crate::bytecode::generate::BytecodeIdx;
 use crate::class::ClassDefId;
 use crate::cpu::{Mem, FREG_PARAMS, FREG_RESULT, FREG_TMP1, REG_PARAMS, REG_RESULT, REG_TMP1};
@@ -552,10 +553,7 @@ where
         let bytecode_type = bytecode.register(src);
         let offset = bytecode.offset(src);
 
-        let reg = match bytecode_type {
-            BytecodeType::Float | BytecodeType::Double => FREG_RESULT.into(),
-            _ => REG_RESULT.into(),
-        };
+        let reg = result_reg(bytecode_type);
 
         self.asm
             .load_mem(bytecode_type.mode(), reg, Mem::Local(offset));
@@ -594,10 +592,7 @@ where
         let bytecode_type = bytecode.register(dest);
         let offset = bytecode.offset(dest);
 
-        let reg = match bytecode_type {
-            BytecodeType::Float | BytecodeType::Double => FREG_RESULT.into(),
-            _ => REG_RESULT.into(),
-        };
+        let reg = result_reg(bytecode_type);
 
         self.asm
             .load_field(field.ty.mode(), reg, REG_RESULT, field.offset, -1);
@@ -805,10 +800,7 @@ where
         let bytecode_type = bytecode.register(src);
         let offset = bytecode.offset(src);
 
-        let reg = match bytecode_type {
-            BytecodeType::Float | BytecodeType::Double => FREG_RESULT.into(),
-            _ => REG_RESULT.into(),
-        };
+        let reg = result_reg(bytecode_type);
 
         self.asm
             .load_mem(bytecode_type.mode(), reg, Mem::Local(offset));
@@ -1019,5 +1011,13 @@ fn should_emit_bytecode(vm: &VM, fct: &Fct) -> bool {
         fct_pattern_match(vm, fct, dbg_names)
     } else {
         false
+    }
+}
+
+fn result_reg(bytecode_type: BytecodeType) -> ExprStore {
+    if bytecode_type.mode().is_float() {
+        FREG_RESULT.into()
+    } else {
+        REG_RESULT.into()
     }
 }

--- a/dora/src/baseline/cannon/codegen.rs
+++ b/dora/src/baseline/cannon/codegen.rs
@@ -591,19 +591,19 @@ where
         self.asm
             .load_mem(bytecode_type.mode(), REG_RESULT.into(), Mem::Local(offset));
 
-        self.asm.load_field(
-            field.ty.mode(),
-            REG_RESULT.into(),
-            REG_RESULT,
-            field.offset,
-            -1,
-        );
-
         let bytecode_type = bytecode.register(dest);
         let offset = bytecode.offset(dest);
 
+        let reg = match bytecode_type {
+            BytecodeType::Float | BytecodeType::Double => FREG_RESULT.into(),
+            _ => REG_RESULT.into(),
+        };
+
         self.asm
-            .store_mem(bytecode_type.mode(), Mem::Local(offset), REG_RESULT.into());
+            .load_field(field.ty.mode(), reg, REG_RESULT, field.offset, -1);
+
+        self.asm
+            .store_mem(bytecode_type.mode(), Mem::Local(offset), reg);
     }
 
     fn emit_load_global_field(

--- a/dora/src/baseline/cannon/codegen.rs
+++ b/dora/src/baseline/cannon/codegen.rs
@@ -993,7 +993,8 @@ impl<'a, 'ast> CodeGen<'ast> for CannonCodeGen<'a, 'ast> {
                 | Bytecode::RetInt(src)
                 | Bytecode::RetLong(src)
                 | Bytecode::RetFloat(src)
-                | Bytecode::RetDouble(src) => self.emit_return_generic(&bytecode, *src),
+                | Bytecode::RetDouble(src)
+                | Bytecode::RetPtr(src) => self.emit_return_generic(&bytecode, *src),
                 Bytecode::RetVoid => self.emit_epilog(),
                 _ => panic!("bytecode {:?} not implemented", btcode),
             }

--- a/tests/cannon/loadfield1.dora
+++ b/tests/cannon/loadfield1.dora
@@ -1,0 +1,48 @@
+fun main() {
+    let x = 0;
+    assert(testBool(FooBool(true)) == true);
+    assert(testByte(FooByte(1Y)) == 1Y);
+    assert(testChar(FooChar('1')) == '1');
+    assert(testInt(FooInt(23)) == 23);
+    assert(testLong(FooLong(1L)) == 1L);
+    assert(testFloat(FooFloat(1F)) == 1F);
+    assert(testDouble(FooDouble(1D)) == 1D);
+
+    let ptr = FooInt(1);
+    assert(testPtr(ptr) === ptr);
+    assert(testPtr(ptr).y == 1)
+}
+
+@cannon fun testBool(x: FooBool) -> Bool {
+    return x.y;
+}
+@cannon fun testByte(x: FooByte) -> Byte {
+    return x.y;
+}
+@cannon fun testChar(x: FooChar) -> Char {
+    return x.y;
+}
+@cannon fun testInt(x: FooInt) -> Int {
+    return x.y;
+}
+@cannon fun testLong(x: FooLong) -> Long {
+    return x.y;
+}
+@cannon fun testFloat(x: FooFloat) -> Float {
+    return x.y;
+}
+@cannon fun testDouble(x: FooDouble) -> Double {
+    return x.y;
+}
+@cannon fun testPtr(x: FooInt) -> FooInt {
+    return x;
+}
+
+class FooBool(let y: Bool)
+class FooByte(let y: Byte)
+class FooChar(let y: Char)
+class FooInt(let y: Int)
+class FooLong(let y: Long)
+class FooFloat(let y: Float)
+class FooDouble(let y: Double)
+class FooPtr(let y: FooInt)


### PR DESCRIPTION
The implementation field loads in cannon didn't consider, that the temporary register should correspond to the machine mode. 

Moreover, I added a test, which immediately showed, that I missed the RetPtr bytecode, when I implemented the various Ret*.