### PR TITLE
Add library code for Zero trait

### DIFF
--- a/dora/stdlib/Array.dora
+++ b/dora/stdlib/Array.dora
@@ -68,6 +68,8 @@ fun arrayNew[T: Default](len: Int) -> Array[T] {
   return array;
 }
 
+fun arrayZero[T: Zero](len: Int) -> Array[T] = return Array[T](len);
+
 fun arrayCopy[T](src: Array[T], srcPos: Int, dest: Array[T], destPos: Int, len: Int) {
   var i = 0;
 

--- a/dora/stdlib/Default.dora
+++ b/dora/stdlib/Default.dora
@@ -1,5 +1,5 @@
 trait Default {
-  @static fun default() -> Self; // should be `let` instead of `fun`
+  @static fun default() -> Self;
 }
 
 impl Default for Bool {
@@ -8,6 +8,10 @@ impl Default for Bool {
 
 impl Default for Byte {
   @static fun default() -> Byte = 0Y;
+}
+
+impl Default for Char {
+  @static fun default() -> Char = '\0';
 }
 
 impl Default for Int {
@@ -29,3 +33,10 @@ impl Default for Double {
 impl Default for String {
   @static fun default() -> String = "";
 }
+
+// feature not implemented yet
+/*
+impl Default for Option[T] {
+  @static fun default() -> Option[T] = ...;
+}
+*/

--- a/dora/stdlib/Zero.dora
+++ b/dora/stdlib/Zero.dora
@@ -1,0 +1,59 @@
+// Implementations of the `Zero` trait indicate that zero-initialized memory of the appropriate size can be allocated to
+// represent a valid value of that type.¹
+//
+//   let numbers: Array[Int] = Array.ofZero[Int](4)
+//   assert(numbers == Array(0, 0, 0, 0)
+//
+//   let strings: Array[Option[String]] = Array.ofZero[Option[String]](2)
+//   assert(strings == Array(None, None)
+//
+// `Zero` is a special trait whose implementations are automatically derived for qualifying types.
+// It cannot be implemented manually.
+// A type qualifies if it is either `Option`, or obeys all of the following rules ...
+// - The type is a struct.
+// - The type does not contain any reference-types directly or transitively.
+//
+// ¹ This means that implementations of `Zero` may make full use of the operating system's optimization of `calloc`
+//   (lazy allocation, lazy zeroing, copy on write, etc.), unlike implementations of the `Default` trait –
+//   which invoke an user-defined function to initialize each individual element (malloc & loop with function calls).
+
+
+// @restricted / @internal
+trait Zero {
+  @static fun zero() -> Self; // should be `let` instead of `fun`
+}
+
+impl Zero for Bool {
+  @static fun zero() -> Bool = false;
+}
+
+impl Zero for Byte {
+  @static fun zero() -> Byte = 0Y;
+}
+
+impl Zero for Char {
+  @static fun zero() -> Char = '\0';
+}
+
+impl Zero for Int {
+  @static fun zero() -> Int = 0;
+}
+
+impl Zero for Long {
+  @static fun zero() -> Long = 0L;
+}
+
+impl Zero for Float {
+  @static fun zero() -> Float = 0.0F;
+}
+
+impl Zero for Double {
+  @static fun zero() -> Double = 0.0;
+}
+
+// feature not implemented yet
+/*
+impl Zero for Option[T] {
+  @static fun zero() -> Option[T] = ...;
+}
+*/


### PR DESCRIPTION
This is the library part for the `Zero` trait – there is a small bit of compiler support necessary right now that records during typechecking whether a class (+ generics) supports zero or not.

The difference between `Default` and `Zero` is that `Default` can be implemented by user code in whatever fashion desired – while `Zero` is more of a marker that any zero-initialized memory of the appropriate size constitutes a valid instance.

This pretty much means only `structs` who do not contain any reference types¹ can be `Zero` – which is good enough for numbers (which are all "honorary" structs, but declared as classes currently), `Option`¹, probably time-/date-related stuff and much more .

¹ We pretend we already live in a world without `nil` here.
² If one squints hard enough.
