### PR TITLE
cannon: float operations

### DIFF
--- a/dora/src/bytecode/encoding.rs
+++ b/dora/src/bytecode/encoding.rs
@@ -15,10 +15,13 @@ pub enum BytecodeInst {
     AddDouble,
 
     SubInt,
+    SubFloat,
     NegInt,
     NegLong,
     MulInt,
+    MulFloat,
     DivInt,
+    DivFloat,
     ModInt,
     AndInt,
     OrInt,
@@ -81,6 +84,13 @@ pub enum BytecodeInst {
     TestGeInt,
     TestLtInt,
     TestLeInt,
+
+    TestEqFloat,
+    TestNeFloat,
+    TestGtFloat,
+    TestGeFloat,
+    TestLtFloat,
+    TestLeFloat,
 
     JumpIfFalse,
     JumpIfTrue,
@@ -159,13 +169,22 @@ impl BytecodeStreamGenerator {
             Bytecode::SubInt(dest, lhs, rhs) => {
                 self.emit_reg3(BytecodeInst::SubInt, dest, lhs, rhs)
             }
+            Bytecode::SubFloat(dest, lhs, rhs) => {
+                self.emit_reg3(BytecodeInst::SubFloat, dest, lhs, rhs)
+            }
             Bytecode::NegInt(dest, src) => self.emit_reg2(BytecodeInst::NegInt, dest, src),
             Bytecode::NegLong(dest, src) => self.emit_reg2(BytecodeInst::NegLong, dest, src),
             Bytecode::MulInt(dest, lhs, rhs) => {
                 self.emit_reg3(BytecodeInst::MulInt, dest, lhs, rhs)
             }
+            Bytecode::MulFloat(dest, lhs, rhs) => {
+                self.emit_reg3(BytecodeInst::MulFloat, dest, lhs, rhs)
+            }
             Bytecode::DivInt(dest, lhs, rhs) => {
                 self.emit_reg3(BytecodeInst::DivInt, dest, lhs, rhs)
+            }
+            Bytecode::DivFloat(dest, lhs, rhs) => {
+                self.emit_reg3(BytecodeInst::DivFloat, dest, lhs, rhs)
             }
             Bytecode::ModInt(dest, lhs, rhs) => {
                 self.emit_reg3(BytecodeInst::ModInt, dest, lhs, rhs)
@@ -288,6 +307,24 @@ impl BytecodeStreamGenerator {
             }
             Bytecode::TestLeInt(dest, lhs, rhs) => {
                 self.emit_reg3(BytecodeInst::TestLeInt, dest, lhs, rhs)
+            }
+            Bytecode::TestEqFloat(dest, lhs, rhs) => {
+                self.emit_reg3(BytecodeInst::TestEqFloat, dest, lhs, rhs)
+            }
+            Bytecode::TestNeFloat(dest, lhs, rhs) => {
+                self.emit_reg3(BytecodeInst::TestNeFloat, dest, lhs, rhs)
+            }
+            Bytecode::TestGtFloat(dest, lhs, rhs) => {
+                self.emit_reg3(BytecodeInst::TestGtFloat, dest, lhs, rhs)
+            }
+            Bytecode::TestGeFloat(dest, lhs, rhs) => {
+                self.emit_reg3(BytecodeInst::TestGeFloat, dest, lhs, rhs)
+            }
+            Bytecode::TestLtFloat(dest, lhs, rhs) => {
+                self.emit_reg3(BytecodeInst::TestLtFloat, dest, lhs, rhs)
+            }
+            Bytecode::TestLeFloat(dest, lhs, rhs) => {
+                self.emit_reg3(BytecodeInst::TestLeFloat, dest, lhs, rhs)
             }
 
             Bytecode::JumpIfFalse(cond, _) => {

--- a/dora/src/bytecode/generate.rs
+++ b/dora/src/bytecode/generate.rs
@@ -222,6 +222,10 @@ impl BytecodeGenerator {
         self.code.push(Bytecode::DivInt(dest, lhs, rhs));
     }
 
+    pub fn emit_div_float(&mut self, dest: Register, lhs: Register, rhs: Register) {
+        self.code.push(Bytecode::DivFloat(dest, lhs, rhs));
+    }
+
     pub fn emit_load_field_bool(
         &mut self,
         dest: Register,
@@ -422,6 +426,10 @@ impl BytecodeGenerator {
         self.code.push(Bytecode::MulInt(dest, lhs, rhs));
     }
 
+    pub fn emit_mul_float(&mut self, dest: Register, lhs: Register, rhs: Register) {
+        self.code.push(Bytecode::MulFloat(dest, lhs, rhs));
+    }
+
     pub fn emit_neg_int(&mut self, dest: Register, src: Register) {
         self.code.push(Bytecode::NegInt(dest, src));
     }
@@ -444,6 +452,10 @@ impl BytecodeGenerator {
 
     pub fn emit_sub_int(&mut self, dest: Register, lhs: Register, rhs: Register) {
         self.code.push(Bytecode::SubInt(dest, lhs, rhs));
+    }
+
+    pub fn emit_sub_float(&mut self, dest: Register, lhs: Register, rhs: Register) {
+        self.code.push(Bytecode::SubFloat(dest, lhs, rhs));
     }
 
     pub fn emit_mov_bool(&mut self, dest: Register, src: Register) {
@@ -518,12 +530,20 @@ impl BytecodeGenerator {
         self.code.push(Bytecode::TestEqInt(dest, lhs, rhs));
     }
 
+    pub fn emit_test_eq_float(&mut self, dest: Register, lhs: Register, rhs: Register) {
+        self.code.push(Bytecode::TestEqFloat(dest, lhs, rhs));
+    }
+
     pub fn emit_test_eq_ptr(&mut self, dest: Register, lhs: Register, rhs: Register) {
         self.code.push(Bytecode::TestEqPtr(dest, lhs, rhs));
     }
 
     pub fn emit_test_ne_int(&mut self, dest: Register, lhs: Register, rhs: Register) {
         self.code.push(Bytecode::TestNeInt(dest, lhs, rhs));
+    }
+
+    pub fn emit_test_ne_float(&mut self, dest: Register, lhs: Register, rhs: Register) {
+        self.code.push(Bytecode::TestNeFloat(dest, lhs, rhs));
     }
 
     pub fn emit_test_ne_ptr(&mut self, dest: Register, lhs: Register, rhs: Register) {
@@ -534,16 +554,32 @@ impl BytecodeGenerator {
         self.code.push(Bytecode::TestGtInt(dest, lhs, rhs));
     }
 
+    pub fn emit_test_gt_float(&mut self, dest: Register, lhs: Register, rhs: Register) {
+        self.code.push(Bytecode::TestGtFloat(dest, lhs, rhs));
+    }
+
     pub fn emit_test_ge_int(&mut self, dest: Register, lhs: Register, rhs: Register) {
         self.code.push(Bytecode::TestGeInt(dest, lhs, rhs));
+    }
+
+    pub fn emit_test_ge_float(&mut self, dest: Register, lhs: Register, rhs: Register) {
+        self.code.push(Bytecode::TestGeFloat(dest, lhs, rhs));
     }
 
     pub fn emit_test_lt_int(&mut self, dest: Register, lhs: Register, rhs: Register) {
         self.code.push(Bytecode::TestLtInt(dest, lhs, rhs));
     }
 
+    pub fn emit_test_lt_float(&mut self, dest: Register, lhs: Register, rhs: Register) {
+        self.code.push(Bytecode::TestLtFloat(dest, lhs, rhs));
+    }
+
     pub fn emit_test_le_int(&mut self, dest: Register, lhs: Register, rhs: Register) {
         self.code.push(Bytecode::TestLeInt(dest, lhs, rhs));
+    }
+
+    pub fn emit_test_le_float(&mut self, dest: Register, lhs: Register, rhs: Register) {
+        self.code.push(Bytecode::TestLeFloat(dest, lhs, rhs));
     }
 
     pub fn emit_load_global_bool(&mut self, dest: Register, gid: GlobalId) {
@@ -989,6 +1025,9 @@ impl BytecodeFunction {
                 Bytecode::DivInt(dest, lhs, rhs) => {
                     println!("{}: {} <-int {} / {}", btidx, dest, lhs, rhs)
                 }
+                Bytecode::DivFloat(dest, lhs, rhs) => {
+                    println!("{}: {} <-float {} / {}", btidx, dest, lhs, rhs)
+                }
                 Bytecode::ConstNil(dest) => println!("{}: {} <- nil", btidx, dest),
                 Bytecode::ConstTrue(dest) => println!("{}: {} <- true", btidx, dest),
                 Bytecode::ConstFalse(dest) => println!("{}: {} <- false", btidx, dest),
@@ -1022,6 +1061,9 @@ impl BytecodeFunction {
                 Bytecode::MulInt(dest, lhs, rhs) => {
                     println!("{}: {} <-int {} * {}", btidx, dest, lhs, rhs)
                 }
+                Bytecode::MulFloat(dest, lhs, rhs) => {
+                    println!("{}: {} <-float {} * {}", btidx, dest, lhs, rhs)
+                }
                 Bytecode::NegInt(dest, src) => println!("{}: {} <-int -{}", btidx, dest, src),
                 Bytecode::NegLong(dest, src) => println!("{}: {} <-long -{}", btidx, dest, src),
                 Bytecode::ShlInt(dest, lhs, rhs) => {
@@ -1036,7 +1078,9 @@ impl BytecodeFunction {
                 Bytecode::SubInt(dest, lhs, rhs) => {
                     println!("{}: {} <-int {} - {}", btidx, dest, lhs, rhs)
                 }
-
+                Bytecode::SubFloat(dest, lhs, rhs) => {
+                    println!("{}: {} <-float {} - {}", btidx, dest, lhs, rhs)
+                }
                 Bytecode::LoadFieldBool(dest, obj, cls, field) => {
                     println!("{}: {} <-bool {} {:?}.{:?}", btidx, dest, obj, cls, field);
                 }
@@ -1073,11 +1117,17 @@ impl BytecodeFunction {
                 Bytecode::TestEqInt(dest, lhs, rhs) => {
                     println!("{}: {} <- {} =.int {}", btidx, dest, lhs, rhs)
                 }
+                Bytecode::TestEqFloat(dest, lhs, rhs) => {
+                    println!("{}: {} <- {} =.float {}", btidx, dest, lhs, rhs)
+                }
                 Bytecode::TestEqPtr(dest, lhs, rhs) => {
                     println!("{}: {} <- {} === {}", btidx, dest, lhs, rhs)
                 }
                 Bytecode::TestNeInt(dest, lhs, rhs) => {
                     println!("{}: {} <- {} !=.int {}", btidx, dest, lhs, rhs)
+                }
+                Bytecode::TestNeFloat(dest, lhs, rhs) => {
+                    println!("{}: {} <- {} !=.float {}", btidx, dest, lhs, rhs)
                 }
                 Bytecode::TestNePtr(dest, lhs, rhs) => {
                     println!("{}: {} <- {} !== {}", btidx, dest, lhs, rhs)
@@ -1085,14 +1135,26 @@ impl BytecodeFunction {
                 Bytecode::TestGtInt(dest, lhs, rhs) => {
                     println!("{}: {} <- {} >.int {}", btidx, dest, lhs, rhs)
                 }
+                Bytecode::TestGtFloat(dest, lhs, rhs) => {
+                    println!("{}: {} <- {} >.float {}", btidx, dest, lhs, rhs)
+                }
                 Bytecode::TestGeInt(dest, lhs, rhs) => {
-                    println!("{}: {} <- {} <=.int {}", btidx, dest, lhs, rhs)
+                    println!("{}: {} <- {} >=.int {}", btidx, dest, lhs, rhs)
+                }
+                Bytecode::TestGeFloat(dest, lhs, rhs) => {
+                    println!("{}: {} <- {} >=.float {}", btidx, dest, lhs, rhs)
                 }
                 Bytecode::TestLtInt(dest, lhs, rhs) => {
-                    println!("{}: {} <- {} >.int {}", btidx, dest, lhs, rhs)
+                    println!("{}: {} <- {} <.int {}", btidx, dest, lhs, rhs)
+                }
+                Bytecode::TestLtFloat(dest, lhs, rhs) => {
+                    println!("{}: {} <- {} <.float {}", btidx, dest, lhs, rhs)
                 }
                 Bytecode::TestLeInt(dest, lhs, rhs) => {
-                    println!("{}: {} <- {} >=.int {}", btidx, dest, lhs, rhs)
+                    println!("{}: {} <- {} <=.int {}", btidx, dest, lhs, rhs)
+                }
+                Bytecode::TestLeFloat(dest, lhs, rhs) => {
+                    println!("{}: {} <- {} <=.float {}", btidx, dest, lhs, rhs)
                 }
                 Bytecode::LoadGlobalBool(dest, gid) => {
                     println!("{}: {} <-bool global {:?}", btidx, dest, gid)

--- a/dora/src/bytecode/opcode.rs
+++ b/dora/src/bytecode/opcode.rs
@@ -11,10 +11,17 @@ pub enum Bytecode {
     AddDouble(Register, Register, Register),
 
     SubInt(Register, Register, Register),
+    SubFloat(Register, Register, Register),
+
     NegInt(Register, Register),
     NegLong(Register, Register),
+
     MulInt(Register, Register, Register),
+    MulFloat(Register, Register, Register),
+
     DivInt(Register, Register, Register),
+    DivFloat(Register, Register, Register),
+
     ModInt(Register, Register, Register),
     AndInt(Register, Register, Register),
     OrInt(Register, Register, Register),
@@ -77,6 +84,13 @@ pub enum Bytecode {
     TestGeInt(Register, Register, Register),
     TestLtInt(Register, Register, Register),
     TestLeInt(Register, Register, Register),
+
+    TestEqFloat(Register, Register, Register),
+    TestNeFloat(Register, Register, Register),
+    TestGtFloat(Register, Register, Register),
+    TestGeFloat(Register, Register, Register),
+    TestLtFloat(Register, Register, Register),
+    TestLeFloat(Register, Register, Register),
 
     JumpIfFalse(Register, BytecodeIdx),
     JumpIfTrue(Register, BytecodeIdx),

--- a/tests/cannon/float1.dora
+++ b/tests/cannon/float1.dora
@@ -1,0 +1,76 @@
+fun main() {
+    assert(test_with_epsilon(add(20F, 5F, 2F), 27F));
+    assert(test_with_epsilon(sub(20F, 5F, 2F), 13F));
+    assert(test_with_epsilon(mul(20F, 5F, 2F), 200F));
+    assert(test_with_epsilon(div(20F, 5F, 2F), 2F));
+
+    assert(!eq(20F, 5F));
+    assert(eq(5F, 5F));
+    assert(!eq(5F, 20F));
+
+    assert(ne(20F, 5F));
+    assert(!ne(5F, 5F));
+    assert(ne(5F, 20F));
+
+
+    assert(!lt(20F, 5F));
+    assert(!lt(5F, 5F));
+    assert(lt(5F, 20F));
+
+    assert(!le(20F, 5F));
+    assert(le(5F, 5F));
+    assert(le(5F, 20F));
+
+    assert(ge(20F, 5F));
+    assert(ge(5F, 5F));
+    assert(!ge(5F, 20F));
+
+    assert(gt(20F, 5F));
+    assert(!gt(5F, 5F));
+    assert(!gt(5F, 20F));
+}
+
+fun test_with_epsilon(expected: Float, value: Float) -> Bool {
+    let epsilon = 0.01F;
+    return value >= (expected-epsilon) && value <= (expected+epsilon);
+}
+
+@cannon fun add(x: Float, y: Float, z: Float) -> Float {
+    return x+y+z;
+}
+
+@cannon fun sub(x: Float, y: Float, z: Float) -> Float {
+    return x-y-z;
+}
+
+@cannon fun mul(x: Float, y: Float, z: Float) -> Float {
+    return x*y*z;
+}
+
+@cannon fun div(x: Float, y: Float, z: Float) -> Float {
+    return x/y/z;
+}
+
+@cannon fun eq(x: Float, y: Float) -> Bool {
+    return x == y;
+}
+
+@cannon fun ne(x: Float, y: Float) -> Bool {
+    return x != y;
+}
+
+@cannon fun lt(x: Float, y: Float) -> Bool {
+    return x < y;
+}
+
+@cannon fun le(x: Float, y: Float) -> Bool {
+    return x <= y;
+}
+
+@cannon fun ge(x: Float, y: Float) -> Bool {
+    return x >= y;
+}
+
+@cannon fun gt(x: Float, y: Float) -> Bool {
+    return x > y;
+}


### PR DESCRIPTION
Based on PR #111 

Adds arithmetic (-,+,/,*) and compare operations (==,!=,<,<=,>=,>) for Float to the bytecode generator and cannon. Includes a simple test for these operations.

Some small fixes in the dump() function of the bytecode generator are also included. The strings didn't always represent the operation correctly. ;)