### PR TITLE
cannon: support invocation of virtual calls

### DIFF
--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -387,7 +387,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         let fct = self.vm.fcts.idx(fct_id);
         let fct = fct.read();
 
-        let callee_id = if fct.kind.is_definition() {
+        let callee_id = if fct.kind.is_definition() && !fct.is_virtual() {
             unimplemented!()
         } else {
             fct_id
@@ -451,38 +451,16 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             }
 
             CallType::Method(_, _, _) => {
-                if return_type.is_unit() {
-                    self.gen
-                        .emit_invoke_direct_void(callee_id, start_reg, num_args);
+                if fct.is_virtual() {
+                    self.visit_call_virtual(
+                        return_type,
+                        callee_id,
+                        start_reg,
+                        num_args,
+                        return_reg,
+                    );
                 } else {
-                    let return_type: BytecodeType = return_type.into();
-
-                    match return_type.into() {
-                        BytecodeType::Bool => self
-                            .gen
-                            .emit_invoke_direct_bool(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Byte => self
-                            .gen
-                            .emit_invoke_direct_byte(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Char => self
-                            .gen
-                            .emit_invoke_direct_char(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Int => self
-                            .gen
-                            .emit_invoke_direct_int(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Long => self
-                            .gen
-                            .emit_invoke_direct_long(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Float => self
-                            .gen
-                            .emit_invoke_direct_float(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Double => self
-                            .gen
-                            .emit_invoke_direct_double(return_reg, callee_id, start_reg, num_args),
-                        BytecodeType::Ptr => self
-                            .gen
-                            .emit_invoke_direct_ptr(return_reg, callee_id, start_reg, num_args),
-                    }
+                    self.visit_call_direct(return_type, callee_id, start_reg, num_args, return_reg);
                 }
             }
             CallType::Expr(_, _) => unimplemented!(),
@@ -539,6 +517,92 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             }
         } else {
             return_reg
+        }
+    }
+
+    fn visit_call_virtual(
+        &mut self,
+        return_type: BuiltinType,
+        callee_id: FctId,
+        start_reg: Register,
+        num_args: usize,
+        return_reg: Register,
+    ) {
+        if return_type.is_unit() {
+            self.gen
+                .emit_invoke_virtual_void(callee_id, start_reg, num_args);
+        } else {
+            let return_type: BytecodeType = return_type.into();
+
+            match return_type.into() {
+                BytecodeType::Bool => self
+                    .gen
+                    .emit_invoke_virtual_bool(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Byte => self
+                    .gen
+                    .emit_invoke_virtual_byte(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Char => self
+                    .gen
+                    .emit_invoke_virtual_char(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Int => self
+                    .gen
+                    .emit_invoke_virtual_int(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Long => self
+                    .gen
+                    .emit_invoke_virtual_long(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Float => self
+                    .gen
+                    .emit_invoke_virtual_float(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Double => self
+                    .gen
+                    .emit_invoke_virtual_double(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Ptr => self
+                    .gen
+                    .emit_invoke_virtual_ptr(return_reg, callee_id, start_reg, num_args),
+            }
+        }
+    }
+
+    fn visit_call_direct(
+        &mut self,
+        return_type: BuiltinType,
+        callee_id: FctId,
+        start_reg: Register,
+        num_args: usize,
+        return_reg: Register,
+    ) {
+        if return_type.is_unit() {
+            self.gen
+                .emit_invoke_direct_void(callee_id, start_reg, num_args);
+        } else {
+            let return_type: BytecodeType = return_type.into();
+
+            match return_type.into() {
+                BytecodeType::Bool => self
+                    .gen
+                    .emit_invoke_direct_bool(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Byte => self
+                    .gen
+                    .emit_invoke_direct_byte(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Char => self
+                    .gen
+                    .emit_invoke_direct_char(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Int => self
+                    .gen
+                    .emit_invoke_direct_int(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Long => self
+                    .gen
+                    .emit_invoke_direct_long(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Float => self
+                    .gen
+                    .emit_invoke_direct_float(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Double => self
+                    .gen
+                    .emit_invoke_direct_double(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Ptr => self
+                    .gen
+                    .emit_invoke_direct_ptr(return_reg, callee_id, start_reg, num_args),
+            }
         }
     }
 

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -2079,6 +2079,196 @@ fn gen_method_call_ptr_with_3_args() {
 }
 
 #[test]
+fn gen_virtual_method_call_void_check_correct_self() {
+    gen(
+        "
+            fun f(i: Int, foo: Foo) { foo.g(); }
+            @open @abstract class Bar {
+                @open @abstract fun g();
+            }
+            class Foo : Bar {
+                @override fun g() {}
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(2), r(1)),
+                InvokeVirtualVoid(fct_id, r(2), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_virtual_method_call_void_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            @open @abstract class Bar {
+                @open @abstract fun g();
+            }
+            class Foo : Bar {
+                @override fun g() {}
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeVirtualVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_virtual_method_call_void_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(1); }
+            @open @abstract class Bar {
+                @open @abstract fun g(a: Int);
+            }
+            class Foo : Bar {
+                @override fun g(a: Int) {}
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                ConstInt(r(2), 1),
+                InvokeVirtualVoid(fct_id, r(1), 2),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_virtual_method_call_void_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(1, 2, 3); }
+            @open @abstract class Bar {
+                @open @abstract fun g(a: Int, b: Int, c: Int);
+            }
+            class Foo : Bar {
+                @override fun g(a: Int, b: Int, c: Int) {}
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                ConstInt(r(2), 1),
+                ConstInt(r(3), 2),
+                ConstInt(r(4), 3),
+                InvokeVirtualVoid(fct_id, r(1), 4),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_virtual_method_call_int_with_0_args() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(); }
+            @open @abstract class Bar {
+                @open @abstract fun g() -> Int;
+            }
+            class Foo : Bar {
+                @override fun g() -> Int { 1 }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                InvokeVirtualVoid(fct_id, r(1), 1),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_virtual_method_call_int_with_1_arg() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(1); }
+            @open @abstract class Bar {
+                @open @abstract fun g(a: Int) -> Int;
+            }
+            class Foo : Bar {
+                @override fun g(a: Int) -> Int { 1 }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                ConstInt(r(2), 1),
+                InvokeVirtualVoid(fct_id, r(1), 2),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
+fn gen_virtual_method_call_int_with_3_args() {
+    gen(
+        "
+            fun f(foo: Foo) { foo.g(1, 2, 3); }
+            @open @abstract class Bar {
+                @open @abstract fun g(a: Int, b: Int, c: Int) -> Int;
+            }
+            class Foo : Bar {
+                @override fun g(a: Int, b: Int, c: Int) -> Int { 1 }
+            }
+            ",
+        |vm, code| {
+            let fct_id = vm
+                .cls_method_by_name("Foo", "g", false)
+                .expect("g not found");
+            let expected = vec![
+                MovPtr(r(1), r(0)),
+                ConstInt(r(2), 1),
+                ConstInt(r(3), 2),
+                ConstInt(r(4), 3),
+                InvokeVirtualVoid(fct_id, r(1), 4),
+                RetVoid,
+            ];
+            assert_eq!(expected, code);
+        },
+    );
+}
+
+#[test]
 fn gen_new_object() {
     gen("fun f() -> Object { return Object(); }", |vm, code| {
         let cls_id = vm.cls_def_by_name("Object");

--- a/dora/src/cannon/codegen.rs
+++ b/dora/src/cannon/codegen.rs
@@ -1100,6 +1100,71 @@ where
         self.asm.throw(REG_RESULT, position);
     }
 
+    fn emit_invoke_virtual_void(&mut self, fct_id: FctId, start_reg: Register, num: u32) {
+        self.emit_invoke_virtual(fct_id, start_reg, num, None);
+    }
+
+    fn emit_invoke_virtual_generic(
+        &mut self,
+        dest: Register,
+        fct_id: FctId,
+        start_reg: Register,
+        num: u32,
+    ) {
+        let bytecode_type = self.bytecode.register_type(dest);
+        let offset = self.bytecode.register_offset(dest);
+
+        let reg = self.emit_invoke_virtual(fct_id, start_reg, num, Some(bytecode_type));
+
+        self.asm
+            .store_mem(bytecode_type.mode(), Mem::Local(offset), reg);
+    }
+
+    fn emit_invoke_virtual(
+        &mut self,
+        fct_id: FctId,
+        start_reg: Register,
+        num: u32,
+        bytecode_type: Option<BytecodeType>,
+    ) -> AnyReg {
+        assert!(num > 0);
+
+        let bytecode_type_self = self.bytecode.register_type(start_reg);
+        let offset_self = self.bytecode.register_offset(start_reg);
+        let position = self.bytecode.offset_position(self.current_offset.to_u32());
+        assert_eq!(bytecode_type_self, BytecodeType::Ptr);
+
+        self.asm.load_mem(
+            bytecode_type_self.mode(),
+            REG_RESULT.into(),
+            Mem::Local(offset_self),
+        );
+
+        let fct = self.vm.fcts.idx(fct_id);
+        let fct = fct.read();
+
+        assert!(fct.type_params.is_empty());
+
+        self.emit_invoke_arguments(start_reg, num);
+
+        // handling of class and function type parameters has to implemented
+        let cls_type_params = TypeList::Empty;
+        let name = fct.full_name(self.vm);
+        self.asm.emit_comment(format!("call virtual {}", name));
+        let vtable_index = fct.vtable_index.unwrap();
+        let gcpoint = GcPoint::from_offsets(self.references.clone());
+
+        let (reg, ty) = match bytecode_type {
+            Some(bytecode_type) => (result_reg(bytecode_type), bytecode_type.into()),
+            None => (REG_RESULT.into(), BuiltinType::Unit),
+        };
+
+        self.asm
+            .indirect_call(vtable_index, position, gcpoint, ty, cls_type_params, reg);
+
+        reg
+    }
+
     fn emit_invoke_direct_void(&mut self, fct_id: FctId, start_reg: Register, num: u32) {
         self.emit_invoke_direct(fct_id, start_reg, num, None);
     }
@@ -1993,80 +2058,80 @@ impl<'a, 'ast: 'a> BytecodeVisitor for CannonCodeGen<'a, 'ast> {
         self.emit_invoke_direct_generic(dest, fct, start, count);
     }
 
-    fn visit_invoke_virtual_void(&mut self, _fct: FctId, _start: Register, _count: u32) {
-        unimplemented!();
+    fn visit_invoke_virtual_void(&mut self, fct: FctId, start: Register, count: u32) {
+        self.emit_invoke_virtual_void(fct, start, count);
     }
     fn visit_invoke_virtual_bool(
         &mut self,
-        _dest: Register,
-        _fct: FctId,
-        _start: Register,
-        _count: u32,
+        dest: Register,
+        fct: FctId,
+        start: Register,
+        count: u32,
     ) {
-        unimplemented!();
+        self.emit_invoke_virtual_generic(dest, fct, start, count);
     }
     fn visit_invoke_virtual_byte(
         &mut self,
-        _dest: Register,
-        _fct: FctId,
-        _start: Register,
-        _count: u32,
+        dest: Register,
+        fct: FctId,
+        start: Register,
+        count: u32,
     ) {
-        unimplemented!();
+        self.emit_invoke_virtual_generic(dest, fct, start, count);
     }
     fn visit_invoke_virtual_char(
         &mut self,
-        _dest: Register,
-        _fct: FctId,
-        _start: Register,
-        _count: u32,
+        dest: Register,
+        fct: FctId,
+        start: Register,
+        count: u32,
     ) {
-        unimplemented!();
+        self.emit_invoke_virtual_generic(dest, fct, start, count);
     }
     fn visit_invoke_virtual_int(
         &mut self,
-        _dest: Register,
-        _fct: FctId,
-        _start: Register,
-        _count: u32,
+        dest: Register,
+        fct: FctId,
+        start: Register,
+        count: u32,
     ) {
-        unimplemented!();
+        self.emit_invoke_virtual_generic(dest, fct, start, count);
     }
     fn visit_invoke_virtual_long(
         &mut self,
-        _dest: Register,
-        _fct: FctId,
-        _start: Register,
-        _count: u32,
+        dest: Register,
+        fct: FctId,
+        start: Register,
+        count: u32,
     ) {
-        unimplemented!();
+        self.emit_invoke_virtual_generic(dest, fct, start, count);
     }
     fn visit_invoke_virtual_float(
         &mut self,
-        _dest: Register,
-        _fct: FctId,
-        _start: Register,
-        _count: u32,
+        dest: Register,
+        fct: FctId,
+        start: Register,
+        count: u32,
     ) {
-        unimplemented!();
+        self.emit_invoke_virtual_generic(dest, fct, start, count);
     }
     fn visit_invoke_virtual_double(
         &mut self,
-        _dest: Register,
-        _fct: FctId,
-        _start: Register,
-        _count: u32,
+        dest: Register,
+        fct: FctId,
+        start: Register,
+        count: u32,
     ) {
-        unimplemented!();
+        self.emit_invoke_virtual_generic(dest, fct, start, count);
     }
     fn visit_invoke_virtual_ptr(
         &mut self,
-        _dest: Register,
-        _fct: FctId,
-        _start: Register,
-        _count: u32,
+        dest: Register,
+        fct: FctId,
+        start: Register,
+        count: u32,
     ) {
-        unimplemented!();
+        self.emit_invoke_virtual_generic(dest, fct, start, count);
     }
 
     fn visit_invoke_static_void(&mut self, fct: FctId, start: Register, count: u32) {

--- a/tests/virt-call1.dora
+++ b/tests/virt-call1.dora
@@ -1,3 +1,4 @@
+//= cannon
 @open @abstract class Foo {
     @open @abstract fun test() -> Int;
 }


### PR DESCRIPTION
As discussed I discontinued my effort to implement the various operations on types and focused to get some of the benchmarks to run. So I implemented the virtual method invocation, which was already defined as bytecode and as visitor functions, but the generator and cannon didn't implement it or not correctly.

The changes are not really complex, mostly some refactoring in the bytecode generator and the implementation details of the corresponding virtual invocation in cannon. At least I think that, maybe I missed the bigger picture.