### PR TITLE
Add runtime support for Zero trait

### DIFF
--- a/dora/src/semck.rs
+++ b/dora/src/semck.rs
@@ -257,7 +257,7 @@ pub fn read_type<'ast>(vm: &VM<'ast>, file: FileId, t: &'ast Type) -> Option<Bui
                                 let cls = cls.read();
 
                                 for &trait_bound in &tp.trait_bounds {
-                                    if !cls.traits.contains(&trait_bound) {
+                                    if !cls.implements_trait(vm, trait_bound) {
                                         let bound = vm.traits[trait_bound].read();
                                         let name = ty.name(vm);
                                         let trait_name = vm.interner.str(bound.name).to_string();

--- a/dora/src/semck/prelude.rs
+++ b/dora/src/semck/prelude.rs
@@ -43,8 +43,9 @@ pub fn internal_classes<'ast>(vm: &mut VM<'ast>) {
     vm.vips.error_class = internal_class(vm, "Error", None);
     vm.vips.exception_class = internal_class(vm, "Exception", None);
     vm.vips.stack_trace_element_class = internal_class(vm, "StackTraceElement", None);
-    vm.vips.stringable_trait = find_trait(vm, "Stringable");
 
+    vm.vips.stringable_trait = find_trait(vm, "Stringable");
+    vm.vips.zero_trait = find_trait(vm, "Zero");
     *vm.vips.iterator_trait.lock() = Some(find_trait(vm, "Iterator"));
 
     internal_free_classes(vm);

--- a/dora/src/semck/typeparamck.rs
+++ b/dora/src/semck/typeparamck.rs
@@ -118,7 +118,7 @@ impl<'a, 'ast> TypeParamCheck<'a, 'ast> {
         let cls = cls.read();
 
         for &trait_bound in &tp.trait_bounds {
-            if !cls.traits.contains(&trait_bound) {
+            if !cls.implements_trait(self.vm, trait_bound) {
                 self.fail_trait_bound(trait_bound, ty);
                 succeeded = false;
             }

--- a/dora/src/ty.rs
+++ b/dora/src/ty.rs
@@ -171,7 +171,7 @@ impl BuiltinType {
         if let Some(cls_id) = self.cls_id(vm) {
             let cls = vm.classes.idx(cls_id);
             let cls = cls.read();
-            return cls.traits.contains(&trait_id);
+            return cls.implements_trait(vm, trait_id);
         }
 
         false

--- a/dora/src/typeck/tests.rs
+++ b/dora/src/typeck/tests.rs
@@ -2144,3 +2144,17 @@ fn test_incompatible_branches() {
         SemError::UnknownCtor("Foo".into(), vec!["Int".into()]),
     );
 }
+
+#[test]
+fn zero_trait_ok() {
+    ok("fun f() { arrayZero[Int](12); }");
+}
+
+#[test]
+fn zero_trait_err() {
+    err(
+        "fun f() { arrayZero[String](12); }",
+        pos(1, 28),
+        SemError::TraitBoundNotSatisfied("String".into(), "Zero".into()),
+    );
+}

--- a/dora/src/vm.rs
+++ b/dora/src/vm.rs
@@ -173,6 +173,7 @@ impl<'ast> VM<'ast> {
                 comparable_trait: empty_trait_id,
                 stringable_trait: empty_trait_id,
                 iterator_trait: Mutex::new(None),
+                zero_trait: empty_trait_id,
 
                 byte_array_def: Mutex::new(None),
                 int_array_def: Mutex::new(None),

--- a/dora/src/vm/class.rs
+++ b/dora/src/vm/class.rs
@@ -195,6 +195,10 @@ impl Class {
             }
         }
     }
+
+    pub fn implements_trait(&self, vm: &VM, trait_id: TraitId) -> bool {
+        self.traits.contains(&trait_id) || vm.vips.zero_trait == trait_id && !self.ty.is_cls()
+    }
 }
 
 pub fn find_field_in_class(

--- a/dora/src/vm/vip.rs
+++ b/dora/src/vm/vip.rs
@@ -30,6 +30,7 @@ pub struct KnownElements {
     pub comparable_trait: TraitId,
     pub stringable_trait: TraitId,
     pub iterator_trait: Mutex<Option<TraitId>>,
+    pub zero_trait: TraitId,
 
     pub byte_array_def: Mutex<Option<ClassDefId>>,
     pub int_array_def: Mutex<Option<ClassDefId>>,

--- a/dora/stdlib/Zero.dora
+++ b/dora/stdlib/Zero.dora
@@ -22,38 +22,3 @@
 trait Zero {
   @static fun zero() -> Self; // should be `let` instead of `fun`
 }
-
-impl Zero for Bool {
-  @static fun zero() -> Bool = false;
-}
-
-impl Zero for Byte {
-  @static fun zero() -> Byte = 0Y;
-}
-
-impl Zero for Char {
-  @static fun zero() -> Char = '\0';
-}
-
-impl Zero for Int {
-  @static fun zero() -> Int = 0;
-}
-
-impl Zero for Long {
-  @static fun zero() -> Long = 0L;
-}
-
-impl Zero for Float {
-  @static fun zero() -> Float = 0.0F;
-}
-
-impl Zero for Double {
-  @static fun zero() -> Double = 0.0;
-}
-
-// feature not implemented yet
-/*
-impl Zero for Option[T] {
-  @static fun zero() -> Option[T] = ...;
-}
-*/

--- a/tests/array/array-zero.dora
+++ b/tests/array/array-zero.dora
@@ -1,0 +1,29 @@
+fun main() {
+    let array = arrayZero[Bool](10);
+    assert(array(0) == false);
+    assert(array(9) == false);
+
+    let array = arrayZero[Byte](10);
+    assert(array(0) == 0Y);
+    assert(array(9) == 0Y);
+
+    let array = arrayZero[Char](10);
+    assert(array(0) == '\0');
+    assert(array(9) == '\0');
+
+    let array = arrayZero[Int](10);
+    assert(array(0) == 0);
+    assert(array(9) == 0);
+
+    let array = arrayZero[Long](10);
+    assert(array(0) == 0L);
+    assert(array(9) == 0L);
+
+    let array = arrayZero[Float](10);
+    assert(array(0) == 0.0F);
+    assert(array(9) == 0.0F);
+
+    let array = arrayZero[Double](10);
+    assert(array(0) == 0.0);
+    assert(array(9) == 0.0);
+}


### PR DESCRIPTION
@dinfuehr Where should I add that check `if cls.is_zero_initializable {add_zero_trait()/add_zero_impl() }`?

(I could also patch the "well-known" classes like `Int`, `Long` etc. immediately in `prelude::internal_classes`, but I think that would scale poorly as soon as users can define their own zero-initializable structs.)
