### PR TITLE
cannon: use correct position for throw/new object/invoke

### DIFF
--- a/dora/src/bytecode/data.rs
+++ b/dora/src/bytecode/data.rs
@@ -278,6 +278,43 @@ pub enum BytecodeOpcode {
     RetPtr,
 }
 
+impl BytecodeOpcode {
+    pub fn need_position(&self) -> bool {
+        match *self {
+            BytecodeOpcode::InvokeDirectVoid
+            | BytecodeOpcode::InvokeDirectBool
+            | BytecodeOpcode::InvokeDirectByte
+            | BytecodeOpcode::InvokeDirectChar
+            | BytecodeOpcode::InvokeDirectInt
+            | BytecodeOpcode::InvokeDirectLong
+            | BytecodeOpcode::InvokeDirectFloat
+            | BytecodeOpcode::InvokeDirectDouble
+            | BytecodeOpcode::InvokeDirectPtr
+            | BytecodeOpcode::InvokeVirtualVoid
+            | BytecodeOpcode::InvokeVirtualBool
+            | BytecodeOpcode::InvokeVirtualByte
+            | BytecodeOpcode::InvokeVirtualChar
+            | BytecodeOpcode::InvokeVirtualInt
+            | BytecodeOpcode::InvokeVirtualLong
+            | BytecodeOpcode::InvokeVirtualFloat
+            | BytecodeOpcode::InvokeVirtualDouble
+            | BytecodeOpcode::InvokeVirtualPtr
+            | BytecodeOpcode::InvokeStaticVoid
+            | BytecodeOpcode::InvokeStaticBool
+            | BytecodeOpcode::InvokeStaticByte
+            | BytecodeOpcode::InvokeStaticChar
+            | BytecodeOpcode::InvokeStaticInt
+            | BytecodeOpcode::InvokeStaticLong
+            | BytecodeOpcode::InvokeStaticFloat
+            | BytecodeOpcode::InvokeStaticDouble
+            | BytecodeOpcode::InvokeStaticPtr
+            | BytecodeOpcode::NewObject
+            | BytecodeOpcode::Throw => true,
+            _ => false,
+        }
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Register(pub usize);
 
@@ -371,10 +408,11 @@ impl BytecodeFunction {
     }
 
     pub fn offset_position(&self, offset: u32) -> Position {
-        let index = self
-            .positions
-            .binary_search_by_key(&offset, |&(o, _)| o)
-            .expect("position not found");
+        let index = self.positions.binary_search_by_key(&offset, |&(o, _)| o);
+        let index = match index {
+            Err(index) => index - 1,
+            Ok(index) => index,
+        };
         self.positions[index].1
     }
 }

--- a/dora/src/bytecode/data.rs
+++ b/dora/src/bytecode/data.rs
@@ -25,6 +25,17 @@ impl PositionTable {
     pub fn get(&self, offset: u32) -> Option<&Position> {
         self.map.get(&offset)
     }
+
+    pub fn to_vec(&self) -> Vec<(u32, Position)> {
+        let mut as_vec = self
+            .map
+            .iter()
+            .clone()
+            .map(|(k, v)| (*k, *v))
+            .collect::<Vec<(u32, Position)>>();
+        as_vec.sort_by(|(a, _), (b, _)| a.cmp(b));
+        as_vec
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -366,6 +377,10 @@ impl BytecodeFunction {
 
     pub fn registers(&self) -> &[BytecodeType] {
         &self.registers
+    }
+
+    pub fn positions(&self) -> &PositionTable {
+        &self.positions
     }
 
     pub fn register_type(&self, register: Register) -> BytecodeType {

--- a/dora/src/bytecode/data.rs
+++ b/dora/src/bytecode/data.rs
@@ -281,7 +281,27 @@ pub enum BytecodeOpcode {
 impl BytecodeOpcode {
     pub fn need_position(&self) -> bool {
         match *self {
-            BytecodeOpcode::InvokeDirectVoid
+            BytecodeOpcode::DivInt
+            | BytecodeOpcode::DivLong
+            | BytecodeOpcode::ModInt
+            | BytecodeOpcode::ModLong
+            | BytecodeOpcode::LoadFieldBool
+            | BytecodeOpcode::LoadFieldByte
+            | BytecodeOpcode::LoadFieldChar
+            | BytecodeOpcode::LoadFieldInt
+            | BytecodeOpcode::LoadFieldLong
+            | BytecodeOpcode::LoadFieldFloat
+            | BytecodeOpcode::LoadFieldDouble
+            | BytecodeOpcode::LoadFieldPtr
+            | BytecodeOpcode::StoreFieldBool
+            | BytecodeOpcode::StoreFieldByte
+            | BytecodeOpcode::StoreFieldChar
+            | BytecodeOpcode::StoreFieldInt
+            | BytecodeOpcode::StoreFieldLong
+            | BytecodeOpcode::StoreFieldFloat
+            | BytecodeOpcode::StoreFieldDouble
+            | BytecodeOpcode::StoreFieldPtr
+            | BytecodeOpcode::InvokeDirectVoid
             | BytecodeOpcode::InvokeDirectBool
             | BytecodeOpcode::InvokeDirectByte
             | BytecodeOpcode::InvokeDirectChar

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -173,7 +173,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
 
     fn visit_stmt_throw(&mut self, stmt: &StmtThrowType) {
         let exception_reg = self.visit_expr(&stmt.expr, DataDest::Alloc);
-        self.gen.emit_throw(exception_reg);
+        self.gen.emit_throw(exception_reg, stmt.pos);
     }
 
     fn visit_stmt_expr(&mut self, stmt: &StmtExprType) {
@@ -353,15 +353,15 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
 
         let start_reg = self.gen.add_register_chain(&arg_types);
         let cls_id = specialize_class_id_params(self.vm, cls_id, &TypeList::Empty);
-        self.gen.emit_new_object(start_reg, cls_id);
+        self.gen.emit_new_object(start_reg, cls_id, expr.pos);
         let error_string_reg = start_reg.offset(1);
         self.gen
             .emit_const_string(error_string_reg, "assert failed".to_string());
 
         self.gen
-            .emit_invoke_direct_void(fct_id, start_reg, num_args);
+            .emit_invoke_direct_void(fct_id, start_reg, num_args, expr.pos);
 
-        self.gen.emit_throw(start_reg);
+        self.gen.emit_throw(start_reg, expr.pos);
 
         self.gen.bind_label(lbl_assert);
     }
@@ -420,7 +420,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
 
         let arg_start_reg = if let CallType::CtorNew(ty, _) = &*call_type {
             let cls_id = specialize_class_ty(self.vm, *ty);
-            self.gen.emit_new_object(start_reg, cls_id);
+            self.gen.emit_new_object(start_reg, cls_id, expr.pos);
             start_reg.offset(1)
         } else if callee.has_self() {
             let self_id = self.src.var_self().id;
@@ -440,7 +440,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         match *call_type {
             CallType::Ctor(_, _) | CallType::CtorNew(_, _) => {
                 self.gen
-                    .emit_invoke_direct_void(callee_id, start_reg, num_args);
+                    .emit_invoke_direct_void(callee_id, start_reg, num_args, expr.pos);
             }
 
             CallType::Method(_, _, _) => unimplemented!(),
@@ -449,35 +449,35 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             CallType::Fct(_, _, _) => {
                 if return_type.is_unit() {
                     self.gen
-                        .emit_invoke_static_void(callee_id, start_reg, num_args);
+                        .emit_invoke_static_void(callee_id, start_reg, num_args, expr.pos);
                 } else {
                     let return_type: BytecodeType = return_type.into();
 
                     match return_type.into() {
-                        BytecodeType::Bool => self
-                            .gen
-                            .emit_invoke_static_bool(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Byte => self
-                            .gen
-                            .emit_invoke_static_byte(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Char => self
-                            .gen
-                            .emit_invoke_static_char(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Int => self
-                            .gen
-                            .emit_invoke_static_int(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Long => self
-                            .gen
-                            .emit_invoke_static_long(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Float => self
-                            .gen
-                            .emit_invoke_static_float(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Double => self
-                            .gen
-                            .emit_invoke_static_double(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Ptr => self
-                            .gen
-                            .emit_invoke_static_ptr(return_reg, callee_id, start_reg, num_args),
+                        BytecodeType::Bool => self.gen.emit_invoke_static_bool(
+                            return_reg, callee_id, start_reg, num_args, expr.pos,
+                        ),
+                        BytecodeType::Byte => self.gen.emit_invoke_static_byte(
+                            return_reg, callee_id, start_reg, num_args, expr.pos,
+                        ),
+                        BytecodeType::Char => self.gen.emit_invoke_static_char(
+                            return_reg, callee_id, start_reg, num_args, expr.pos,
+                        ),
+                        BytecodeType::Int => self.gen.emit_invoke_static_int(
+                            return_reg, callee_id, start_reg, num_args, expr.pos,
+                        ),
+                        BytecodeType::Long => self.gen.emit_invoke_static_long(
+                            return_reg, callee_id, start_reg, num_args, expr.pos,
+                        ),
+                        BytecodeType::Float => self.gen.emit_invoke_static_float(
+                            return_reg, callee_id, start_reg, num_args, expr.pos,
+                        ),
+                        BytecodeType::Double => self.gen.emit_invoke_static_double(
+                            return_reg, callee_id, start_reg, num_args, expr.pos,
+                        ),
+                        BytecodeType::Ptr => self.gen.emit_invoke_static_ptr(
+                            return_reg, callee_id, start_reg, num_args, expr.pos,
+                        ),
                     }
                 }
             }
@@ -528,7 +528,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         match *call_type {
             CallType::Ctor(_, _) => {
                 self.gen
-                    .emit_invoke_direct_void(callee_id, start_reg, num_args);
+                    .emit_invoke_direct_void(callee_id, start_reg, num_args, expr.pos);
             }
 
             _ => unreachable!(),

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -19,6 +19,15 @@ fn code(code: &'static str) -> Vec<Bytecode> {
     })
 }
 
+fn position(code: &'static str) -> Vec<(u32, Position)> {
+    test::parse(code, |vm| {
+        let fct_id = vm.fct_by_name("f").expect("no function `f`.");
+        let tp = TypeList::empty();
+        let fct = bytecode::generate_fct(vm, fct_id, &tp, &tp);
+        fct.positions().to_vec()
+    })
+}
+
 fn code_method(code: &'static str) -> Vec<Bytecode> {
     code_method_with_class_name(code, "Foo")
 }
@@ -159,6 +168,62 @@ fn gen_load_field_ptr() {
 }
 
 #[test]
+fn gen_position_load_field_byte() {
+    let result = position("class Foo(let bar: Byte) fun f(a: Foo) -> Byte { return a.bar; }");
+    let expected = vec![(0, p(1, 58))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_load_field_bool() {
+    let result = position("class Foo(let bar: Bool) fun f(a: Foo) -> Bool { return a.bar; }");
+    let expected = vec![(0, p(1, 58))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_load_field_char() {
+    let result = position("class Foo(let bar: Char) fun f(a: Foo) -> Char { return a.bar; }");
+    let expected = vec![(0, p(1, 58))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_load_field_int() {
+    let result = position("class Foo(let bar: Int) fun f(a: Foo) -> Int { return a.bar; }");
+    let expected = vec![(0, p(1, 56))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_load_field_long() {
+    let result = position("class Foo(let bar: Long) fun f(a: Foo) -> Long { return a.bar; }");
+    let expected = vec![(0, p(1, 58))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_load_field_float() {
+    let result = position("class Foo(let bar: Float) fun f(a: Foo) -> Float { return a.bar; }");
+    let expected = vec![(0, p(1, 60))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_load_field_double() {
+    let result = position("class Foo(let bar: Double) fun f(a: Foo) -> Double { return a.bar; }");
+    let expected = vec![(0, p(1, 62))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_load_field_ptr() {
+    let result = position("class Foo(let bar: Object) fun f(a: Foo) -> Object { return a.bar; }");
+    let expected = vec![(0, p(1, 62))];
+    assert_eq!(expected, result);
+}
+
+#[test]
 fn gen_store_field_byte() {
     gen(
         "class Foo(var bar: Byte) fun f(a: Foo, b: Byte) { a.bar = b; }",
@@ -255,6 +320,62 @@ fn gen_store_field_ptr() {
 }
 
 #[test]
+fn gen_position_store_field_byte() {
+    let result = position("class Foo(var bar: Byte) fun f(a: Foo, b: Byte) { a.bar = b; }");
+    let expected = vec![(0, p(1, 57))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_store_field_bool() {
+    let result = position("class Foo(var bar: Bool) fun f(a: Foo, b: Bool) { a.bar = b; }");
+    let expected = vec![(0, p(1, 57))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_store_field_char() {
+    let result = position("class Foo(var bar: Char) fun f(a: Foo, b: Char) { a.bar = b; }");
+    let expected = vec![(0, p(1, 57))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_store_field_int() {
+    let result = position("class Foo(var bar: Int) fun f(a: Foo, b: Int) { a.bar = b; }");
+    let expected = vec![(0, p(1, 55))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_store_field_long() {
+    let result = position("class Foo(var bar: Long) fun f(a: Foo, b: Long) { a.bar = b; }");
+    let expected = vec![(0, p(1, 57))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_store_field_float() {
+    let result = position("class Foo(var bar: Float) fun f(a: Foo, b: Float) { a.bar = b; }");
+    let expected = vec![(0, p(1, 59))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_store_field_double() {
+    let result = position("class Foo(var bar: Double) fun f(a: Foo, b: Double) { a.bar = b; }");
+    let expected = vec![(0, p(1, 61))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_store_field_ptr() {
+    let result = position("class Foo(var bar: Object) fun f(a: Foo, b: Object) { a.bar = b; }");
+    let expected = vec![(0, p(1, 61))];
+    assert_eq!(expected, result);
+}
+
+#[test]
 fn gen_add_int() {
     let result = code("fun f() -> Int { return 1 + 2; }");
     let expected = vec![
@@ -324,6 +445,13 @@ fn gen_sub_float() {
 fn gen_div_int() {
     let result = code("fun f(a: Int, b: Int) -> Int { return a / b; }");
     let expected = vec![DivInt(r(2), r(0), r(1)), RetInt(r(2))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_div_int() {
+    let result = position("fun f(a: Int, b: Int) -> Int { return a / b; }");
+    let expected = vec![(0, p(1, 41))];
     assert_eq!(expected, result);
 }
 
@@ -577,6 +705,13 @@ fn gen_expr_not() {
 fn gen_expr_mod() {
     let result = code("fun f(a: Int, b: Int) -> Int { return a % b; }");
     let expected = vec![ModInt(r(2), r(0), r(1)), RetInt(r(2))];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn gen_position_mod_int() {
+    let result = position("fun f(a: Int, b: Int) -> Int { return a % b; }");
+    let expected = vec![(0, p(1, 41))];
     assert_eq!(expected, result);
 }
 
@@ -976,6 +1111,13 @@ fn gen_new_object() {
 }
 
 #[test]
+fn gen_position_new_object() {
+    let result = position("fun f() -> Object { return Object(); }");
+    let expected = vec![(0, p(1, 34))];
+    assert_eq!(expected, result);
+}
+
+#[test]
 fn gen_new_object_with_multiple_args() {
     gen(
         "
@@ -996,6 +1138,17 @@ fn gen_new_object_with_multiple_args() {
             assert_eq!(expected, code);
         },
     );
+}
+
+#[test]
+fn gen_position_new_object_with_multiple_args() {
+    let result = position(
+        "
+            class Foo(a: Int, b: Int, c: Int)
+            fun f() -> Foo { return Foo(1, 2, 3); }",
+    );
+    let expected = vec![(0, p(3, 40))];
+    assert_eq!(expected, result);
 }
 
 #[test]
@@ -1185,6 +1338,13 @@ fn gen_assert() {
 }
 
 #[test]
+fn gen_position_assert() {
+    let result = position("fun f() { assert(true); }");
+    let expected = vec![(5, p(1, 17))];
+    assert_eq!(expected, result);
+}
+
+#[test]
 fn gen_throw() {
     gen("fun f() { throw Exception(\"exception\"); }", |vm, code| {
         let cls_id = vm.cls_def_by_name("Exception");
@@ -1202,13 +1362,9 @@ fn gen_throw() {
 
 #[test]
 fn gen_position_throw() {
-    gen_fct(
-        "fun f() { throw Exception(\"exception\"); }",
-        |_vm, _code, fct| {
-            let expected = vec![(0, p(1, 26)), (10, p(1, 11))];
-            assert_eq!(expected, fct.positions().to_vec());
-        },
-    );
+    let result = position("fun f() { throw Exception(\"exception\"); }");
+    let expected = vec![(0, p(1, 26)), (10, p(1, 11))];
+    assert_eq!(expected, result);
 }
 
 fn p(line: u32, column: u32) -> Position {

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -1205,13 +1205,7 @@ fn gen_position_throw() {
     gen_fct(
         "fun f() { throw Exception(\"exception\"); }",
         |_vm, _code, fct| {
-            let expected = vec![
-                (0, p(1, 26)),
-                (3, p(1, 27)),
-                (6, p(1, 26)),
-                (10, p(1, 11)),
-                (12, p(1, 11)),
-            ];
+            let expected = vec![(0, p(1, 26)), (10, p(1, 11))];
             assert_eq!(expected, fct.positions().to_vec());
         },
     );

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -586,14 +586,8 @@ impl BytecodeWriter {
         self.emit_load_global(BytecodeOpcode::LoadGlobalPtr, dest, gid);
     }
 
-    pub fn emit_invoke_direct_void(
-        &mut self,
-        fid: FctId,
-        start: Register,
-        num: usize,
-        pos: Position,
-    ) {
-        self.emit_fct_void(BytecodeOpcode::InvokeDirectVoid, fid, start, num, pos);
+    pub fn emit_invoke_direct_void(&mut self, fid: FctId, start: Register, num: usize) {
+        self.emit_fct_void(BytecodeOpcode::InvokeDirectVoid, fid, start, num);
     }
 
     pub fn emit_invoke_direct_bool(
@@ -602,9 +596,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectBool, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeDirectBool, dest, fid, start, num);
     }
 
     pub fn emit_invoke_direct_byte(
@@ -613,9 +606,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectByte, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeDirectByte, dest, fid, start, num);
     }
 
     pub fn emit_invoke_direct_char(
@@ -624,9 +616,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectChar, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeDirectChar, dest, fid, start, num);
     }
 
     pub fn emit_invoke_direct_int(
@@ -635,9 +626,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectInt, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeDirectInt, dest, fid, start, num);
     }
 
     pub fn emit_invoke_direct_long(
@@ -646,9 +636,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectLong, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeDirectLong, dest, fid, start, num);
     }
 
     pub fn emit_invoke_direct_float(
@@ -657,16 +646,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(
-            BytecodeOpcode::InvokeDirectFloat,
-            dest,
-            fid,
-            start,
-            num,
-            pos,
-        );
+        self.emit_fct(BytecodeOpcode::InvokeDirectFloat, dest, fid, start, num);
     }
 
     pub fn emit_invoke_direct_double(
@@ -675,16 +656,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(
-            BytecodeOpcode::InvokeDirectDouble,
-            dest,
-            fid,
-            start,
-            num,
-            pos,
-        );
+        self.emit_fct(BytecodeOpcode::InvokeDirectDouble, dest, fid, start, num);
     }
 
     pub fn emit_invoke_direct_ptr(
@@ -693,19 +666,12 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectPtr, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeDirectPtr, dest, fid, start, num);
     }
 
-    pub fn emit_invoke_virtual_void(
-        &mut self,
-        fid: FctId,
-        start: Register,
-        num: usize,
-        pos: Position,
-    ) {
-        self.emit_fct_void(BytecodeOpcode::InvokeVirtualVoid, fid, start, num, pos);
+    pub fn emit_invoke_virtual_void(&mut self, fid: FctId, start: Register, num: usize) {
+        self.emit_fct_void(BytecodeOpcode::InvokeVirtualVoid, fid, start, num);
     }
 
     pub fn emit_invoke_virtual_bool(
@@ -714,16 +680,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(
-            BytecodeOpcode::InvokeVirtualBool,
-            dest,
-            fid,
-            start,
-            num,
-            pos,
-        );
+        self.emit_fct(BytecodeOpcode::InvokeVirtualBool, dest, fid, start, num);
     }
 
     pub fn emit_invoke_virtual_byte(
@@ -732,16 +690,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(
-            BytecodeOpcode::InvokeVirtualByte,
-            dest,
-            fid,
-            start,
-            num,
-            pos,
-        );
+        self.emit_fct(BytecodeOpcode::InvokeVirtualByte, dest, fid, start, num);
     }
 
     pub fn emit_invoke_virtual_char(
@@ -750,16 +700,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(
-            BytecodeOpcode::InvokeVirtualChar,
-            dest,
-            fid,
-            start,
-            num,
-            pos,
-        );
+        self.emit_fct(BytecodeOpcode::InvokeVirtualChar, dest, fid, start, num);
     }
 
     pub fn emit_invoke_virtual_int(
@@ -768,9 +710,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualInt, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeVirtualInt, dest, fid, start, num);
     }
 
     pub fn emit_invoke_virtual_long(
@@ -779,16 +720,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(
-            BytecodeOpcode::InvokeVirtualLong,
-            dest,
-            fid,
-            start,
-            num,
-            pos,
-        );
+        self.emit_fct(BytecodeOpcode::InvokeVirtualLong, dest, fid, start, num);
     }
 
     pub fn emit_invoke_virtual_float(
@@ -797,16 +730,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(
-            BytecodeOpcode::InvokeVirtualFloat,
-            dest,
-            fid,
-            start,
-            num,
-            pos,
-        );
+        self.emit_fct(BytecodeOpcode::InvokeVirtualFloat, dest, fid, start, num);
     }
 
     pub fn emit_invoke_virtual_double(
@@ -815,16 +740,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(
-            BytecodeOpcode::InvokeVirtualDouble,
-            dest,
-            fid,
-            start,
-            num,
-            pos,
-        );
+        self.emit_fct(BytecodeOpcode::InvokeVirtualDouble, dest, fid, start, num);
     }
 
     pub fn emit_invoke_virtual_ptr(
@@ -833,19 +750,12 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualPtr, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeVirtualPtr, dest, fid, start, num);
     }
 
-    pub fn emit_invoke_static_void(
-        &mut self,
-        fid: FctId,
-        start: Register,
-        num: usize,
-        pos: Position,
-    ) {
-        self.emit_fct_void(BytecodeOpcode::InvokeStaticVoid, fid, start, num, pos);
+    pub fn emit_invoke_static_void(&mut self, fid: FctId, start: Register, num: usize) {
+        self.emit_fct_void(BytecodeOpcode::InvokeStaticVoid, fid, start, num);
     }
 
     pub fn emit_invoke_static_bool(
@@ -854,9 +764,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticBool, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeStaticBool, dest, fid, start, num);
     }
 
     pub fn emit_invoke_static_byte(
@@ -865,9 +774,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticByte, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeStaticByte, dest, fid, start, num);
     }
 
     pub fn emit_invoke_static_char(
@@ -876,9 +784,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticChar, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeStaticChar, dest, fid, start, num);
     }
 
     pub fn emit_invoke_static_int(
@@ -887,9 +794,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticInt, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeStaticInt, dest, fid, start, num);
     }
 
     pub fn emit_invoke_static_long(
@@ -898,9 +804,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticLong, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeStaticLong, dest, fid, start, num);
     }
 
     pub fn emit_invoke_static_float(
@@ -909,16 +814,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(
-            BytecodeOpcode::InvokeStaticFloat,
-            dest,
-            fid,
-            start,
-            num,
-            pos,
-        );
+        self.emit_fct(BytecodeOpcode::InvokeStaticFloat, dest, fid, start, num);
     }
 
     pub fn emit_invoke_static_double(
@@ -927,16 +824,8 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(
-            BytecodeOpcode::InvokeStaticDouble,
-            dest,
-            fid,
-            start,
-            num,
-            pos,
-        );
+        self.emit_fct(BytecodeOpcode::InvokeStaticDouble, dest, fid, start, num);
     }
 
     pub fn emit_invoke_static_ptr(
@@ -945,18 +834,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
-        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticPtr, dest, fid, start, num, pos);
+        self.emit_fct(BytecodeOpcode::InvokeStaticPtr, dest, fid, start, num);
     }
 
-    pub fn emit_throw(&mut self, opnd: Register, pos: Position) {
-        self.emit_position(pos);
+    pub fn emit_throw(&mut self, opnd: Register) {
         self.emit_reg1(BytecodeOpcode::Throw, opnd);
     }
 
-    pub fn emit_new_object(&mut self, dest: Register, cls_id: ClassDefId, pos: Position) {
-        self.emit_new(BytecodeOpcode::NewObject, dest, cls_id, pos);
+    pub fn emit_new_object(&mut self, dest: Register, cls_id: ClassDefId) {
+        self.emit_new(BytecodeOpcode::NewObject, dest, cls_id);
     }
 
     pub fn generate(mut self) -> BytecodeFunction {
@@ -1048,21 +935,12 @@ impl BytecodeWriter {
         idx.into()
     }
 
-    fn emit_new(&mut self, inst: BytecodeOpcode, r1: Register, cid: ClassDefId, pos: Position) {
-        self.emit_position(pos);
+    fn emit_new(&mut self, inst: BytecodeOpcode, r1: Register, cid: ClassDefId) {
         let values = [inst as u32, r1.to_usize() as u32, cid.to_usize() as u32];
         self.emit_values(&values);
     }
 
-    fn emit_fct_void(
-        &mut self,
-        inst: BytecodeOpcode,
-        fid: FctId,
-        r1: Register,
-        cnt: usize,
-        pos: Position,
-    ) {
-        self.emit_position(pos);
+    fn emit_fct_void(&mut self, inst: BytecodeOpcode, fid: FctId, r1: Register, cnt: usize) {
         let values = [
             inst as u32,
             fid.to_usize() as u32,
@@ -1079,9 +957,7 @@ impl BytecodeWriter {
         fid: FctId,
         r2: Register,
         cnt: usize,
-        pos: Position,
     ) {
-        self.emit_position(pos);
         let values = [
             inst as u32,
             r1.to_usize() as u32,
@@ -1115,7 +991,7 @@ impl BytecodeWriter {
         self.emit_values(&values);
     }
 
-    fn emit_position(&mut self, pos: Position) {
+    pub fn set_position(&mut self, pos: Position) {
         let offset = self.code.len() as u32;
         self.positions.insert(offset, pos);
     }

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -25,6 +25,7 @@ pub struct BytecodeWriter {
     const_pool: Vec<ConstPoolEntry>,
 
     positions: PositionTable,
+    position: Position,
 }
 
 impl BytecodeWriter {
@@ -41,6 +42,7 @@ impl BytecodeWriter {
             const_pool: Vec::new(),
 
             positions: PositionTable::new(),
+            position: Position { line: 0, column: 0 },
         }
     }
 
@@ -992,8 +994,7 @@ impl BytecodeWriter {
     }
 
     pub fn set_position(&mut self, pos: Position) {
-        let offset = self.code.len() as u32;
-        self.positions.insert(offset, pos);
+        self.position = pos;
     }
 
     fn emit_op(&mut self, inst: BytecodeOpcode) {
@@ -1002,6 +1003,9 @@ impl BytecodeWriter {
     }
 
     fn emit_values(&mut self, values: &[u32]) {
+        let offset = self.code.len() as u32;
+        self.positions.insert(offset, self.position);
+
         let is_wide = values.iter().any(|&val| val > u8::max_value() as u32);
 
         if is_wide {

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -1018,7 +1018,8 @@ impl BytecodeWriter {
             self.emit_position();
         }
 
-        let is_wide = values.iter().any(|&val| val > u8::max_value() as u32);
+        let is_wide = op as u32 > u8::max_value() as u32
+            || values.iter().any(|&val| val > u8::max_value() as u32);
 
         if is_wide {
             self.emit_wide();

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -4,7 +4,7 @@ use std::mem;
 
 use crate::bytecode::{
     BytecodeFunction, BytecodeOffset, BytecodeOpcode, BytecodeType, ConstPoolEntry, ConstPoolIdx,
-    PositionTable, Register,
+    Register,
 };
 use crate::vm::{ClassDefId, FctId, FieldId, GlobalId};
 
@@ -24,7 +24,7 @@ pub struct BytecodeWriter {
     registers: Vec<BytecodeType>,
     const_pool: Vec<ConstPoolEntry>,
 
-    positions: PositionTable,
+    positions: Vec<(u32, Position)>,
     position: Position,
 }
 
@@ -41,7 +41,7 @@ impl BytecodeWriter {
             registers: Vec::new(),
             const_pool: Vec::new(),
 
-            positions: PositionTable::new(),
+            positions: Vec::new(),
             position: Position { line: 0, column: 0 },
         }
     }
@@ -1002,9 +1002,14 @@ impl BytecodeWriter {
         self.emit_values(&values);
     }
 
-    fn emit_values(&mut self, values: &[u32]) {
+    fn emit_position(&mut self) {
         let offset = self.code.len() as u32;
-        self.positions.insert(offset, self.position);
+        let position = (offset, self.position);
+        self.positions.push(position);
+    }
+
+    fn emit_values(&mut self, values: &[u32]) {
+        self.emit_position();
 
         let is_wide = values.iter().any(|&val| val > u8::max_value() as u32);
 

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -4,9 +4,11 @@ use std::mem;
 
 use crate::bytecode::{
     BytecodeFunction, BytecodeOffset, BytecodeOpcode, BytecodeType, ConstPoolEntry, ConstPoolIdx,
-    Register,
+    PositionTable, Register,
 };
 use crate::vm::{ClassDefId, FctId, FieldId, GlobalId};
+
+use dora_parser::lexer::position::Position;
 
 #[derive(Copy, Clone, PartialEq, Debug, Eq, Hash)]
 pub struct Label(pub usize);
@@ -21,6 +23,8 @@ pub struct BytecodeWriter {
 
     registers: Vec<BytecodeType>,
     const_pool: Vec<ConstPoolEntry>,
+
+    positions: PositionTable,
 }
 
 impl BytecodeWriter {
@@ -35,6 +39,8 @@ impl BytecodeWriter {
 
             registers: Vec::new(),
             const_pool: Vec::new(),
+
+            positions: PositionTable::new(),
         }
     }
 
@@ -580,8 +586,14 @@ impl BytecodeWriter {
         self.emit_load_global(BytecodeOpcode::LoadGlobalPtr, dest, gid);
     }
 
-    pub fn emit_invoke_direct_void(&mut self, fid: FctId, start: Register, num: usize) {
-        self.emit_fct_void(BytecodeOpcode::InvokeDirectVoid, fid, start, num);
+    pub fn emit_invoke_direct_void(
+        &mut self,
+        fid: FctId,
+        start: Register,
+        num: usize,
+        pos: Position,
+    ) {
+        self.emit_fct_void(BytecodeOpcode::InvokeDirectVoid, fid, start, num, pos);
     }
 
     pub fn emit_invoke_direct_bool(
@@ -590,8 +602,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectBool, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeDirectBool, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_direct_byte(
@@ -600,8 +613,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectByte, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeDirectByte, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_direct_char(
@@ -610,8 +624,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectChar, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeDirectChar, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_direct_int(
@@ -620,8 +635,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectInt, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeDirectInt, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_direct_long(
@@ -630,8 +646,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectLong, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeDirectLong, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_direct_float(
@@ -640,8 +657,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectFloat, dest, fid, start, num);
+        self.emit_fct(
+            BytecodeOpcode::InvokeDirectFloat,
+            dest,
+            fid,
+            start,
+            num,
+            pos,
+        );
     }
 
     pub fn emit_invoke_direct_double(
@@ -650,8 +675,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectDouble, dest, fid, start, num);
+        self.emit_fct(
+            BytecodeOpcode::InvokeDirectDouble,
+            dest,
+            fid,
+            start,
+            num,
+            pos,
+        );
     }
 
     pub fn emit_invoke_direct_ptr(
@@ -660,12 +693,19 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectPtr, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeDirectPtr, dest, fid, start, num, pos);
     }
 
-    pub fn emit_invoke_virtual_void(&mut self, fid: FctId, start: Register, num: usize) {
-        self.emit_fct_void(BytecodeOpcode::InvokeVirtualVoid, fid, start, num);
+    pub fn emit_invoke_virtual_void(
+        &mut self,
+        fid: FctId,
+        start: Register,
+        num: usize,
+        pos: Position,
+    ) {
+        self.emit_fct_void(BytecodeOpcode::InvokeVirtualVoid, fid, start, num, pos);
     }
 
     pub fn emit_invoke_virtual_bool(
@@ -674,8 +714,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualBool, dest, fid, start, num);
+        self.emit_fct(
+            BytecodeOpcode::InvokeVirtualBool,
+            dest,
+            fid,
+            start,
+            num,
+            pos,
+        );
     }
 
     pub fn emit_invoke_virtual_byte(
@@ -684,8 +732,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualByte, dest, fid, start, num);
+        self.emit_fct(
+            BytecodeOpcode::InvokeVirtualByte,
+            dest,
+            fid,
+            start,
+            num,
+            pos,
+        );
     }
 
     pub fn emit_invoke_virtual_char(
@@ -694,8 +750,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualChar, dest, fid, start, num);
+        self.emit_fct(
+            BytecodeOpcode::InvokeVirtualChar,
+            dest,
+            fid,
+            start,
+            num,
+            pos,
+        );
     }
 
     pub fn emit_invoke_virtual_int(
@@ -704,8 +768,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualInt, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeVirtualInt, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_virtual_long(
@@ -714,8 +779,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualLong, dest, fid, start, num);
+        self.emit_fct(
+            BytecodeOpcode::InvokeVirtualLong,
+            dest,
+            fid,
+            start,
+            num,
+            pos,
+        );
     }
 
     pub fn emit_invoke_virtual_float(
@@ -724,8 +797,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualFloat, dest, fid, start, num);
+        self.emit_fct(
+            BytecodeOpcode::InvokeVirtualFloat,
+            dest,
+            fid,
+            start,
+            num,
+            pos,
+        );
     }
 
     pub fn emit_invoke_virtual_double(
@@ -734,8 +815,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualDouble, dest, fid, start, num);
+        self.emit_fct(
+            BytecodeOpcode::InvokeVirtualDouble,
+            dest,
+            fid,
+            start,
+            num,
+            pos,
+        );
     }
 
     pub fn emit_invoke_virtual_ptr(
@@ -744,12 +833,19 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualPtr, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeVirtualPtr, dest, fid, start, num, pos);
     }
 
-    pub fn emit_invoke_static_void(&mut self, fid: FctId, start: Register, num: usize) {
-        self.emit_fct_void(BytecodeOpcode::InvokeStaticVoid, fid, start, num);
+    pub fn emit_invoke_static_void(
+        &mut self,
+        fid: FctId,
+        start: Register,
+        num: usize,
+        pos: Position,
+    ) {
+        self.emit_fct_void(BytecodeOpcode::InvokeStaticVoid, fid, start, num, pos);
     }
 
     pub fn emit_invoke_static_bool(
@@ -758,8 +854,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticBool, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeStaticBool, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_static_byte(
@@ -768,8 +865,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticByte, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeStaticByte, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_static_char(
@@ -778,8 +876,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticChar, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeStaticChar, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_static_int(
@@ -788,8 +887,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticInt, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeStaticInt, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_static_long(
@@ -798,8 +898,9 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticLong, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeStaticLong, dest, fid, start, num, pos);
     }
 
     pub fn emit_invoke_static_float(
@@ -808,8 +909,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticFloat, dest, fid, start, num);
+        self.emit_fct(
+            BytecodeOpcode::InvokeStaticFloat,
+            dest,
+            fid,
+            start,
+            num,
+            pos,
+        );
     }
 
     pub fn emit_invoke_static_double(
@@ -818,8 +927,16 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticDouble, dest, fid, start, num);
+        self.emit_fct(
+            BytecodeOpcode::InvokeStaticDouble,
+            dest,
+            fid,
+            start,
+            num,
+            pos,
+        );
     }
 
     pub fn emit_invoke_static_ptr(
@@ -828,22 +945,30 @@ impl BytecodeWriter {
         fid: FctId,
         start: Register,
         num: usize,
+        pos: Position,
     ) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticPtr, dest, fid, start, num);
+        self.emit_fct(BytecodeOpcode::InvokeStaticPtr, dest, fid, start, num, pos);
     }
 
-    pub fn emit_throw(&mut self, opnd: Register) {
+    pub fn emit_throw(&mut self, opnd: Register, pos: Position) {
+        self.emit_position(pos);
         self.emit_reg1(BytecodeOpcode::Throw, opnd);
     }
 
-    pub fn emit_new_object(&mut self, dest: Register, cls_id: ClassDefId) {
-        self.emit_new(BytecodeOpcode::NewObject, dest, cls_id);
+    pub fn emit_new_object(&mut self, dest: Register, cls_id: ClassDefId, pos: Position) {
+        self.emit_new(BytecodeOpcode::NewObject, dest, cls_id, pos);
     }
 
     pub fn generate(mut self) -> BytecodeFunction {
         self.resolve_forward_jumps();
 
-        BytecodeFunction::new(self.code, self.const_pool, self.registers, self.arguments)
+        BytecodeFunction::new(
+            self.code,
+            self.const_pool,
+            self.registers,
+            self.arguments,
+            self.positions,
+        )
     }
 
     fn resolve_forward_jumps(&mut self) {
@@ -923,12 +1048,21 @@ impl BytecodeWriter {
         idx.into()
     }
 
-    fn emit_new(&mut self, inst: BytecodeOpcode, r1: Register, cid: ClassDefId) {
+    fn emit_new(&mut self, inst: BytecodeOpcode, r1: Register, cid: ClassDefId, pos: Position) {
+        self.emit_position(pos);
         let values = [inst as u32, r1.to_usize() as u32, cid.to_usize() as u32];
         self.emit_values(&values);
     }
 
-    fn emit_fct_void(&mut self, inst: BytecodeOpcode, fid: FctId, r1: Register, cnt: usize) {
+    fn emit_fct_void(
+        &mut self,
+        inst: BytecodeOpcode,
+        fid: FctId,
+        r1: Register,
+        cnt: usize,
+        pos: Position,
+    ) {
+        self.emit_position(pos);
         let values = [
             inst as u32,
             fid.to_usize() as u32,
@@ -945,7 +1079,9 @@ impl BytecodeWriter {
         fid: FctId,
         r2: Register,
         cnt: usize,
+        pos: Position,
     ) {
+        self.emit_position(pos);
         let values = [
             inst as u32,
             r1.to_usize() as u32,
@@ -977,6 +1113,11 @@ impl BytecodeWriter {
     fn emit_load_global(&mut self, inst: BytecodeOpcode, r1: Register, gid: GlobalId) {
         let values = [inst as u32, r1.to_usize() as u32, gid.to_usize() as u32];
         self.emit_values(&values);
+    }
+
+    fn emit_position(&mut self, pos: Position) {
+        let offset = self.code.len() as u32;
+        self.positions.insert(offset, pos);
     }
 
     fn emit_op(&mut self, inst: BytecodeOpcode) {

--- a/dora/src/cannon/codegen.rs
+++ b/dora/src/cannon/codegen.rs
@@ -409,12 +409,15 @@ where
 
         let bytecode_type = self.bytecode.register_type(dest);
         let offset = self.bytecode.register_offset(dest);
+
+        let position = self.bytecode.offset_position(self.current_offset.to_u32());
+
         self.asm.int_div(
             bytecode_type.mode(),
             REG_RESULT,
             REG_RESULT,
             REG_TMP1,
-            Position::new(1, 1),
+            position,
         );
 
         self.asm
@@ -472,12 +475,15 @@ where
 
         let bytecode_type = self.bytecode.register_type(dest);
         let offset = self.bytecode.register_offset(dest);
+
+        let position = self.bytecode.offset_position(self.current_offset.to_u32());
+
         self.asm.int_mod(
             bytecode_type.mode(),
             REG_RESULT,
             REG_RESULT,
             REG_TMP1,
-            Position::new(1, 1),
+            position,
         );
 
         self.asm

--- a/dora/src/cannon/codegen.rs
+++ b/dora/src/cannon/codegen.rs
@@ -1,5 +1,4 @@
 use dora_parser::ast::*;
-use dora_parser::lexer::position::Position;
 use std::collections::hash_map::HashMap;
 
 use crate::bytecode::{
@@ -1018,13 +1017,9 @@ where
         };
 
         let gcpoint = GcPoint::from_offsets(self.references.clone());
-        self.asm.allocate(
-            REG_RESULT.into(),
-            alloc_size,
-            Position { line: 0, column: 0 }, // Correct position is currently not known.
-            false,
-            gcpoint,
-        );
+        let position = self.bytecode.offset_position(self.current_offset.to_u32());
+        self.asm
+            .allocate(REG_RESULT.into(), alloc_size, position, false, gcpoint);
 
         let bytecode_type = self.bytecode.register_type(dest);
         let offset = self.bytecode.register_offset(dest);
@@ -1071,10 +1066,8 @@ where
         self.asm
             .load_mem(bytecode_type.mode(), REG_RESULT.into(), Mem::Local(offset));
 
-        self.asm.throw(
-            REG_RESULT,
-            Position { line: 0, column: 0 }, // Correct position is currently not known.
-        );
+        let position = self.bytecode.offset_position(self.current_offset.to_u32());
+        self.asm.throw(REG_RESULT, position);
     }
 
     fn emit_invoke_direct_void(&mut self, fct_id: FctId, start_reg: Register, num: u32) {
@@ -1132,12 +1125,13 @@ where
         self.asm.emit_comment(Comment::CallDirect(fct_id));
         let ptr = self.ptr_for_fct_id(fct_id, cls_type_params.clone(), fct_type_params.clone());
         let gcpoint = GcPoint::from_offsets(self.references.clone());
+        let position = self.bytecode.offset_position(self.current_offset.to_u32());
         self.asm.direct_call(
             fct_id,
             ptr.to_ptr(),
             cls_type_params,
             fct_type_params,
-            Position { line: 0, column: 0 }, // Correct position is currently not known.
+            position,
             gcpoint,
             BuiltinType::Unit,
             REG_RESULT.into(),

--- a/tests/cannon/assert1.dora
+++ b/tests/cannon/assert1.dora
@@ -1,0 +1,16 @@
+//= error exception
+fun main() {
+  var x = Foo(12);
+  x.test();
+  x.test2(1);
+}
+
+class Foo(let i: Int) {
+  @cannon fun test() {
+    var x = self.i;
+  }
+
+  @cannon fun test2(i: Int) {
+    assert(i == 2);
+  }
+}


### PR DESCRIPTION
As mentioned in the code, _cannon_ didn't pass the correct position to the assembler, but created a dummy object. I now have added a `PositionTable` to the bytecode function, which maps the position to the instructions, which require a position. In _cannon_, I then use this map to retrieve the correct position.