### PR TITLE
bytecode: fix method call

### DIFF
--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -1111,6 +1111,29 @@ fn gen_fct_call_int_with_3_args() {
 }
 
 #[test]
+fn gen_method_call_void_check_correct_self() {
+    gen(
+        "
+            fun f(i: Int, foo: Foo) { foo.g(); }
+            class Foo {
+                fun g() { }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(1)),
+                InvokeDirectVoid(fct_id, r(2), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
 fn gen_method_call_void_with_0_args() {
     gen(
         "

--- a/tests/obj1.dora
+++ b/tests/obj1.dora
@@ -1,3 +1,4 @@
+//= cannon
 fun main() {
   Foo();
 }

--- a/tests/obj2.dora
+++ b/tests/obj2.dora
@@ -1,3 +1,4 @@
+//= cannon
 fun main() {
   let obj = Foo(1);
   assert(obj.a == 1);

--- a/tests/obj3.dora
+++ b/tests/obj3.dora
@@ -1,3 +1,4 @@
+//= cannon
 fun main() {
   let o1 = Foo();
   let o2 = o1;

--- a/tests/obj4.dora
+++ b/tests/obj4.dora
@@ -1,4 +1,6 @@
+//= cannon
 fun main() {
+  let i = 1;
   let o1 = Foo();
   let o2 = o1.me();
   assert(o1 === o2);

--- a/tests/obj5.dora
+++ b/tests/obj5.dora
@@ -1,3 +1,4 @@
+//= cannon
 fun main() {
   foo();
 }

--- a/tests/obj6.dora
+++ b/tests/obj6.dora
@@ -1,3 +1,4 @@
+//= cannon
 fun main() {
   let f = Foo(12);
   var a1 = f.a1();

--- a/tests/obj7.dora
+++ b/tests/obj7.dora
@@ -1,3 +1,4 @@
+//= cannon
 fun main() {
   let f1 = Foo1(1);
   let f2 = Foo2(1, 2);

--- a/tests/obj8.dora
+++ b/tests/obj8.dora
@@ -1,3 +1,4 @@
+//= cannon
 fun main() {
   let f = Foo(1, 2);
 

--- a/tests/obj9.dora
+++ b/tests/obj9.dora
@@ -1,3 +1,4 @@
+//= cannon
 fun main() {
     t(A());
     t(B());


### PR DESCRIPTION
As you mentioned to me, the bytecode generator didn't handle method calls correctly. Instead of moving the called object to the corresponding argument register, it pushed `self` of the current function.

As currently `var_self` hasn't any check to assure the function has self, it doesn't throw an error, but returns the first variable (=`Register(0)`). Because of this, some tests coincidentally worked, as the register for the called object was `Register(0)`. I didn't changed this behavior for now, but added a test to assure the bytecode generator handles this correctly.