### PR TITLE
cannon: fix error when storing float value in field; add test for StoreField

### DIFF
--- a/dora/src/cannon/codegen.rs
+++ b/dora/src/cannon/codegen.rs
@@ -853,8 +853,10 @@ where
         let bytecode_type = self.bytecode.register_type(src);
         let offset = self.bytecode.register_offset(src);
 
+        let result_reg = result_reg(bytecode_type);
+
         self.asm
-            .load_mem(bytecode_type.mode(), REG_RESULT.into(), Mem::Local(offset));
+            .load_mem(bytecode_type.mode(), result_reg, Mem::Local(offset));
 
         let bytecode_type = self.bytecode.register_type(obj);
         let offset = self.bytecode.register_offset(obj);
@@ -870,7 +872,7 @@ where
             field.ty.mode(),
             REG_TMP1,
             field.offset,
-            REG_RESULT.into(),
+            result_reg.into(),
             pos,
             write_barrier,
             card_table_offset,

--- a/tests/cannon/load1.dora
+++ b/tests/cannon/load1.dora
@@ -10,8 +10,9 @@ fun main() {
     assert(loadString(FooString("1")) == "1");
 
     let ptr = FooInt(1);
-    assert(loadPtr(ptr) === ptr);
-    assert(loadPtr(ptr).y == 1)
+    let fooPtr = FooPtr(ptr);
+    assert(loadPtr(fooPtr) === ptr);
+    assert(loadPtr(fooPtr).y == 1);
 }
 
 @cannon fun loadBool(x: FooBool) -> Bool {
@@ -38,8 +39,8 @@ fun main() {
 @cannon fun loadString(x: FooString) -> String {
     return x.y;
 }
-@cannon fun loadPtr(x: FooInt) -> FooInt {
-    return x;
+@cannon fun loadPtr(x: FooPtr) -> FooInt {
+    return x.y;
 }
 
 class FooBool(let y: Bool)

--- a/tests/cannon/store1.dora
+++ b/tests/cannon/store1.dora
@@ -1,0 +1,88 @@
+fun main() {
+    let fooBool = FooBool();
+    let fooByte = FooByte();
+    let fooChar = FooChar();
+    let fooInt = FooInt();
+    let fooLong = FooLong();
+    let fooFloat = FooFloat();
+    let fooDouble = FooDouble();
+    let fooString = FooString();
+    let fooPtr = FooPtr();
+
+    storeBool(fooBool, true);
+    storeByte(fooByte, 1Y);
+    storeChar(fooChar, '1');
+    storeInt(fooInt, 23);
+    storeLong(fooLong, 1L);
+    storeFloat(fooFloat, 1F);
+    storeDouble(fooDouble, 1D);
+    storeString(fooString, "1");
+    storePtr(fooPtr, fooInt);
+
+    assert(fooBool.y == true);
+    assert(fooByte.y == 1Y);
+    assert(fooChar.y == '1');
+    assert(fooInt.y == 23);
+    assert(fooLong.y == 1L);
+    assert(fooFloat.y == 1F);
+    assert(fooDouble.y == 1D);
+    assert(fooString.y == "1");
+    assert(fooPtr.y === fooInt);
+    assert(fooPtr.y.y == 23)
+}
+
+@cannon fun storeBool(x: FooBool, z: Bool) {
+    x.y = z;
+}
+@cannon fun storeByte(x: FooByte, z: Byte) {
+    x.y = z;
+}
+@cannon fun storeChar(x: FooChar, z: Char) {
+    x.y = z;
+}
+@cannon fun storeInt(x: FooInt, z: Int) {
+    x.y = z;
+}
+@cannon fun storeLong(x: FooLong, z: Long) {
+    x.y = z;
+}
+@cannon fun storeFloat(x: FooFloat, z: Float) {
+    x.y = z;
+}
+@cannon fun storeDouble(x: FooDouble, z: Double) {
+    x.y = z;
+}
+@cannon fun storeString(x: FooString, z: String) {
+    x.y = z;
+}
+@cannon fun storePtr(x: FooPtr, z: FooInt) {
+    x.y = z;
+}
+
+class FooBool() {
+    var y: Bool;
+}
+class FooByte() {
+    var y: Byte;
+}
+class FooChar() {
+    var y: Char;
+}
+class FooInt() {
+    var y: Int;
+}
+class FooLong() {
+    var y: Long;
+}
+class FooFloat() {
+    var y: Float;
+}
+class FooDouble() {
+    var y: Double;
+}
+class FooString() {
+    var y: String;
+}
+class FooPtr() {
+    var y: FooInt;
+}


### PR DESCRIPTION
cannon ignored the type of the value and tried to store the value into an integer register. I fixed this and also added tests for this.

Additionally, I fixed the test for LoadFieldPtr, as it didn't load any field and instead just returned the argument.