### PR TITLE
cannon: direct invoke

### DIFF
--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -1211,14 +1211,6 @@ impl DataDest {
         }
     }
 
-    fn is_reg(&self) -> bool {
-        match self {
-            DataDest::Effect => false,
-            DataDest::Reg(_) => true,
-            DataDest::Alloc => false,
-        }
-    }
-
     fn reg(&self) -> Register {
         match self {
             DataDest::Effect | DataDest::Alloc => panic!("not a register"),

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -529,12 +529,14 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         }
 
         if call_type.is_ctor_new() || call_type.is_ctor() {
-            if dest.is_reg() {
-                let return_reg = self.ensure_register(dest, BytecodeType::Ptr);
-                self.gen.emit_mov_ptr(return_reg, start_reg);
-                return_reg
-            } else {
-                start_reg
+            match dest {
+                DataDest::Effect => Register::invalid(),
+                DataDest::Reg(_) => {
+                    let return_reg = self.ensure_register(dest, BytecodeType::Ptr);
+                    self.gen.emit_mov_ptr(return_reg, start_reg);
+                    return_reg
+                }
+                DataDest::Alloc => start_reg,
             }
         } else {
             return_reg

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -450,7 +450,41 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                     .emit_invoke_direct_void(callee_id, start_reg, num_args);
             }
 
-            CallType::Method(_, _, _) => unimplemented!(),
+            CallType::Method(_, _, _) => {
+                if return_type.is_unit() {
+                    self.gen
+                        .emit_invoke_direct_void(callee_id, start_reg, num_args);
+                } else {
+                    let return_type: BytecodeType = return_type.into();
+
+                    match return_type.into() {
+                        BytecodeType::Bool => self
+                            .gen
+                            .emit_invoke_direct_bool(return_reg, callee_id, start_reg, num_args),
+                        BytecodeType::Byte => self
+                            .gen
+                            .emit_invoke_direct_byte(return_reg, callee_id, start_reg, num_args),
+                        BytecodeType::Char => self
+                            .gen
+                            .emit_invoke_direct_char(return_reg, callee_id, start_reg, num_args),
+                        BytecodeType::Int => self
+                            .gen
+                            .emit_invoke_direct_int(return_reg, callee_id, start_reg, num_args),
+                        BytecodeType::Long => self
+                            .gen
+                            .emit_invoke_direct_long(return_reg, callee_id, start_reg, num_args),
+                        BytecodeType::Float => self
+                            .gen
+                            .emit_invoke_direct_float(return_reg, callee_id, start_reg, num_args),
+                        BytecodeType::Double => self
+                            .gen
+                            .emit_invoke_direct_double(return_reg, callee_id, start_reg, num_args),
+                        BytecodeType::Ptr => self
+                            .gen
+                            .emit_invoke_direct_ptr(return_reg, callee_id, start_reg, num_args),
+                    }
+                }
+            }
             CallType::Expr(_, _) => unimplemented!(),
 
             CallType::Fct(_, _, _) => {

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -531,10 +531,9 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         if call_type.is_ctor_new() || call_type.is_ctor() {
             match dest {
                 DataDest::Effect => Register::invalid(),
-                DataDest::Reg(_) => {
-                    let return_reg = self.ensure_register(dest, BytecodeType::Ptr);
-                    self.gen.emit_mov_ptr(return_reg, start_reg);
-                    return_reg
+                DataDest::Reg(reg) => {
+                    self.gen.emit_mov_ptr(reg, start_reg);
+                    reg
                 }
                 DataDest::Alloc => start_reg,
             }

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -528,8 +528,14 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             CallType::Intrinsic(_) => unreachable!(),
         }
 
-        if call_type.is_ctor_new() {
-            start_reg
+        if call_type.is_ctor_new() || call_type.is_ctor() {
+            if dest.is_reg() {
+                let return_reg = self.ensure_register(dest, BytecodeType::Ptr);
+                self.gen.emit_mov_ptr(return_reg, start_reg);
+                return_reg
+            } else {
+                start_reg
+            }
         } else {
             return_reg
         }
@@ -1201,6 +1207,14 @@ impl DataDest {
             DataDest::Effect => false,
             DataDest::Reg(_) => false,
             DataDest::Alloc => true,
+        }
+    }
+
+    fn is_reg(&self) -> bool {
+        match self {
+            DataDest::Effect => false,
+            DataDest::Reg(_) => true,
+            DataDest::Alloc => false,
         }
     }
 

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -1111,6 +1111,847 @@ fn gen_fct_call_int_with_3_args() {
 }
 
 #[test]
+fn gen_method_call_void_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            class Foo {
+                fun g() { }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeDirectVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_void_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(1); }
+            class Foo {
+                fun g(a: Int) { }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                ConstInt(r(2), 1),
+                InvokeDirectVoid(fct_id, r(1), 2),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_void_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(1, 2, 3); }
+            class Foo {
+                fun g(a: Int, b: Int, c: Int) { }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                ConstInt(r(2), 1),
+                ConstInt(r(3), 2),
+                ConstInt(r(4), 3),
+                InvokeDirectVoid(fct_id, r(1), 4),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_bool_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Bool { return foo.g(); }
+            class Foo {
+                fun g() -> Bool { return true; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                InvokeDirectBool(r(1), fct_id, r(2), 1),
+                RetBool(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_bool_with_0_args_and_unused_result() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            class Foo {
+                fun g() -> Bool { return true; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeDirectVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_bool_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) -> Bool { return foo.g(true); }
+            class Foo {
+                fun g(a: Bool) -> Bool { return true; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstTrue(r(3)),
+                InvokeDirectBool(r(1), fct_id, r(2), 2),
+                RetBool(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_bool_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Bool { return foo.g(true, false, true); }
+            class Foo {
+                fun g(a: Bool, b: Bool, c: Bool) -> Bool { return true; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstTrue(r(3)),
+                ConstFalse(r(4)),
+                ConstTrue(r(5)),
+                InvokeDirectBool(r(1), fct_id, r(2), 4),
+                RetBool(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_byte_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Byte { return foo.g(); }
+            class Foo {
+                fun g() -> Byte { return 1Y; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                InvokeDirectByte(r(1), fct_id, r(2), 1),
+                RetByte(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_byte_with_0_args_and_unused_result() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            class Foo {
+                fun g() -> Byte { return 1Y; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeDirectVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_byte_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) -> Byte { return foo.g(1Y); }
+            class Foo {
+                fun g(a: Byte) -> Byte { return 1Y; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstByte(r(3), 1),
+                InvokeDirectByte(r(1), fct_id, r(2), 2),
+                RetByte(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_byte_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Byte { return foo.g(1Y, 2Y, 3Y); }
+            class Foo {
+                fun g(a: Byte, b: Byte, c: Byte) -> Byte { return 1Y; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstByte(r(3), 1),
+                ConstByte(r(4), 2),
+                ConstByte(r(5), 3),
+                InvokeDirectByte(r(1), fct_id, r(2), 4),
+                RetByte(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_char_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Char { return foo.g(); }
+            class Foo {
+                fun g() -> Char { return '1'; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                InvokeDirectChar(r(1), fct_id, r(2), 1),
+                RetChar(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_char_with_0_args_and_unused_result() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            class Foo {
+                fun g() -> Char { return '1'; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeDirectVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_char_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) -> Char { return foo.g('1'); }
+            class Foo {
+                fun g(a: Char) -> Char { return '1'; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstChar(r(3), '1'),
+                InvokeDirectChar(r(1), fct_id, r(2), 2),
+                RetChar(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_char_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Char { return foo.g('1', '2', '3'); }
+            class Foo {
+                fun g(a: Char, b: Char, c: Char) -> Char { return '1'; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstChar(r(3), '1'),
+                ConstChar(r(4), '2'),
+                ConstChar(r(5), '3'),
+                InvokeDirectChar(r(1), fct_id, r(2), 4),
+                RetChar(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_int_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Int { return foo.g(); }
+            class Foo {
+                fun g() -> Int { return 1; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                InvokeDirectInt(r(1), fct_id, r(2), 1),
+                RetInt(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_int_with_0_args_and_unused_result() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            class Foo {
+                fun g() -> Int { return 1; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeDirectVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_int_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) -> Int { return foo.g(1); }
+            class Foo {
+                fun g(a: Int) -> Int { return 1; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstInt(r(3), 1),
+                InvokeDirectInt(r(1), fct_id, r(2), 2),
+                RetInt(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_int_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Int { return foo.g(1, 2, 3); }
+            class Foo {
+                fun g(a: Int, b: Int, c: Int) -> Int { return 1; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstInt(r(3), 1),
+                ConstInt(r(4), 2),
+                ConstInt(r(5), 3),
+                InvokeDirectInt(r(1), fct_id, r(2), 4),
+                RetInt(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_long_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Long { return foo.g(); }
+            class Foo {
+                fun g() -> Long { return 1L; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                InvokeDirectLong(r(1), fct_id, r(2), 1),
+                RetLong(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_long_with_0_args_and_unused_result() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            class Foo {
+                fun g() -> Long { return 1L; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeDirectVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_long_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) -> Long { return foo.g(1L); }
+            class Foo {
+                fun g(a: Long) -> Long { return 1L; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstLong(r(3), 1),
+                InvokeDirectLong(r(1), fct_id, r(2), 2),
+                RetLong(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_long_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Long { return foo.g(1L, 2L, 3L); }
+            class Foo {
+                fun g(a: Long, b: Long, c: Long) -> Long { return 1L; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstLong(r(3), 1),
+                ConstLong(r(4), 2),
+                ConstLong(r(5), 3),
+                InvokeDirectLong(r(1), fct_id, r(2), 4),
+                RetLong(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_float_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Float { return foo.g(); }
+            class Foo {
+                fun g() -> Float { return 1F; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                InvokeDirectFloat(r(1), fct_id, r(2), 1),
+                RetFloat(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_float_with_0_args_and_unused_result() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            class Foo {
+                fun g() -> Float { return 1F; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeDirectVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_float_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) -> Float { return foo.g(1F); }
+            class Foo {
+                fun g(a: Float) -> Float { return 1F; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstFloat(r(3), 1_f32),
+                InvokeDirectFloat(r(1), fct_id, r(2), 2),
+                RetFloat(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_float_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Float { return foo.g(1F, 2F, 3F); }
+            class Foo {
+                fun g(a: Float, b: Float, c: Float) -> Float { return 1F; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstFloat(r(3), 1_f32),
+                ConstFloat(r(4), 2_f32),
+                ConstFloat(r(5), 3_f32),
+                InvokeDirectFloat(r(1), fct_id, r(2), 4),
+                RetFloat(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_double_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Double { return foo.g(); }
+            class Foo {
+                fun g() -> Double { return 1D; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                InvokeDirectDouble(r(1), fct_id, r(2), 1),
+                RetDouble(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_double_with_0_args_and_unused_result() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            class Foo {
+                fun g() -> Double { return 1D; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeDirectVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_double_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) -> Double { return foo.g(1D); }
+            class Foo {
+                fun g(a: Double) -> Double { return 1D; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstDouble(r(3), 1_f64),
+                InvokeDirectDouble(r(1), fct_id, r(2), 2),
+                RetDouble(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_double_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> Double { return foo.g(1D, 2D, 3D); }
+            class Foo {
+                fun g(a: Double, b: Double, c: Double) -> Double { return 1D; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstDouble(r(3), 1_f64),
+                ConstDouble(r(4), 2_f64),
+                ConstDouble(r(5), 3_f64),
+                InvokeDirectDouble(r(1), fct_id, r(2), 4),
+                RetDouble(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_ptr_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> String { return foo.g(); }
+            class Foo {
+                fun g() -> String { return \"1\"; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                InvokeDirectPtr(r(1), fct_id, r(2), 1),
+                RetPtr(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_ptr_with_0_args_and_unused_result() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            class Foo {
+                fun g() -> String { return \"1\"; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeDirectVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_ptr_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) -> String { return foo.g(\"1\"); }
+            class Foo {
+                fun g(a: String) -> String { return \"1\"; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstString(r(3), "1".to_string()),
+                InvokeDirectPtr(r(1), fct_id, r(2), 2),
+                RetPtr(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_method_call_ptr_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) -> String { return foo.g(\"1\", \"2\", \"3\"); }
+            class Foo {
+                fun g(a: String, b: String, c: String) -> String { return \"1\"; }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(0)),
+                ConstString(r(3), "1".to_string()),
+                ConstString(r(4), "2".to_string()),
+                ConstString(r(5), "3".to_string()),
+                InvokeDirectPtr(r(1), fct_id, r(2), 4),
+                RetPtr(r(1)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
 fn gen_new_object() {
     gen("fun f() -> Object { return Object(); }", |vm, code| {
         let cls_id = vm.cls_def_by_name("Object");

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -1966,6 +1966,24 @@ fn gen_new_object() {
 }
 
 #[test]
+fn gen_new_object_assign_to_var() {
+    gen(
+        "fun f() -> Object { let obj = Object(); return obj; }",
+        |vm, code| {
+            let cls_id = vm.cls_def_by_name("Object");
+            let ctor_id = vm.ctor_by_name("Object");
+            let expected = vec![
+                NewObject(r(1), cls_id),
+                InvokeDirectVoid(ctor_id, r(1), 1),
+                MovPtr(r(0), r(1)),
+                RetPtr(r(0)),
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
 fn gen_position_new_object() {
     let result = position("fun f() -> Object { return Object(); }");
     let expected = vec![(0, p(1, 34))];

--- a/tests/cannon/fct3.dora
+++ b/tests/cannon/fct3.dora
@@ -1,0 +1,73 @@
+fun main() {
+  let foo = Foo();
+  assert(foo.foo_bool() == true);
+  assert(foo.foo_byte() == 3Y);
+  assert(foo.foo_char() == '3');
+  assert(foo.foo_int() == 3);
+  assert(foo.foo_long() == 3L);
+  assert(foo.foo_float() == 3F);
+  assert(foo.foo_double() == 3D);
+  assert(foo.foo_string() == "3");
+}
+
+class Foo {
+  @cannon fun foo_bool() -> Bool {
+    return self.bar_bool();
+  }
+  @cannon fun bar_bool() -> Bool {
+    return true;
+  }
+
+  @cannon fun foo_byte() -> Byte {
+    return self.bar_byte();
+  }
+  @cannon fun bar_byte() -> Byte {
+    return 3Y;
+  }
+
+  @cannon fun foo_char() -> Char {
+    return self.bar_char();
+  }
+  @cannon fun bar_char() -> Char {
+    return '3';
+  }
+
+  @cannon fun foo_int() -> Int {
+    return self.bar_int();
+  }
+  @cannon fun bar_int() -> Int {
+    return 3;
+  }
+
+  @cannon fun foo_long() -> Long {
+    return self.bar_long();
+  }
+
+  @cannon fun bar_long() -> Long {
+    return 3L;
+  }
+
+  @cannon fun foo_float() -> Float {
+    return self.bar_float();
+  }
+
+  @cannon fun bar_float() -> Float {
+    return 3F;
+  }
+
+  @cannon fun foo_double() -> Double {
+    return self.bar_double();
+  }
+
+  @cannon fun bar_double() -> Double {
+    return 3D;
+  }
+
+  @cannon fun foo_string() -> String {
+    return self.bar_string();
+  }
+
+  @cannon fun bar_string() -> String {
+    return "3";
+  }
+}

--- a/tests/cannon/fct4.dora
+++ b/tests/cannon/fct4.dora
@@ -1,0 +1,81 @@
+fun main() {
+  let foo = Foo();
+  assert(foo.foo_bool() == false);
+  assert(foo.foo_byte() == 6Y);
+  assert(foo.foo_char() == '6');
+  assert(foo.foo_int() == 6);
+  assert(foo.foo_long() == 6L);
+  assert(foo.foo_float() == 6F);
+  assert(foo.foo_double() == 6D);
+  assert(foo.foo_string() == "33");
+}
+
+class Foo {
+  @cannon fun foo_bool() -> Bool {
+    return self.bar_bool(true);
+  }
+  fun bar_bool(a: Bool) -> Bool {
+    assert(a == true);
+    return !a;
+  }
+
+  @cannon fun foo_byte() -> Byte {
+    return self.bar_byte(3Y);
+  }
+  fun bar_byte(a: Byte) -> Byte {
+    assert(a == 3Y);
+    return (3+a.toInt()).toByte();
+  }
+
+  @cannon fun foo_char() -> Char {
+    return self.bar_char('3');
+  }
+  fun bar_char(a: Char) -> Char {
+    assert(a == '3');
+    return try! (3+a.toInt()).toChar();  
+  }
+
+  @cannon fun foo_int() -> Int {
+    return self.bar_int(3);
+  }
+  fun bar_int(a: Int) -> Int {
+    assert(a == 3);
+    return 3+a;
+  }
+
+  @cannon fun foo_long() -> Long {
+    return self.bar_long(3L);
+  }
+
+  fun bar_long(a: Long) -> Long {
+    assert(a == 3L);
+    return 3L+a;
+  }
+
+  @cannon fun foo_float() -> Float {
+    return self.bar_float(3F);
+  }
+
+  fun bar_float(a: Float) -> Float {
+    assert(a == 3F);
+    return 3F+a;
+  }
+
+  @cannon fun foo_double() -> Double {
+    return self.bar_double(3D);
+  }
+
+  fun bar_double(a: Double) -> Double {
+    assert(a == 3D);
+    return 3D+a;
+  }
+
+  @cannon fun foo_string() -> String {
+    return self.bar_string("3");
+  }
+
+  fun bar_string(a: String) -> String {
+    assert(a == "3");
+    return "3"+a;
+  }
+}

--- a/tests/nil3.dora
+++ b/tests/nil3.dora
@@ -1,3 +1,4 @@
+//= cannon
 //= error nil
 
 class Foo {


### PR DESCRIPTION
Until now, only DirectInvokeVoid was supported. I added the necessary code inside the bytecode generator and implemented the calls in cannon. Additionally, the call checks now for nil before calling the method.
Also I fixed a bug, where following code failed, because the object was not moved to the variable register and added a test case for it.
`let obj = Foo(1); // class Foo(let a: Int)
assert(obj.a == 1);
`