### PR TITLE
Allow defining and calling methods without parentheses

### DIFF
--- a/dora-parser/src/ast.rs
+++ b/dora-parser/src/ast.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 #[cfg(test)]
 use crate::interner::Interner;
-
 use crate::interner::Name;
 use crate::lexer::position::{Position, Span};
 use crate::lexer::token::{FloatSuffix, IntBase, IntSuffix};
@@ -667,7 +666,7 @@ pub struct Function {
     pub internal: bool,
     pub is_constructor: bool,
 
-    pub params: Vec<Param>,
+    pub params: Option<Vec<Param>>,
 
     pub return_type: Option<Type>,
     pub block: Option<Box<ExprBlockType>>,

--- a/dora-parser/src/ast/dump.rs
+++ b/dora-parser/src/ast/dump.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use crate::ast::*;
-
 use crate::interner::{ArcStr, Interner, Name};
 
 macro_rules! dump {
@@ -372,12 +371,15 @@ impl<'a> AstDumper<'a> {
             dump!(d, "internal = {}", fct.internal);
             dump!(d, "params");
             d.indent(|d| {
-                if fct.params.is_empty() {
-                    dump!(d, "no params");
-                } else {
-                    for param in &fct.params {
-                        d.dump_param(param);
+                if fct.params.is_some() {
+                    let params = fct.params.as_ref().unwrap();
+                    if !params.is_empty() {
+                        for param in params {
+                            d.dump_param(param);
+                        }
                     }
+                } else {
+                    dump!(d, "no params");
                 }
             });
 

--- a/dora-parser/src/ast/visit.rs
+++ b/dora-parser/src/ast/visit.rs
@@ -204,7 +204,7 @@ pub fn walk_field<V: Visitor>(v: &mut V, f: &Field) {
 }
 
 pub fn walk_fct<V: Visitor>(v: &mut V, f: &Function) {
-    for p in &f.params {
+    for p in iter_some(&f.params) {
         v.visit_param(p);
     }
 
@@ -381,5 +381,12 @@ pub fn walk_expr<V: Visitor>(v: &mut V, e: &Expr) {
         Expr::LitStr(_) => {}
         Expr::LitBool(_) => {}
         Expr::Ident(_) => {}
+    }
+}
+
+fn iter_some<T>(opt: &Option<Vec<T>>) -> impl Iterator<Item = &T> {
+    match opt {
+        Some(opt) => opt.iter(),
+        None => (&[]).iter(),
     }
 }

--- a/dora-parser/src/builder.rs
+++ b/dora-parser/src/builder.rs
@@ -1,8 +1,6 @@
 use crate::ast::*;
-
 use crate::interner::*;
 use crate::lexer::position::{Position, Span};
-
 use crate::parser::NodeIdGenerator;
 
 pub struct Builder<'a> {
@@ -81,7 +79,7 @@ pub struct BuilderFct<'a> {
     is_public: bool,
     is_constructor: bool,
     return_type: Option<Type>,
-    params: Vec<Param>,
+    params: Option<Vec<Param>>,
     block: Option<Box<ExprBlockType>>,
 }
 
@@ -94,7 +92,7 @@ impl<'a> BuilderFct<'a> {
             is_public: false,
             is_constructor: false,
             return_type: None,
-            params: Vec::new(),
+            params: None,
             block: None,
         }
     }
@@ -108,9 +106,12 @@ impl<'a> BuilderFct<'a> {
     ) -> &mut BuilderFct<'a> {
         let id = self.id_generator.next();
 
+        if self.params.is_none() {
+            self.params = Some(Vec::new());
+        }
         let param = Param {
             id,
-            idx: self.params.len() as u32,
+            idx: self.params.as_ref().unwrap().len() as u32,
             name,
             variadic,
             pos,
@@ -118,7 +119,7 @@ impl<'a> BuilderFct<'a> {
             data_type: ty,
         };
 
-        self.params.push(param);
+        self.params.as_mut().unwrap().push(param);
         self
     }
 

--- a/dora/src/lib.rs
+++ b/dora/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(allocator_api)]
 #![feature(llvm_asm)]
 #![feature(new_uninit)]
+#![feature(option_result_contains)]
 
 extern crate alloc;
 

--- a/dora/src/semck/fctdefck.rs
+++ b/dora/src/semck/fctdefck.rs
@@ -4,6 +4,7 @@ use crate::error::msg::SemError;
 use crate::semck::{self, AllowSelf, TypeParamContext};
 use crate::sym::{NestedSymTable, Sym};
 use crate::ty::SourceType;
+use crate::utils::iter_some;
 use crate::vm::{self, Fct, FctId, FctParent, TypeParamId, VM};
 
 pub fn check(vm: &VM) {
@@ -138,7 +139,7 @@ pub fn check(vm: &VM) {
             }
         }
 
-        for p in &ast.params {
+        for p in iter_some(&ast.params) {
             if fct.variadic_arguments {
                 vm.diag
                     .lock()

--- a/dora/src/utils.rs
+++ b/dora/src/utils.rs
@@ -1,5 +1,13 @@
-use parking_lot::{Mutex, MutexGuard};
 use std::sync::Arc;
+
+use parking_lot::{Mutex, MutexGuard};
+
+pub fn iter_some<T>(opt: &Option<Vec<T>>) -> impl Iterator<Item = &T> {
+    match opt {
+        Some(opt) => opt.iter(),
+        None => (&[]).iter(),
+    }
+}
 
 pub struct GrowableVec<T> {
     elements: Mutex<Vec<Arc<T>>>,

--- a/tests/fn9.dora
+++ b/tests/fn9.dora
@@ -1,0 +1,7 @@
+fun main() {
+  assert(Foo(22).b == 23);
+}
+
+class Foo(let a: Int32) {
+  fun b: Int32 = self.a + 1;
+}


### PR DESCRIPTION
### Why do this?

The idea is to allow decoupling how a member is implemented from how it is exposed,
allowing authors to reevaluate the costs of (re-)computation vs. storage
without breaking every existing caller of such code.

This approach is based on experience with earlier attempts, like

- Java's "use getters/setters everywhere, just in case"
- C#'s "use properties, which are source incompatible with getters/setters and binary incompatible with fields"

but provides the desired decoupling while _not_ breaking user code and avoiding other drawbacks of older designs as well.

As the distinction between fun, let and var is nevertheless important,
the idea is that an IDE should use different colors when referring to such members
(which provides more useful information than in Java's or C#'s case).

### When to use this?

The idea is that methods which are "constant" for the instance they are called on
are defined without (), and methods that mutate their instance are defined with ().

Example:
    `true.not, 1.toString, array.length, iterator.hasNext`
        vs.
    `iterator.next(), random.nextInt(), ...`

### Further steps

This is one of the steppingstones to allow classes to directly implement traits with their constructor parameters (https://github.com/dinfuehr/dora/issues/56):

```
trait HasAge {
  fun age -> Int;
}
class Person(let name: String, let age: Int) impl HasAge {
  // no further work to be done to implement HasAge
  // let age acts as an implementation for the trait's fun age
}
```
