### PR TITLE
cannon: not intrinsic (int)

### DIFF
--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -850,6 +850,13 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
 
                     dest
                 }
+                Intrinsic::IntNot => {
+                    let dest = self.ensure_register(dest, BytecodeType::Int);
+                    let src = self.visit_expr(&expr.opnd, DataDest::Alloc);
+                    self.gen.emit_not_int(dest, src);
+
+                    dest
+                }
                 Intrinsic::LongNot => {
                     let dest = self.ensure_register(dest, BytecodeType::Long);
                     let src = self.visit_expr(&expr.opnd, DataDest::Alloc);

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -378,6 +378,10 @@ impl BytecodeWriter {
         self.emit_reg2(BytecodeOpcode::NotBool, dest, src);
     }
 
+    pub fn emit_not_int(&mut self, dest: Register, src: Register) {
+        self.emit_reg2(BytecodeOpcode::NotInt, dest, src);
+    }
+
     pub fn emit_not_long(&mut self, dest: Register, src: Register) {
         self.emit_reg2(BytecodeOpcode::NotLong, dest, src);
     }

--- a/dora/src/cannon/codegen.rs
+++ b/dora/src/cannon/codegen.rs
@@ -1600,8 +1600,8 @@ impl<'a, 'ast: 'a> BytecodeVisitor for CannonCodeGen<'a, 'ast> {
     fn visit_not_bool(&mut self, dest: Register, src: Register) {
         self.emit_not_bool(dest, src);
     }
-    fn visit_not_int(&mut self, _dest: Register, _src: Register) {
-        unimplemented!();
+    fn visit_not_int(&mut self, dest: Register, src: Register) {
+        self.emit_not_int(dest, src);
     }
     fn visit_not_long(&mut self, dest: Register, src: Register) {
         self.emit_not_int(dest, src);

--- a/tests/cannon/int1.dora
+++ b/tests/cannon/int1.dora
@@ -1,5 +1,5 @@
 fun main() {
-    // assert(not(20) == 245);
+    assert(not(20) == -21);
 
     assert(add(20, 7) == 27);
     assert(sub(20, 7) == 13);


### PR DESCRIPTION
As mentioned in #174 this adds support for the missing `!` operator for Int.