### PR TITLE
cannon: support creation of objects

### DIFF
--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -489,6 +489,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
     }
 
     fn visit_expr_delegation(&mut self, expr: &ExprDelegationType, dest: DataDest) -> Register {
+        assert!(dest.is_effect());
         let call_type = self.src.map_calls.get(expr.id).unwrap().clone();
         let fct_id = call_type.fct_id().unwrap();
 
@@ -496,11 +497,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         let callee = self.vm.fcts.idx(callee_id);
         let callee = callee.read();
 
-        let return_type = if dest.is_effect() {
-            BuiltinType::Unit
-        } else {
-            self.specialize_type_for_call(&call_type, callee.return_type)
-        };
+        assert!(callee.return_type.is_unit());
         let arg_types = callee
             .params_with_self()
             .iter()
@@ -522,7 +519,6 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             self.visit_expr(arg, DataDest::Reg(arg_reg));
         }
 
-        assert!(return_type.is_unit());
         match *call_type {
             CallType::Ctor(_, _) => {
                 self.gen

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -144,6 +144,102 @@ fn gen_load_field_ptr() {
 }
 
 #[test]
+fn gen_store_field_byte() {
+    gen(
+        "class Foo(var bar: Byte) fun f(a: Foo, b: Byte) { a.bar = b; }",
+        |vm, code| {
+            let (cls, field) = vm.field_by_name("Foo", "bar");
+            let expected = vec![StoreFieldByte(r(1), r(0), cls, field), RetVoid];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_store_field_bool() {
+    gen(
+        "class Foo(var bar: Bool) fun f(a: Foo, b: Bool) { a.bar = b; }",
+        |vm, code| {
+            let (cls, field) = vm.field_by_name("Foo", "bar");
+            let expected = vec![StoreFieldBool(r(1), r(0), cls, field), RetVoid];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_store_field_char() {
+    gen(
+        "class Foo(var bar: Char) fun f(a: Foo, b: Char) { a.bar = b; }",
+        |vm, code| {
+            let (cls, field) = vm.field_by_name("Foo", "bar");
+            let expected = vec![StoreFieldChar(r(1), r(0), cls, field), RetVoid];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_store_field_int() {
+    gen(
+        "class Foo(var bar: Int) fun f(a: Foo, b: Int) { a.bar = b; }",
+        |vm, code| {
+            let (cls, field) = vm.field_by_name("Foo", "bar");
+            let expected = vec![StoreFieldInt(r(1), r(0), cls, field), RetVoid];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_store_field_long() {
+    gen(
+        "class Foo(var bar: Long) fun f(a: Foo, b: Long) { a.bar = b; }",
+        |vm, code| {
+            let (cls, field) = vm.field_by_name("Foo", "bar");
+            let expected = vec![StoreFieldLong(r(1), r(0), cls, field), RetVoid];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_store_field_float() {
+    gen(
+        "class Foo(var bar: Float) fun f(a: Foo, b: Float) { a.bar = b; }",
+        |vm, code| {
+            let (cls, field) = vm.field_by_name("Foo", "bar");
+            let expected = vec![StoreFieldFloat(r(1), r(0), cls, field), RetVoid];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_store_field_double() {
+    gen(
+        "class Foo(var bar: Double) fun f(a: Foo, b: Double) { a.bar = b; }",
+        |vm, code| {
+            let (cls, field) = vm.field_by_name("Foo", "bar");
+            let expected = vec![StoreFieldDouble(r(1), r(0), cls, field), RetVoid];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_store_field_ptr() {
+    gen(
+        "class Foo(var bar: Object) fun f(a: Foo, b: Object) { a.bar = b; }",
+        |vm, code| {
+            let (cls, field) = vm.field_by_name("Foo", "bar");
+            let expected = vec![StoreFieldPtr(r(1), r(0), cls, field), RetVoid];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
 fn gen_add_int() {
     let result = code("fun f() -> Int { return 1 + 2; }");
     let expected = vec![

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -194,6 +194,86 @@ impl BytecodeWriter {
         self.emit_load_field(BytecodeOpcode::LoadFieldPtr, dest, obj, cls, field);
     }
 
+    pub fn emit_store_field_bool(
+        &mut self,
+        src: Register,
+        obj: Register,
+        cls: ClassDefId,
+        field: FieldId,
+    ) {
+        self.emit_store_field(BytecodeOpcode::StoreFieldBool, src, obj, cls, field);
+    }
+
+    pub fn emit_store_field_byte(
+        &mut self,
+        src: Register,
+        obj: Register,
+        cls: ClassDefId,
+        field: FieldId,
+    ) {
+        self.emit_store_field(BytecodeOpcode::StoreFieldByte, src, obj, cls, field);
+    }
+
+    pub fn emit_store_field_char(
+        &mut self,
+        src: Register,
+        obj: Register,
+        cls: ClassDefId,
+        field: FieldId,
+    ) {
+        self.emit_store_field(BytecodeOpcode::StoreFieldChar, src, obj, cls, field);
+    }
+
+    pub fn emit_store_field_int(
+        &mut self,
+        src: Register,
+        obj: Register,
+        cls: ClassDefId,
+        field: FieldId,
+    ) {
+        self.emit_store_field(BytecodeOpcode::StoreFieldInt, src, obj, cls, field);
+    }
+
+    pub fn emit_store_field_long(
+        &mut self,
+        src: Register,
+        obj: Register,
+        cls: ClassDefId,
+        field: FieldId,
+    ) {
+        self.emit_store_field(BytecodeOpcode::StoreFieldLong, src, obj, cls, field);
+    }
+
+    pub fn emit_store_field_float(
+        &mut self,
+        src: Register,
+        obj: Register,
+        cls: ClassDefId,
+        field: FieldId,
+    ) {
+        self.emit_store_field(BytecodeOpcode::StoreFieldFloat, src, obj, cls, field);
+    }
+
+    pub fn emit_store_field_double(
+        &mut self,
+        src: Register,
+        obj: Register,
+        cls: ClassDefId,
+        field: FieldId,
+    ) {
+        self.emit_store_field(BytecodeOpcode::StoreFieldDouble, src, obj, cls, field);
+    }
+
+    pub fn emit_store_field_ptr(
+        &mut self,
+        src: Register,
+        obj: Register,
+        cls: ClassDefId,
+        field: FieldId,
+    ) {
+        self.emit_store_field(BytecodeOpcode::StoreFieldPtr, src, obj, cls, field);
+    }
+
     pub fn emit_const_nil(&mut self, dest: Register) {
         self.emit_reg1(BytecodeOpcode::ConstNil, dest);
     }
@@ -871,6 +951,24 @@ impl BytecodeWriter {
     }
 
     fn emit_load_field(
+        &mut self,
+        inst: BytecodeOpcode,
+        r1: Register,
+        r2: Register,
+        cid: ClassDefId,
+        fid: FieldId,
+    ) {
+        let values = [
+            inst as u32,
+            r1.to_usize() as u32,
+            r2.to_usize() as u32,
+            cid.to_usize() as u32,
+            fid.to_usize() as u32,
+        ];
+        self.emit_values(&values);
+    }
+
+    fn emit_store_field(
         &mut self,
         inst: BytecodeOpcode,
         r1: Register,

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -121,7 +121,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_load_field(BytecodeOpcode::LoadFieldBool, dest, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::LoadFieldBool, dest, obj, cls, field);
     }
 
     pub fn emit_load_field_byte(
@@ -131,7 +131,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_load_field(BytecodeOpcode::LoadFieldByte, dest, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::LoadFieldByte, dest, obj, cls, field);
     }
 
     pub fn emit_load_field_char(
@@ -141,7 +141,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_load_field(BytecodeOpcode::LoadFieldChar, dest, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::LoadFieldChar, dest, obj, cls, field);
     }
 
     pub fn emit_load_field_int(
@@ -151,7 +151,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_load_field(BytecodeOpcode::LoadFieldInt, dest, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::LoadFieldInt, dest, obj, cls, field);
     }
 
     pub fn emit_load_field_long(
@@ -161,7 +161,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_load_field(BytecodeOpcode::LoadFieldLong, dest, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::LoadFieldLong, dest, obj, cls, field);
     }
 
     pub fn emit_load_field_float(
@@ -171,7 +171,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_load_field(BytecodeOpcode::LoadFieldFloat, dest, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::LoadFieldFloat, dest, obj, cls, field);
     }
 
     pub fn emit_load_field_double(
@@ -181,7 +181,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_load_field(BytecodeOpcode::LoadFieldDouble, dest, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::LoadFieldDouble, dest, obj, cls, field);
     }
 
     pub fn emit_load_field_ptr(
@@ -191,7 +191,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_load_field(BytecodeOpcode::LoadFieldPtr, dest, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::LoadFieldPtr, dest, obj, cls, field);
     }
 
     pub fn emit_store_field_bool(
@@ -201,7 +201,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_store_field(BytecodeOpcode::StoreFieldBool, src, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::StoreFieldBool, src, obj, cls, field);
     }
 
     pub fn emit_store_field_byte(
@@ -211,7 +211,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_store_field(BytecodeOpcode::StoreFieldByte, src, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::StoreFieldByte, src, obj, cls, field);
     }
 
     pub fn emit_store_field_char(
@@ -221,7 +221,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_store_field(BytecodeOpcode::StoreFieldChar, src, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::StoreFieldChar, src, obj, cls, field);
     }
 
     pub fn emit_store_field_int(
@@ -231,7 +231,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_store_field(BytecodeOpcode::StoreFieldInt, src, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::StoreFieldInt, src, obj, cls, field);
     }
 
     pub fn emit_store_field_long(
@@ -241,7 +241,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_store_field(BytecodeOpcode::StoreFieldLong, src, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::StoreFieldLong, src, obj, cls, field);
     }
 
     pub fn emit_store_field_float(
@@ -251,7 +251,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_store_field(BytecodeOpcode::StoreFieldFloat, src, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::StoreFieldFloat, src, obj, cls, field);
     }
 
     pub fn emit_store_field_double(
@@ -261,7 +261,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_store_field(BytecodeOpcode::StoreFieldDouble, src, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::StoreFieldDouble, src, obj, cls, field);
     }
 
     pub fn emit_store_field_ptr(
@@ -271,7 +271,7 @@ impl BytecodeWriter {
         cls: ClassDefId,
         field: FieldId,
     ) {
-        self.emit_store_field(BytecodeOpcode::StoreFieldPtr, src, obj, cls, field);
+        self.emit_access_field(BytecodeOpcode::StoreFieldPtr, src, obj, cls, field);
     }
 
     pub fn emit_const_nil(&mut self, dest: Register) {
@@ -950,25 +950,7 @@ impl BytecodeWriter {
         self.emit_values(&values);
     }
 
-    fn emit_load_field(
-        &mut self,
-        inst: BytecodeOpcode,
-        r1: Register,
-        r2: Register,
-        cid: ClassDefId,
-        fid: FieldId,
-    ) {
-        let values = [
-            inst as u32,
-            r1.to_usize() as u32,
-            r2.to_usize() as u32,
-            cid.to_usize() as u32,
-            fid.to_usize() as u32,
-        ];
-        self.emit_values(&values);
-    }
-
-    fn emit_store_field(
+    fn emit_access_field(
         &mut self,
         inst: BytecodeOpcode,
         r1: Register,

--- a/dora/src/cannon/codegen.rs
+++ b/dora/src/cannon/codegen.rs
@@ -1070,8 +1070,10 @@ where
     fn emit_invoke_direct_void(&mut self, fct_id: FctId, start_reg: Register, num: u32) {
         assert_eq!(self.bytecode.register_type(start_reg), BytecodeType::Ptr);
 
-        let _fct = self.vm.fcts.idx(fct_id);
-        let _fct = _fct.read();
+        let fct = self.vm.fcts.idx(fct_id);
+        let fct = fct.read();
+
+        assert!(fct.type_params.is_empty());
 
         let Register(start) = start_reg;
 

--- a/dora/src/cannon/codegen.rs
+++ b/dora/src/cannon/codegen.rs
@@ -1001,15 +1001,10 @@ where
 
         let alloc_size = match cls.size {
             InstanceSize::Fixed(size) => AllocationSize::Fixed(size as usize),
-            _ => unimplemented!(
+            _ => unreachable!(
                 "class size type {:?} for new object not supported",
                 cls.size
             ),
-        };
-
-        let array_ref = match cls.size {
-            InstanceSize::ObjArray => true,
-            _ => false,
         };
 
         let gcpoint = GcPoint::from_offsets(self.references.clone());
@@ -1017,7 +1012,7 @@ where
             REG_RESULT.into(),
             alloc_size,
             Position { line: 0, column: 0 }, // Correct position is currently not known.
-            array_ref,
+            false,
             gcpoint,
         );
 
@@ -1051,7 +1046,7 @@ where
             InstanceSize::Fixed(size) => {
                 self.asm.fill_zero(REG_RESULT, size as usize);
             }
-            _ => {}
+            _ => unreachable!(),
         }
 
         self.references.push(offset);

--- a/tests/cannon/ctor1.dora
+++ b/tests/cannon/ctor1.dora
@@ -1,0 +1,12 @@
+//= output "xyz"
+
+@cannon class X(let msg: String) {
+}
+
+@cannon fun cannonMain() -> X {
+    return X("xyz");
+}
+
+fun main() {
+    print(cannonMain().msg);
+}

--- a/tests/cannon/ctor2.dora
+++ b/tests/cannon/ctor2.dora
@@ -1,0 +1,13 @@
+@cannon @open class Y(let a: Int) {}
+@cannon class X(let b: Int, a: Int) : Y(a) {}
+
+@cannon fun cannonMain() -> X {
+    return X(2, 4);
+}
+
+fun main() {
+  let x = cannonMain();
+
+  assert(x.a == 4);
+  assert(x.b == 2);
+}


### PR DESCRIPTION
This PR allows to call the constructor of a class to create a new object. As a consequence StoreField* are now supported.