### PR TITLE
bytecode: emit InvokeStatic for method calls without nil check (e.g. Int.toString())

### DIFF
--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -400,7 +400,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         let fct = self.vm.fcts.idx(fct_id);
         let fct = fct.read();
 
-        if let FctKind::Builtin(_intrinsic) = fct.kind {
+        if (fct.kind.is_definition() && !fct.is_virtual()) || fct.kind.is_intrinsic() {
             unimplemented!()
         }
 

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -400,25 +400,16 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         let fct = self.vm.fcts.idx(fct_id);
         let fct = fct.read();
 
-        let callee_id = if fct.kind.is_definition() && !fct.is_virtual() {
-            unimplemented!()
-        } else {
-            fct_id
-        };
-
-        let callee = self.vm.fcts.idx(callee_id);
-        let callee = callee.read();
-
-        if let FctKind::Builtin(_intrinsic) = callee.kind {
+        if let FctKind::Builtin(_intrinsic) = fct.kind {
             unimplemented!()
         }
 
         let return_type = if dest.is_effect() {
             BuiltinType::Unit
         } else {
-            self.specialize_type_for_call(&call_type, callee.return_type)
+            self.specialize_type_for_call(&call_type, fct.return_type)
         };
-        let arg_types = callee
+        let arg_types = fct
             .params_with_self()
             .iter()
             .map(|&arg| self.specialize_type_for_call(&call_type, arg).into())
@@ -460,20 +451,14 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         match *call_type {
             CallType::Ctor(_, _) | CallType::CtorNew(_, _) => {
                 self.gen
-                    .emit_invoke_direct_void(callee_id, start_reg, num_args);
+                    .emit_invoke_direct_void(fct_id, start_reg, num_args);
             }
 
             CallType::Method(_, _, _) => {
                 if fct.is_virtual() {
-                    self.visit_call_virtual(
-                        return_type,
-                        callee_id,
-                        start_reg,
-                        num_args,
-                        return_reg,
-                    );
+                    self.visit_call_virtual(return_type, fct_id, start_reg, num_args, return_reg);
                 } else {
-                    self.visit_call_direct(return_type, callee_id, start_reg, num_args, return_reg);
+                    self.visit_call_direct(return_type, fct_id, start_reg, num_args, return_reg);
                 }
             }
             CallType::Expr(_, _) => unimplemented!(),
@@ -481,35 +466,35 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             CallType::Fct(_, _, _) => {
                 if return_type.is_unit() {
                     self.gen
-                        .emit_invoke_static_void(callee_id, start_reg, num_args);
+                        .emit_invoke_static_void(fct_id, start_reg, num_args);
                 } else {
                     let return_type: BytecodeType = return_type.into();
 
                     match return_type.into() {
                         BytecodeType::Bool => self
                             .gen
-                            .emit_invoke_static_bool(return_reg, callee_id, start_reg, num_args),
+                            .emit_invoke_static_bool(return_reg, fct_id, start_reg, num_args),
                         BytecodeType::Byte => self
                             .gen
-                            .emit_invoke_static_byte(return_reg, callee_id, start_reg, num_args),
+                            .emit_invoke_static_byte(return_reg, fct_id, start_reg, num_args),
                         BytecodeType::Char => self
                             .gen
-                            .emit_invoke_static_char(return_reg, callee_id, start_reg, num_args),
+                            .emit_invoke_static_char(return_reg, fct_id, start_reg, num_args),
                         BytecodeType::Int => self
                             .gen
-                            .emit_invoke_static_int(return_reg, callee_id, start_reg, num_args),
+                            .emit_invoke_static_int(return_reg, fct_id, start_reg, num_args),
                         BytecodeType::Long => self
                             .gen
-                            .emit_invoke_static_long(return_reg, callee_id, start_reg, num_args),
+                            .emit_invoke_static_long(return_reg, fct_id, start_reg, num_args),
                         BytecodeType::Float => self
                             .gen
-                            .emit_invoke_static_float(return_reg, callee_id, start_reg, num_args),
+                            .emit_invoke_static_float(return_reg, fct_id, start_reg, num_args),
                         BytecodeType::Double => self
                             .gen
-                            .emit_invoke_static_double(return_reg, callee_id, start_reg, num_args),
+                            .emit_invoke_static_double(return_reg, fct_id, start_reg, num_args),
                         BytecodeType::Ptr => self
                             .gen
-                            .emit_invoke_static_ptr(return_reg, callee_id, start_reg, num_args),
+                            .emit_invoke_static_ptr(return_reg, fct_id, start_reg, num_args),
                     }
                 }
             }

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -428,18 +428,23 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             Register::zero()
         };
         self.gen.set_position(expr.pos);
-        let arg_start_reg = match *call_type {
+        let (arg_start_reg, nil_check) = match *call_type {
             CallType::CtorNew(ty, _) => {
                 let cls_id = specialize_class_ty(self.vm, ty);
                 self.gen.emit_new_object(start_reg, cls_id);
-                start_reg.offset(1)
+                (start_reg.offset(1), true)
             }
             CallType::Method(_, _, _) => {
+                let nil_check = match arg_types[0] {
+                    BytecodeType::Ptr => true,
+                    _ => false,
+                };
+
                 let obj_expr = expr.object().expect("method target required");
                 self.visit_expr(obj_expr, DataDest::Reg(start_reg));
-                start_reg.offset(1)
+                (start_reg.offset(1), nil_check)
             }
-            _ => start_reg,
+            _ => (start_reg, false),
         };
 
         for (idx, arg) in expr.args.iter().enumerate() {
@@ -454,7 +459,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                     .emit_invoke_direct_void(fct_id, start_reg, num_args);
             }
 
-            CallType::Method(_, _, _) => {
+            CallType::Method(_, _, _) if nil_check => {
                 if fct.is_virtual() {
                     self.visit_call_virtual(return_type, fct_id, start_reg, num_args, return_reg);
                 } else {
@@ -462,8 +467,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                 }
             }
             CallType::Expr(_, _) => unimplemented!(),
-
-            CallType::Fct(_, _, _) => {
+            CallType::Method(_, _, _) | CallType::Fct(_, _, _) => {
                 if return_type.is_unit() {
                     self.gen
                         .emit_invoke_static_void(fct_id, start_reg, num_args);

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -459,48 +459,18 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                     .emit_invoke_direct_void(fct_id, start_reg, num_args);
             }
 
-            CallType::Method(_, _, _) if nil_check => {
+            CallType::Method(_, _, _) => {
                 if fct.is_virtual() {
                     self.visit_call_virtual(return_type, fct_id, start_reg, num_args, return_reg);
+                } else if !nil_check {
+                    self.visit_call_static(return_type, fct_id, start_reg, num_args, return_reg);
                 } else {
                     self.visit_call_direct(return_type, fct_id, start_reg, num_args, return_reg);
                 }
             }
             CallType::Expr(_, _) => unimplemented!(),
-            CallType::Method(_, _, _) | CallType::Fct(_, _, _) => {
-                if return_type.is_unit() {
-                    self.gen
-                        .emit_invoke_static_void(fct_id, start_reg, num_args);
-                } else {
-                    let return_type: BytecodeType = return_type.into();
-
-                    match return_type.into() {
-                        BytecodeType::Bool => self
-                            .gen
-                            .emit_invoke_static_bool(return_reg, fct_id, start_reg, num_args),
-                        BytecodeType::Byte => self
-                            .gen
-                            .emit_invoke_static_byte(return_reg, fct_id, start_reg, num_args),
-                        BytecodeType::Char => self
-                            .gen
-                            .emit_invoke_static_char(return_reg, fct_id, start_reg, num_args),
-                        BytecodeType::Int => self
-                            .gen
-                            .emit_invoke_static_int(return_reg, fct_id, start_reg, num_args),
-                        BytecodeType::Long => self
-                            .gen
-                            .emit_invoke_static_long(return_reg, fct_id, start_reg, num_args),
-                        BytecodeType::Float => self
-                            .gen
-                            .emit_invoke_static_float(return_reg, fct_id, start_reg, num_args),
-                        BytecodeType::Double => self
-                            .gen
-                            .emit_invoke_static_double(return_reg, fct_id, start_reg, num_args),
-                        BytecodeType::Ptr => self
-                            .gen
-                            .emit_invoke_static_ptr(return_reg, fct_id, start_reg, num_args),
-                    }
-                }
+            CallType::Fct(_, _, _) => {
+                self.visit_call_static(return_type, fct_id, start_reg, num_args, return_reg);
             }
 
             CallType::Trait(_, _) => unimplemented!(),
@@ -604,6 +574,49 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                 BytecodeType::Ptr => self
                     .gen
                     .emit_invoke_direct_ptr(return_reg, callee_id, start_reg, num_args),
+            }
+        }
+    }
+
+    fn visit_call_static(
+        &mut self,
+        return_type: BuiltinType,
+        callee_id: FctId,
+        start_reg: Register,
+        num_args: usize,
+        return_reg: Register,
+    ) {
+        if return_type.is_unit() {
+            self.gen
+                .emit_invoke_static_void(callee_id, start_reg, num_args);
+        } else {
+            let return_type: BytecodeType = return_type.into();
+
+            match return_type.into() {
+                BytecodeType::Bool => self
+                    .gen
+                    .emit_invoke_static_bool(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Byte => self
+                    .gen
+                    .emit_invoke_static_byte(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Char => self
+                    .gen
+                    .emit_invoke_static_char(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Int => self
+                    .gen
+                    .emit_invoke_static_int(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Long => self
+                    .gen
+                    .emit_invoke_static_long(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Float => self
+                    .gen
+                    .emit_invoke_static_float(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Double => self
+                    .gen
+                    .emit_invoke_static_double(return_reg, callee_id, start_reg, num_args),
+                BytecodeType::Ptr => self
+                    .gen
+                    .emit_invoke_static_ptr(return_reg, callee_id, start_reg, num_args),
             }
         }
     }


### PR DESCRIPTION
Currently the bytecode generator didn't check if a call of type `CallType::Method` really needed the nil check, which is necessary for direct invocation. As a result `1.toString()` was translated to `InvokeDirectPtr(...)`. But when cannon tried to generate the machine code, it checked if the first argument ("self") was indeed of type `BytecodeType::Ptr`. This ultimately failed, as the first argument is `Int`.

I added a check in the generator for`CallType::Method` and if the first argument type is not a Ptr, a flag is set. If the flag is set, `InvokeStatic` is emitted. 