### PR TITLE
bytecode/cannon/vm: Add specializations for functions to vm and use in bytecode/cannon

### DIFF
--- a/dora/src/bytecode/dumper.rs
+++ b/dora/src/bytecode/dumper.rs
@@ -3,7 +3,7 @@ use std::io;
 use crate::bytecode::{
     read, BytecodeFunction, BytecodeOffset, BytecodeVisitor, ConstPoolIdx, Register,
 };
-use crate::vm::{ClassDefId, FctId, FieldId, GlobalId};
+use crate::vm::{ClassDefId, FctDefId, FieldId, GlobalId};
 
 pub fn dump(bc: &BytecodeFunction) {
     let mut stdout = io::stdout();
@@ -87,12 +87,12 @@ impl<'a> BytecodeDumper<'a> {
         writeln!(self.w, " {}, {}", r1, gid.to_usize()).expect("write! failed");
     }
 
-    fn emit_fct_void(&mut self, name: &str, fid: FctId, r1: Register, cnt: u32) {
+    fn emit_fct_void(&mut self, name: &str, fid: FctDefId, r1: Register, cnt: u32) {
         self.emit_start(name);
         writeln!(self.w, " {}, {}, {}", fid.to_usize(), r1, cnt).expect("write! failed");
     }
 
-    fn emit_fct(&mut self, name: &str, r1: Register, fid: FctId, r2: Register, cnt: u32) {
+    fn emit_fct(&mut self, name: &str, r1: Register, fid: FctDefId, r2: Register, cnt: u32) {
         self.emit_start(name);
         writeln!(self.w, " {}, {}, {}, {}", r1, fid.to_usize(), r2, cnt).expect("write! failed");
     }
@@ -675,208 +675,232 @@ impl<'a> BytecodeVisitor for BytecodeDumper<'a> {
         self.emit_idx("JumpConst", idx);
     }
 
-    fn visit_invoke_direct_void(&mut self, fct: FctId, start: Register, count: u32) {
-        self.emit_fct_void("InvokeDirectVoid", fct, start, count);
+    fn visit_invoke_direct_void(&mut self, fctdef: FctDefId, start: Register, count: u32) {
+        self.emit_fct_void("InvokeDirectVoid", fctdef, start, count);
     }
     fn visit_invoke_direct_bool(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeDirectBool", dest, fct, start, count);
+        self.emit_fct("InvokeDirectBool", dest, fctdef, start, count);
     }
     fn visit_invoke_direct_byte(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeDirectByte", dest, fct, start, count);
+        self.emit_fct("InvokeDirectByte", dest, fctdef, start, count);
     }
     fn visit_invoke_direct_char(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeDirectChar", dest, fct, start, count);
+        self.emit_fct("InvokeDirectChar", dest, fctdef, start, count);
     }
-    fn visit_invoke_direct_int(&mut self, dest: Register, fct: FctId, start: Register, count: u32) {
-        self.emit_fct("InvokeDirectInt", dest, fct, start, count);
+    fn visit_invoke_direct_int(
+        &mut self,
+        dest: Register,
+        fctdef: FctDefId,
+        start: Register,
+        count: u32,
+    ) {
+        self.emit_fct("InvokeDirectInt", dest, fctdef, start, count);
     }
     fn visit_invoke_direct_long(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeDirectLong", dest, fct, start, count);
+        self.emit_fct("InvokeDirectLong", dest, fctdef, start, count);
     }
     fn visit_invoke_direct_float(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeDirectFloat", dest, fct, start, count);
+        self.emit_fct("InvokeDirectFloat", dest, fctdef, start, count);
     }
     fn visit_invoke_direct_double(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeDirectDouble", dest, fct, start, count);
+        self.emit_fct("InvokeDirectDouble", dest, fctdef, start, count);
     }
-    fn visit_invoke_direct_ptr(&mut self, dest: Register, fct: FctId, start: Register, count: u32) {
-        self.emit_fct("InvokeDirectPtr", dest, fct, start, count);
+    fn visit_invoke_direct_ptr(
+        &mut self,
+        dest: Register,
+        fctdef: FctDefId,
+        start: Register,
+        count: u32,
+    ) {
+        self.emit_fct("InvokeDirectPtr", dest, fctdef, start, count);
     }
 
-    fn visit_invoke_virtual_void(&mut self, fct: FctId, start: Register, count: u32) {
-        self.emit_fct_void("InvokeVirtualVoid", fct, start, count);
+    fn visit_invoke_virtual_void(&mut self, fctdef: FctDefId, start: Register, count: u32) {
+        self.emit_fct_void("InvokeVirtualVoid", fctdef, start, count);
     }
     fn visit_invoke_virtual_bool(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeVirtualBool", dest, fct, start, count);
+        self.emit_fct("InvokeVirtualBool", dest, fctdef, start, count);
     }
     fn visit_invoke_virtual_byte(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeVirtualByte", dest, fct, start, count);
+        self.emit_fct("InvokeVirtualByte", dest, fctdef, start, count);
     }
     fn visit_invoke_virtual_char(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeVirtualChar", dest, fct, start, count);
+        self.emit_fct("InvokeVirtualChar", dest, fctdef, start, count);
     }
     fn visit_invoke_virtual_int(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeVirtualInt", dest, fct, start, count);
+        self.emit_fct("InvokeVirtualInt", dest, fctdef, start, count);
     }
     fn visit_invoke_virtual_long(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeVirtualLong", dest, fct, start, count);
+        self.emit_fct("InvokeVirtualLong", dest, fctdef, start, count);
     }
     fn visit_invoke_virtual_float(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeVirtualFloat", dest, fct, start, count);
+        self.emit_fct("InvokeVirtualFloat", dest, fctdef, start, count);
     }
     fn visit_invoke_virtual_double(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeVirtualDouble", dest, fct, start, count);
+        self.emit_fct("InvokeVirtualDouble", dest, fctdef, start, count);
     }
     fn visit_invoke_virtual_ptr(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeVirtualPtr", dest, fct, start, count);
+        self.emit_fct("InvokeVirtualPtr", dest, fctdef, start, count);
     }
 
-    fn visit_invoke_static_void(&mut self, fct: FctId, start: Register, count: u32) {
-        self.emit_fct_void("InvokeStaticVoid", fct, start, count);
+    fn visit_invoke_static_void(&mut self, fctdef: FctDefId, start: Register, count: u32) {
+        self.emit_fct_void("InvokeStaticVoid", fctdef, start, count);
     }
     fn visit_invoke_static_bool(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeStaticBool", dest, fct, start, count);
+        self.emit_fct("InvokeStaticBool", dest, fctdef, start, count);
     }
     fn visit_invoke_static_byte(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeStaticByte", dest, fct, start, count);
+        self.emit_fct("InvokeStaticByte", dest, fctdef, start, count);
     }
     fn visit_invoke_static_char(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeStaticChar", dest, fct, start, count);
+        self.emit_fct("InvokeStaticChar", dest, fctdef, start, count);
     }
-    fn visit_invoke_static_int(&mut self, dest: Register, fct: FctId, start: Register, count: u32) {
-        self.emit_fct("InvokeStaticInt", dest, fct, start, count);
+    fn visit_invoke_static_int(
+        &mut self,
+        dest: Register,
+        fctdef: FctDefId,
+        start: Register,
+        count: u32,
+    ) {
+        self.emit_fct("InvokeStaticInt", dest, fctdef, start, count);
     }
     fn visit_invoke_static_long(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeStaticLong", dest, fct, start, count);
+        self.emit_fct("InvokeStaticLong", dest, fctdef, start, count);
     }
     fn visit_invoke_static_float(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeStaticFloat", dest, fct, start, count);
+        self.emit_fct("InvokeStaticFloat", dest, fctdef, start, count);
     }
     fn visit_invoke_static_double(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit_fct("InvokeStaticDouble", dest, fct, start, count);
+        self.emit_fct("InvokeStaticDouble", dest, fctdef, start, count);
     }
-    fn visit_invoke_static_ptr(&mut self, dest: Register, fct: FctId, start: Register, count: u32) {
-        self.emit_fct("InvokeStaticPtr", dest, fct, start, count);
+    fn visit_invoke_static_ptr(
+        &mut self,
+        dest: Register,
+        fctdef: FctDefId,
+        start: Register,
+        count: u32,
+    ) {
+        self.emit_fct("InvokeStaticPtr", dest, fctdef, start, count);
     }
 
     fn visit_new_object(&mut self, dest: Register, cls: ClassDefId) {

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -1435,7 +1435,6 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             fct_id: fct.id,
             cls_type_params: cls_type_params.clone(),
             fct_type_params: fct_type_params.clone(),
-            jit_fct_id: None,
         });
 
         let old = fct.specializations_fct_def.write().insert(

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -1414,7 +1414,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         let (cls_type_params, fct_type_params) = self.determine_call_type_params(call_type);
 
         if let Some(&id) = fct
-            .specializations_fct_def
+            .specializations
             .read()
             .get(&(cls_type_params.clone(), fct_type_params.clone()))
         {
@@ -1437,7 +1437,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             fct_type_params: fct_type_params.clone(),
         });
 
-        let old = fct.specializations_fct_def.write().insert(
+        let old = fct.specializations.write().insert(
             (cls_type_params.clone(), fct_type_params.clone()),
             fct_def_id,
         );

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -1434,7 +1434,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             id: FctDefId(0),
             fct_id: fct.id,
             cls_type_params: cls_type_params.clone(),
-            type_params: fct_type_params.clone(),
+            fct_type_params: fct_type_params.clone(),
             jit_fct_id: None,
         });
 

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -7,7 +7,7 @@ use crate::bytecode::{
 };
 use crate::test;
 use crate::ty::TypeList;
-use crate::vm::{ClassDefId, FctId, FieldId, GlobalId, VM};
+use crate::vm::{ClassDefId, FctDefId, FieldId, GlobalId, VM};
 use dora_parser::lexer::position::Position;
 
 fn code(code: &'static str) -> Vec<Bytecode> {
@@ -1253,7 +1253,7 @@ fn gen_fct_call_void_with_0_args() {
             fun g() { }
             ",
         |vm, code| {
-            let fct_id = vm.fct_by_name("g").expect("g not found");
+            let fct_id = vm.fct_def_by_name("g").expect("g not found");
             let expected = vec![InvokeStaticVoid(fct_id, r(0), 0), RetVoid];
             assert_eq!(expected, code);
         },
@@ -1268,7 +1268,7 @@ fn gen_fct_call_int_with_0_args() {
             fun g() -> Int { return 1; }
             ",
         |vm, code| {
-            let fct_id = vm.fct_by_name("g").expect("g not found");
+            let fct_id = vm.fct_def_by_name("g").expect("g not found");
             let expected = vec![InvokeStaticInt(r(0), fct_id, r(0), 0), RetInt(r(0))];
             assert_eq!(expected, code);
         },
@@ -1283,7 +1283,7 @@ fn gen_fct_call_int_with_0_args_and_unused_result() {
             fun g() -> Int { return 1; }
             ",
         |vm, code| {
-            let fct_id = vm.fct_by_name("g").expect("g not found");
+            let fct_id = vm.fct_def_by_name("g").expect("g not found");
             let expected = vec![InvokeStaticVoid(fct_id, r(0), 0), RetVoid];
             assert_eq!(expected, code);
         },
@@ -1298,7 +1298,7 @@ fn gen_fct_call_void_with_1_arg() {
             fun g(a: Int) { }
             ",
         |vm, code| {
-            let fct_id = vm.fct_by_name("g").expect("g not found");
+            let fct_id = vm.fct_def_by_name("g").expect("g not found");
             let expected = vec![
                 ConstInt(r(0), 1),
                 InvokeStaticVoid(fct_id, r(0), 1),
@@ -1317,7 +1317,7 @@ fn gen_fct_call_void_with_3_args() {
             fun g(a: Int, b: Int, c: Int) { }
             ",
         |vm, code| {
-            let fct_id = vm.fct_by_name("g").expect("g not found");
+            let fct_id = vm.fct_def_by_name("g").expect("g not found");
             let expected = vec![
                 ConstInt(r(0), 1),
                 ConstInt(r(1), 2),
@@ -1338,7 +1338,7 @@ fn gen_fct_call_int_with_1_arg() {
             fun g(a: Int) -> Int { return a; }
             ",
         |vm, code| {
-            let fct_id = vm.fct_by_name("g").expect("g not found");
+            let fct_id = vm.fct_def_by_name("g").expect("g not found");
             let expected = vec![
                 ConstInt(r(1), 1),
                 InvokeStaticInt(r(0), fct_id, r(1), 1),
@@ -1357,7 +1357,7 @@ fn gen_fct_call_int_with_3_args() {
             fun g(a: Int, b: Int, c: Int) -> Int { return 1; }
             ",
         |vm, code| {
-            let fct_id = vm.fct_by_name("g").expect("g not found");
+            let fct_id = vm.fct_def_by_name("g").expect("g not found");
             let expected = vec![
                 ConstInt(r(1), 1),
                 ConstInt(r(2), 2),
@@ -1381,7 +1381,7 @@ fn gen_method_call_void_check_correct_self() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(1)),
@@ -1404,7 +1404,7 @@ fn gen_method_call_void_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -1427,7 +1427,7 @@ fn gen_method_call_void_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -1451,7 +1451,7 @@ fn gen_method_call_void_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -1477,7 +1477,7 @@ fn gen_method_call_bool_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1500,7 +1500,7 @@ fn gen_method_call_bool_with_0_args_and_unused_result() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -1523,7 +1523,7 @@ fn gen_method_call_bool_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1547,7 +1547,7 @@ fn gen_method_call_bool_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1573,7 +1573,7 @@ fn gen_method_call_byte_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1596,7 +1596,7 @@ fn gen_method_call_byte_with_0_args_and_unused_result() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -1619,7 +1619,7 @@ fn gen_method_call_byte_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1643,7 +1643,7 @@ fn gen_method_call_byte_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1669,7 +1669,7 @@ fn gen_method_call_char_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1692,7 +1692,7 @@ fn gen_method_call_char_with_0_args_and_unused_result() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -1715,7 +1715,7 @@ fn gen_method_call_char_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1739,7 +1739,7 @@ fn gen_method_call_char_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1765,7 +1765,7 @@ fn gen_method_call_int_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1788,7 +1788,7 @@ fn gen_method_call_int_with_0_args_and_unused_result() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -1811,7 +1811,7 @@ fn gen_method_call_int_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1835,7 +1835,7 @@ fn gen_method_call_int_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1861,7 +1861,7 @@ fn gen_method_call_long_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1884,7 +1884,7 @@ fn gen_method_call_long_with_0_args_and_unused_result() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -1907,7 +1907,7 @@ fn gen_method_call_long_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1931,7 +1931,7 @@ fn gen_method_call_long_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1957,7 +1957,7 @@ fn gen_method_call_float_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -1980,7 +1980,7 @@ fn gen_method_call_float_with_0_args_and_unused_result() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -2003,7 +2003,7 @@ fn gen_method_call_float_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -2027,7 +2027,7 @@ fn gen_method_call_float_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -2053,7 +2053,7 @@ fn gen_method_call_double_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -2076,7 +2076,7 @@ fn gen_method_call_double_with_0_args_and_unused_result() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -2099,7 +2099,7 @@ fn gen_method_call_double_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -2123,7 +2123,7 @@ fn gen_method_call_double_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -2149,7 +2149,7 @@ fn gen_method_call_ptr_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -2172,7 +2172,7 @@ fn gen_method_call_ptr_with_0_args_and_unused_result() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -2195,7 +2195,7 @@ fn gen_method_call_ptr_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -2219,7 +2219,7 @@ fn gen_method_call_ptr_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(0)),
@@ -2248,7 +2248,7 @@ fn gen_virtual_method_call_void_check_correct_self() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(2), r(1)),
@@ -2274,7 +2274,7 @@ fn gen_virtual_method_call_void_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -2300,7 +2300,7 @@ fn gen_virtual_method_call_void_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -2327,7 +2327,7 @@ fn gen_virtual_method_call_void_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -2356,7 +2356,7 @@ fn gen_virtual_method_call_int_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -2382,7 +2382,7 @@ fn gen_virtual_method_call_int_with_1_arg() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -2409,7 +2409,7 @@ fn gen_virtual_method_call_int_with_3_args() {
             ",
         |vm, code| {
             let fct_id = vm
-                .cls_method_by_name("Foo", "g", false)
+                .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
                 MovPtr(r(1), r(0)),
@@ -2428,7 +2428,7 @@ fn gen_virtual_method_call_int_with_3_args() {
 fn gen_new_object() {
     gen("fun f() -> Object { return Object(); }", |vm, code| {
         let cls_id = vm.cls_def_by_name("Object");
-        let ctor_id = vm.ctor_by_name("Object");
+        let ctor_id = vm.ctor_def_by_name("Object");
         let expected = vec![
             NewObject(r(0), cls_id),
             InvokeDirectVoid(ctor_id, r(0), 1),
@@ -2444,7 +2444,7 @@ fn gen_new_object_assign_to_var() {
         "fun f() -> Object { let obj = Object(); return obj; }",
         |vm, code| {
             let cls_id = vm.cls_def_by_name("Object");
-            let ctor_id = vm.ctor_by_name("Object");
+            let ctor_id = vm.ctor_def_by_name("Object");
             let expected = vec![
                 NewObject(r(1), cls_id),
                 InvokeDirectVoid(ctor_id, r(1), 1),
@@ -2472,7 +2472,7 @@ fn gen_new_object_with_multiple_args() {
             ",
         |vm, code| {
             let cls_id = vm.cls_def_by_name("Foo");
-            let ctor_id = vm.ctor_by_name("Foo");
+            let ctor_id = vm.ctor_def_by_name("Foo");
             let expected = vec![
                 NewObject(r(0), cls_id),
                 ConstInt(r(1), 1),
@@ -2669,7 +2669,7 @@ fn gen_self_assign_for_string() {
 fn gen_assert() {
     gen("fun f() { assert(true); }", |vm, code| {
         let cls_id = vm.cls_def_by_name("Error");
-        let ctor_id = vm.ctor_by_name("Error");
+        let ctor_id = vm.ctor_def_by_name("Error");
         let expected = vec![
             ConstTrue(r(0)),
             JumpIfTrue(r(0), 6),
@@ -2694,7 +2694,7 @@ fn gen_position_assert() {
 fn gen_throw() {
     gen("fun f() { throw Exception(\"exception\"); }", |vm, code| {
         let cls_id = vm.cls_def_by_name("Exception");
-        let ctor_id = vm.ctor_by_name("Exception");
+        let ctor_id = vm.ctor_def_by_name("Exception");
         let expected = vec![
             NewObject(r(0), cls_id),
             ConstString(r(1), "exception".to_string()),
@@ -2893,35 +2893,35 @@ pub enum Bytecode {
     JumpIfFalse(Register, usize),
     JumpIfTrue(Register, usize),
 
-    InvokeDirectVoid(FctId, Register, u32),
-    InvokeDirectBool(Register, FctId, Register, u32),
-    InvokeDirectByte(Register, FctId, Register, u32),
-    InvokeDirectChar(Register, FctId, Register, u32),
-    InvokeDirectInt(Register, FctId, Register, u32),
-    InvokeDirectLong(Register, FctId, Register, u32),
-    InvokeDirectFloat(Register, FctId, Register, u32),
-    InvokeDirectDouble(Register, FctId, Register, u32),
-    InvokeDirectPtr(Register, FctId, Register, u32),
+    InvokeDirectVoid(FctDefId, Register, u32),
+    InvokeDirectBool(Register, FctDefId, Register, u32),
+    InvokeDirectByte(Register, FctDefId, Register, u32),
+    InvokeDirectChar(Register, FctDefId, Register, u32),
+    InvokeDirectInt(Register, FctDefId, Register, u32),
+    InvokeDirectLong(Register, FctDefId, Register, u32),
+    InvokeDirectFloat(Register, FctDefId, Register, u32),
+    InvokeDirectDouble(Register, FctDefId, Register, u32),
+    InvokeDirectPtr(Register, FctDefId, Register, u32),
 
-    InvokeVirtualVoid(FctId, Register, u32),
-    InvokeVirtualBool(Register, FctId, Register, u32),
-    InvokeVirtualByte(Register, FctId, Register, u32),
-    InvokeVirtualChar(Register, FctId, Register, u32),
-    InvokeVirtualInt(Register, FctId, Register, u32),
-    InvokeVirtualLong(Register, FctId, Register, u32),
-    InvokeVirtualFloat(Register, FctId, Register, u32),
-    InvokeVirtualDouble(Register, FctId, Register, u32),
-    InvokeVirtualPtr(Register, FctId, Register, u32),
+    InvokeVirtualVoid(FctDefId, Register, u32),
+    InvokeVirtualBool(Register, FctDefId, Register, u32),
+    InvokeVirtualByte(Register, FctDefId, Register, u32),
+    InvokeVirtualChar(Register, FctDefId, Register, u32),
+    InvokeVirtualInt(Register, FctDefId, Register, u32),
+    InvokeVirtualLong(Register, FctDefId, Register, u32),
+    InvokeVirtualFloat(Register, FctDefId, Register, u32),
+    InvokeVirtualDouble(Register, FctDefId, Register, u32),
+    InvokeVirtualPtr(Register, FctDefId, Register, u32),
 
-    InvokeStaticVoid(FctId, Register, u32),
-    InvokeStaticBool(Register, FctId, Register, u32),
-    InvokeStaticByte(Register, FctId, Register, u32),
-    InvokeStaticChar(Register, FctId, Register, u32),
-    InvokeStaticInt(Register, FctId, Register, u32),
-    InvokeStaticLong(Register, FctId, Register, u32),
-    InvokeStaticFloat(Register, FctId, Register, u32),
-    InvokeStaticDouble(Register, FctId, Register, u32),
-    InvokeStaticPtr(Register, FctId, Register, u32),
+    InvokeStaticVoid(FctDefId, Register, u32),
+    InvokeStaticBool(Register, FctDefId, Register, u32),
+    InvokeStaticByte(Register, FctDefId, Register, u32),
+    InvokeStaticChar(Register, FctDefId, Register, u32),
+    InvokeStaticInt(Register, FctDefId, Register, u32),
+    InvokeStaticLong(Register, FctDefId, Register, u32),
+    InvokeStaticFloat(Register, FctDefId, Register, u32),
+    InvokeStaticDouble(Register, FctDefId, Register, u32),
+    InvokeStaticPtr(Register, FctDefId, Register, u32),
 
     NewObject(Register, ClassDefId),
 
@@ -3588,208 +3588,232 @@ impl<'a> BytecodeVisitor for BytecodeArrayBuilder<'a> {
         self.visit_jump(value as u32);
     }
 
-    fn visit_invoke_direct_void(&mut self, fct: FctId, start: Register, count: u32) {
-        self.emit(Bytecode::InvokeDirectVoid(fct, start, count));
+    fn visit_invoke_direct_void(&mut self, fctdef: FctDefId, start: Register, count: u32) {
+        self.emit(Bytecode::InvokeDirectVoid(fctdef, start, count));
     }
     fn visit_invoke_direct_bool(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeDirectBool(dest, fct, start, count));
+        self.emit(Bytecode::InvokeDirectBool(dest, fctdef, start, count));
     }
     fn visit_invoke_direct_byte(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeDirectByte(dest, fct, start, count));
+        self.emit(Bytecode::InvokeDirectByte(dest, fctdef, start, count));
     }
     fn visit_invoke_direct_char(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeDirectChar(dest, fct, start, count));
+        self.emit(Bytecode::InvokeDirectChar(dest, fctdef, start, count));
     }
-    fn visit_invoke_direct_int(&mut self, dest: Register, fct: FctId, start: Register, count: u32) {
-        self.emit(Bytecode::InvokeDirectInt(dest, fct, start, count));
+    fn visit_invoke_direct_int(
+        &mut self,
+        dest: Register,
+        fctdef: FctDefId,
+        start: Register,
+        count: u32,
+    ) {
+        self.emit(Bytecode::InvokeDirectInt(dest, fctdef, start, count));
     }
     fn visit_invoke_direct_long(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeDirectLong(dest, fct, start, count));
+        self.emit(Bytecode::InvokeDirectLong(dest, fctdef, start, count));
     }
     fn visit_invoke_direct_float(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeDirectFloat(dest, fct, start, count));
+        self.emit(Bytecode::InvokeDirectFloat(dest, fctdef, start, count));
     }
     fn visit_invoke_direct_double(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeDirectDouble(dest, fct, start, count));
+        self.emit(Bytecode::InvokeDirectDouble(dest, fctdef, start, count));
     }
-    fn visit_invoke_direct_ptr(&mut self, dest: Register, fct: FctId, start: Register, count: u32) {
-        self.emit(Bytecode::InvokeDirectPtr(dest, fct, start, count));
+    fn visit_invoke_direct_ptr(
+        &mut self,
+        dest: Register,
+        fctdef: FctDefId,
+        start: Register,
+        count: u32,
+    ) {
+        self.emit(Bytecode::InvokeDirectPtr(dest, fctdef, start, count));
     }
 
-    fn visit_invoke_virtual_void(&mut self, fct: FctId, start: Register, count: u32) {
-        self.emit(Bytecode::InvokeVirtualVoid(fct, start, count));
+    fn visit_invoke_virtual_void(&mut self, fctdef: FctDefId, start: Register, count: u32) {
+        self.emit(Bytecode::InvokeVirtualVoid(fctdef, start, count));
     }
     fn visit_invoke_virtual_bool(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeVirtualBool(dest, fct, start, count));
+        self.emit(Bytecode::InvokeVirtualBool(dest, fctdef, start, count));
     }
     fn visit_invoke_virtual_byte(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeVirtualByte(dest, fct, start, count));
+        self.emit(Bytecode::InvokeVirtualByte(dest, fctdef, start, count));
     }
     fn visit_invoke_virtual_char(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeVirtualChar(dest, fct, start, count));
+        self.emit(Bytecode::InvokeVirtualChar(dest, fctdef, start, count));
     }
     fn visit_invoke_virtual_int(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeVirtualInt(dest, fct, start, count));
+        self.emit(Bytecode::InvokeVirtualInt(dest, fctdef, start, count));
     }
     fn visit_invoke_virtual_long(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeVirtualLong(dest, fct, start, count));
+        self.emit(Bytecode::InvokeVirtualLong(dest, fctdef, start, count));
     }
     fn visit_invoke_virtual_float(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeVirtualFloat(dest, fct, start, count));
+        self.emit(Bytecode::InvokeVirtualFloat(dest, fctdef, start, count));
     }
     fn visit_invoke_virtual_double(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeVirtualDouble(dest, fct, start, count));
+        self.emit(Bytecode::InvokeVirtualDouble(dest, fctdef, start, count));
     }
     fn visit_invoke_virtual_ptr(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeVirtualPtr(dest, fct, start, count));
+        self.emit(Bytecode::InvokeVirtualPtr(dest, fctdef, start, count));
     }
 
-    fn visit_invoke_static_void(&mut self, fct: FctId, start: Register, count: u32) {
-        self.emit(Bytecode::InvokeStaticVoid(fct, start, count));
+    fn visit_invoke_static_void(&mut self, fctdef: FctDefId, start: Register, count: u32) {
+        self.emit(Bytecode::InvokeStaticVoid(fctdef, start, count));
     }
     fn visit_invoke_static_bool(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeStaticBool(dest, fct, start, count));
+        self.emit(Bytecode::InvokeStaticBool(dest, fctdef, start, count));
     }
     fn visit_invoke_static_byte(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeStaticByte(dest, fct, start, count));
+        self.emit(Bytecode::InvokeStaticByte(dest, fctdef, start, count));
     }
     fn visit_invoke_static_char(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeStaticChar(dest, fct, start, count));
+        self.emit(Bytecode::InvokeStaticChar(dest, fctdef, start, count));
     }
-    fn visit_invoke_static_int(&mut self, dest: Register, fct: FctId, start: Register, count: u32) {
-        self.emit(Bytecode::InvokeStaticInt(dest, fct, start, count));
+    fn visit_invoke_static_int(
+        &mut self,
+        dest: Register,
+        fctdef: FctDefId,
+        start: Register,
+        count: u32,
+    ) {
+        self.emit(Bytecode::InvokeStaticInt(dest, fctdef, start, count));
     }
     fn visit_invoke_static_long(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeStaticLong(dest, fct, start, count));
+        self.emit(Bytecode::InvokeStaticLong(dest, fctdef, start, count));
     }
     fn visit_invoke_static_float(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeStaticFloat(dest, fct, start, count));
+        self.emit(Bytecode::InvokeStaticFloat(dest, fctdef, start, count));
     }
     fn visit_invoke_static_double(
         &mut self,
         dest: Register,
-        fct: FctId,
+        fctdef: FctDefId,
         start: Register,
         count: u32,
     ) {
-        self.emit(Bytecode::InvokeStaticDouble(dest, fct, start, count));
+        self.emit(Bytecode::InvokeStaticDouble(dest, fctdef, start, count));
     }
-    fn visit_invoke_static_ptr(&mut self, dest: Register, fct: FctId, start: Register, count: u32) {
-        self.emit(Bytecode::InvokeStaticPtr(dest, fct, start, count));
+    fn visit_invoke_static_ptr(
+        &mut self,
+        dest: Register,
+        fctdef: FctDefId,
+        start: Register,
+        count: u32,
+    ) {
+        self.emit(Bytecode::InvokeStaticPtr(dest, fctdef, start, count));
     }
 
     fn visit_new_object(&mut self, dest: Register, cls: ClassDefId) {

--- a/dora/src/bytecode/reader.rs
+++ b/dora/src/bytecode/reader.rs
@@ -1,7 +1,7 @@
 use num_traits::cast::FromPrimitive;
 
 use crate::bytecode::{BytecodeOffset, BytecodeOpcode, ConstPoolIdx, Register};
-use crate::vm::{ClassDefId, FctId, FieldId, GlobalId};
+use crate::vm::{ClassDefId, FctDefId, FieldId, GlobalId};
 
 pub fn read<T: BytecodeVisitor>(data: &[u8], visitor: &mut T) {
     BytecodeReader::new(data, visitor).read();
@@ -1153,7 +1153,7 @@ where
         Register(self.read_index(wide) as usize)
     }
 
-    fn read_fct(&mut self, wide: bool) -> FctId {
+    fn read_fct(&mut self, wide: bool) -> FctDefId {
         (self.read_index(wide) as usize).into()
     }
 
@@ -1776,13 +1776,13 @@ pub trait BytecodeVisitor {
         unimplemented!();
     }
 
-    fn visit_invoke_direct_void(&mut self, _fct: FctId, _start: Register, _count: u32) {
+    fn visit_invoke_direct_void(&mut self, _fctdef: FctDefId, _start: Register, _count: u32) {
         unimplemented!();
     }
     fn visit_invoke_direct_bool(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1791,7 +1791,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_direct_byte(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1800,7 +1800,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_direct_char(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1809,7 +1809,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_direct_int(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1818,7 +1818,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_direct_long(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1827,7 +1827,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_direct_float(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1836,7 +1836,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_direct_double(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1845,20 +1845,20 @@ pub trait BytecodeVisitor {
     fn visit_invoke_direct_ptr(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
         unimplemented!();
     }
 
-    fn visit_invoke_virtual_void(&mut self, _fct: FctId, _start: Register, _count: u32) {
+    fn visit_invoke_virtual_void(&mut self, _fctdef: FctDefId, _start: Register, _count: u32) {
         unimplemented!();
     }
     fn visit_invoke_virtual_bool(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1867,7 +1867,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_virtual_byte(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1876,7 +1876,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_virtual_char(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1885,7 +1885,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_virtual_int(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1894,7 +1894,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_virtual_long(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1903,7 +1903,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_virtual_float(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1912,7 +1912,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_virtual_double(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1921,20 +1921,20 @@ pub trait BytecodeVisitor {
     fn visit_invoke_virtual_ptr(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
         unimplemented!();
     }
 
-    fn visit_invoke_static_void(&mut self, _fct: FctId, _start: Register, _count: u32) {
+    fn visit_invoke_static_void(&mut self, _fctdef: FctDefId, _start: Register, _count: u32) {
         unimplemented!();
     }
     fn visit_invoke_static_bool(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1943,7 +1943,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_static_byte(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1952,7 +1952,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_static_char(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1961,7 +1961,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_static_int(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1970,7 +1970,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_static_long(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1979,7 +1979,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_static_float(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1988,7 +1988,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_static_double(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {
@@ -1997,7 +1997,7 @@ pub trait BytecodeVisitor {
     fn visit_invoke_static_ptr(
         &mut self,
         _dest: Register,
-        _fct: FctId,
+        _fctdef: FctDefId,
         _start: Register,
         _count: u32,
     ) {

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -6,7 +6,7 @@ use crate::bytecode::{
     BytecodeFunction, BytecodeOffset, BytecodeOpcode, BytecodeType, ConstPoolEntry, ConstPoolIdx,
     Register,
 };
-use crate::vm::{ClassDefId, FctId, FieldId, GlobalId};
+use crate::vm::{ClassDefId, FctDefId, FieldId, GlobalId};
 
 use dora_parser::lexer::position::Position;
 
@@ -816,14 +816,14 @@ impl BytecodeWriter {
         self.emit_store_global(BytecodeOpcode::StoreGlobalPtr, src, gid);
     }
 
-    pub fn emit_invoke_direct_void(&mut self, fid: FctId, start: Register, num: usize) {
+    pub fn emit_invoke_direct_void(&mut self, fid: FctDefId, start: Register, num: usize) {
         self.emit_fct_void(BytecodeOpcode::InvokeDirectVoid, fid, start, num);
     }
 
     pub fn emit_invoke_direct_bool(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -833,7 +833,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_direct_byte(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -843,7 +843,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_direct_char(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -853,7 +853,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_direct_int(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -863,7 +863,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_direct_long(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -873,7 +873,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_direct_float(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -883,7 +883,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_direct_double(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -893,21 +893,21 @@ impl BytecodeWriter {
     pub fn emit_invoke_direct_ptr(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
         self.emit_fct(BytecodeOpcode::InvokeDirectPtr, dest, fid, start, num);
     }
 
-    pub fn emit_invoke_virtual_void(&mut self, fid: FctId, start: Register, num: usize) {
+    pub fn emit_invoke_virtual_void(&mut self, fid: FctDefId, start: Register, num: usize) {
         self.emit_fct_void(BytecodeOpcode::InvokeVirtualVoid, fid, start, num);
     }
 
     pub fn emit_invoke_virtual_bool(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -917,7 +917,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_virtual_byte(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -927,7 +927,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_virtual_char(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -937,7 +937,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_virtual_int(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -947,7 +947,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_virtual_long(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -957,7 +957,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_virtual_float(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -967,7 +967,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_virtual_double(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -977,21 +977,21 @@ impl BytecodeWriter {
     pub fn emit_invoke_virtual_ptr(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
         self.emit_fct(BytecodeOpcode::InvokeVirtualPtr, dest, fid, start, num);
     }
 
-    pub fn emit_invoke_static_void(&mut self, fid: FctId, start: Register, num: usize) {
+    pub fn emit_invoke_static_void(&mut self, fid: FctDefId, start: Register, num: usize) {
         self.emit_fct_void(BytecodeOpcode::InvokeStaticVoid, fid, start, num);
     }
 
     pub fn emit_invoke_static_bool(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -1001,7 +1001,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_static_byte(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -1011,7 +1011,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_static_char(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -1021,7 +1021,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_static_int(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -1031,7 +1031,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_static_long(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -1041,7 +1041,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_static_float(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -1051,7 +1051,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_static_double(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -1061,7 +1061,7 @@ impl BytecodeWriter {
     pub fn emit_invoke_static_ptr(
         &mut self,
         dest: Register,
-        fid: FctId,
+        fid: FctDefId,
         start: Register,
         num: usize,
     ) {
@@ -1169,7 +1169,7 @@ impl BytecodeWriter {
         self.emit_values(inst, &values);
     }
 
-    fn emit_fct_void(&mut self, inst: BytecodeOpcode, fid: FctId, r1: Register, cnt: usize) {
+    fn emit_fct_void(&mut self, inst: BytecodeOpcode, fid: FctDefId, r1: Register, cnt: usize) {
         let values = [fid.to_usize() as u32, r1.to_usize() as u32, cnt as u32];
         self.emit_values(inst, &values);
     }
@@ -1178,7 +1178,7 @@ impl BytecodeWriter {
         &mut self,
         inst: BytecodeOpcode,
         r1: Register,
-        fid: FctId,
+        fid: FctDefId,
         r2: Register,
         cnt: usize,
     ) {

--- a/dora/src/cannon/codegen.rs
+++ b/dora/src/cannon/codegen.rs
@@ -1333,7 +1333,7 @@ where
         self.emit_invoke_arguments(start_reg, num);
 
         let cls_type_params = fct_def.cls_type_params.clone();
-        let fct_type_params = fct_def.type_params.clone();
+        let fct_type_params = fct_def.fct_type_params.clone();
 
         let name = fct.full_name(self.vm);
         self.asm.emit_comment(format!("call direct {}", name));
@@ -1395,7 +1395,7 @@ where
         self.emit_invoke_arguments(start_reg, num);
 
         let cls_type_params = fct_def.cls_type_params.clone();
-        let fct_type_params = fct_def.type_params.clone();
+        let fct_type_params = fct_def.fct_type_params.clone();
 
         let name = fct.full_name(self.vm);
         self.asm.emit_comment(format!("call direct {}", name));

--- a/dora/src/semck/clsdefck.rs
+++ b/dora/src/semck/clsdefck.rs
@@ -284,7 +284,7 @@ impl<'x, 'ast> Visitor<'ast> for ClsDefCheck<'x, 'ast> {
             type_params: Vec::new(),
             kind,
 
-            specializations_fct_def: RwLock::new(HashMap::new()),
+            specializations: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);
@@ -338,7 +338,7 @@ impl<'x, 'ast> Visitor<'ast> for ClsDefCheck<'x, 'ast> {
             type_params: Vec::new(),
             kind,
 
-            specializations_fct_def: RwLock::new(HashMap::new()),
+            specializations: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);

--- a/dora/src/semck/clsdefck.rs
+++ b/dora/src/semck/clsdefck.rs
@@ -1,5 +1,5 @@
 use parking_lot::RwLock;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::error::msg::SemError;
 use crate::semck;
@@ -283,6 +283,8 @@ impl<'x, 'ast> Visitor<'ast> for ClsDefCheck<'x, 'ast> {
 
             type_params: Vec::new(),
             kind,
+
+            specializations_fct_def: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);
@@ -335,6 +337,8 @@ impl<'x, 'ast> Visitor<'ast> for ClsDefCheck<'x, 'ast> {
 
             type_params: Vec::new(),
             kind,
+
+            specializations_fct_def: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);

--- a/dora/src/semck/extensiondefck.rs
+++ b/dora/src/semck/extensiondefck.rs
@@ -1,4 +1,5 @@
 use parking_lot::RwLock;
+use std::collections::HashMap;
 
 use crate::error::msg::SemError;
 use crate::semck;
@@ -133,6 +134,8 @@ impl<'x, 'ast> Visitor<'ast> for ExtensionCheck<'x, 'ast> {
 
             type_params: Vec::new(),
             kind,
+
+            specializations_fct_def: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);

--- a/dora/src/semck/extensiondefck.rs
+++ b/dora/src/semck/extensiondefck.rs
@@ -135,7 +135,7 @@ impl<'x, 'ast> Visitor<'ast> for ExtensionCheck<'x, 'ast> {
             type_params: Vec::new(),
             kind,
 
-            specializations_fct_def: RwLock::new(HashMap::new()),
+            specializations: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);

--- a/dora/src/semck/globaldef.rs
+++ b/dora/src/semck/globaldef.rs
@@ -334,6 +334,8 @@ impl<'x, 'ast> Visitor<'ast> for GlobalDef<'x, 'ast> {
 
             type_params: Vec::new(),
             kind,
+
+            specializations_fct_def: RwLock::new(HashMap::new()),
         };
 
         if let Err(sym) = self.vm.add_fct_to_sym(fct) {

--- a/dora/src/semck/globaldef.rs
+++ b/dora/src/semck/globaldef.rs
@@ -335,7 +335,7 @@ impl<'x, 'ast> Visitor<'ast> for GlobalDef<'x, 'ast> {
             type_params: Vec::new(),
             kind,
 
-            specializations_fct_def: RwLock::new(HashMap::new()),
+            specializations: RwLock::new(HashMap::new()),
         };
 
         if let Err(sym) = self.vm.add_fct_to_sym(fct) {

--- a/dora/src/semck/impldefck.rs
+++ b/dora/src/semck/impldefck.rs
@@ -1,4 +1,5 @@
 use parking_lot::RwLock;
+use std::collections::HashMap;
 
 use crate::error::msg::SemError;
 use crate::sym::Sym;
@@ -160,6 +161,8 @@ impl<'x, 'ast> Visitor<'ast> for ImplCheck<'x, 'ast> {
 
             type_params: Vec::new(),
             kind,
+
+            specializations_fct_def: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);

--- a/dora/src/semck/impldefck.rs
+++ b/dora/src/semck/impldefck.rs
@@ -162,7 +162,7 @@ impl<'x, 'ast> Visitor<'ast> for ImplCheck<'x, 'ast> {
             type_params: Vec::new(),
             kind,
 
-            specializations_fct_def: RwLock::new(HashMap::new()),
+            specializations: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);

--- a/dora/src/semck/moduledefck.rs
+++ b/dora/src/semck/moduledefck.rs
@@ -211,7 +211,7 @@ impl<'x, 'ast> Visitor<'ast> for ModuleCheck<'x, 'ast> {
             type_params: Vec::new(),
             kind,
 
-            specializations_fct_def: RwLock::new(HashMap::new()),
+            specializations: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);
@@ -265,7 +265,7 @@ impl<'x, 'ast> Visitor<'ast> for ModuleCheck<'x, 'ast> {
             type_params: Vec::new(),
             kind,
 
-            specializations_fct_def: RwLock::new(HashMap::new()),
+            specializations: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);

--- a/dora/src/semck/moduledefck.rs
+++ b/dora/src/semck/moduledefck.rs
@@ -1,4 +1,5 @@
 use parking_lot::RwLock;
+use std::collections::HashMap;
 
 use crate::error::msg::SemError;
 use crate::semck;
@@ -209,6 +210,8 @@ impl<'x, 'ast> Visitor<'ast> for ModuleCheck<'x, 'ast> {
 
             type_params: Vec::new(),
             kind,
+
+            specializations_fct_def: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);
@@ -261,6 +264,8 @@ impl<'x, 'ast> Visitor<'ast> for ModuleCheck<'x, 'ast> {
 
             type_params: Vec::new(),
             kind,
+
+            specializations_fct_def: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);

--- a/dora/src/semck/traitdefck.rs
+++ b/dora/src/semck/traitdefck.rs
@@ -91,7 +91,7 @@ impl<'x, 'ast> Visitor<'ast> for TraitCheck<'x, 'ast> {
             type_params: Vec::new(),
             kind: FctKind::Definition,
 
-            specializations_fct_def: RwLock::new(HashMap::new()),
+            specializations: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);

--- a/dora/src/semck/traitdefck.rs
+++ b/dora/src/semck/traitdefck.rs
@@ -1,3 +1,6 @@
+use parking_lot::RwLock;
+use std::collections::HashMap;
+
 use crate::error::msg::SemError;
 use crate::ty::BuiltinType;
 use crate::vm::{Fct, FctId, FctKind, FctParent, NodeMap, TraitId, VM};
@@ -87,6 +90,8 @@ impl<'x, 'ast> Visitor<'ast> for TraitCheck<'x, 'ast> {
 
             type_params: Vec::new(),
             kind: FctKind::Definition,
+
+            specializations_fct_def: RwLock::new(HashMap::new()),
         };
 
         let fctid = self.vm.add_fct(fct);

--- a/dora/src/vm.rs
+++ b/dora/src/vm.rs
@@ -371,7 +371,7 @@ impl<'ast> VM<'ast> {
             let fct = self.fcts.idx(fct_id);
             let fct = fct.read();
             let fct_def = fct
-                .specializations_fct_def
+                .specializations
                 .read()
                 .get(&(TypeList::Empty, TypeList::Empty))
                 .and_then(|fct_def_id| Some(*fct_def_id));
@@ -427,7 +427,7 @@ impl<'ast> VM<'ast> {
         let fct = self.fcts.idx(fct_id);
         let fct = fct.read();
         let fct_def = fct
-            .specializations_fct_def
+            .specializations
             .read()
             .get(&(TypeList::Empty, TypeList::Empty))
             .and_then(|fct_def_id| Some(*fct_def_id));
@@ -456,7 +456,7 @@ impl<'ast> VM<'ast> {
         let fct = self.fcts.idx(fct_id);
         let fct = fct.read();
         let fct_def = fct
-            .specializations_fct_def
+            .specializations
             .read()
             .get(&(TypeList::Empty, TypeList::Empty))
             .and_then(|fct_def_id| Some(*fct_def_id))

--- a/dora/src/vm.rs
+++ b/dora/src/vm.rs
@@ -300,6 +300,17 @@ impl<'ast> VM<'ast> {
         }
     }
 
+    pub fn add_fct_def(&self, mut fct_def: FctDef) -> FctDefId {
+        let mut fct_defs = self.fct_defs.lock();
+        let fid = FctDefId(fct_defs.len());
+
+        fct_def.id = fid;
+
+        fct_defs.push(Arc::new(RwLock::new(fct_def)));
+
+        fid
+    }
+
     #[cfg(test)]
     pub fn cls_by_name(&self, name: &'static str) -> ClassId {
         let name = self.interner.intern(name);

--- a/dora/src/vm.rs
+++ b/dora/src/vm.rs
@@ -36,7 +36,7 @@ pub use self::cnst::{ConstData, ConstId, ConstValue};
 pub use self::enums::{EnumData, EnumId};
 pub use self::exception::{exception_get_and_clear, exception_set};
 pub use self::extension::{ExtensionData, ExtensionId};
-pub use self::fct::{Fct, FctId, FctKind, FctParent, Intrinsic};
+pub use self::fct::{Fct, FctDef, FctDefId, FctId, FctKind, FctParent, Intrinsic};
 pub use self::field::{Field, FieldDef, FieldId};
 pub use self::global::{GlobalData, GlobalId};
 pub use self::impls::{ImplData, ImplId};
@@ -103,8 +103,9 @@ pub struct VM<'ast> {
     pub tuples: Mutex<Tuples>,                 // stores all tuple definitions
     pub modules: GrowableVec<RwLock<Module>>,  // stores all module source definitions
     pub module_defs: GrowableVec<RwLock<ModuleDef>>, // stores all module definitions
-    pub fcts: GrowableVec<RwLock<Fct<'ast>>>,  // stores all function definitions
+    pub fcts: GrowableVec<RwLock<Fct<'ast>>>,  // stores all function source definitions
     pub jit_fcts: GrowableVec<JitFct>,         // stores all function implementations
+    pub fct_defs: GrowableVec<RwLock<FctDef>>, // stores all function definitions
     pub enums: Vec<RwLock<EnumData>>,          // store all enum definitions
     pub traits: Vec<RwLock<TraitData>>,        // stores all trait definitions
     pub impls: Vec<RwLock<ImplData>>,          // stores all impl definitions
@@ -199,6 +200,7 @@ impl<'ast> VM<'ast> {
             sym: Mutex::new(SymTable::new()),
             fcts: GrowableVec::new(),
             jit_fcts: GrowableVec::new(),
+            fct_defs: GrowableVec::new(),
             code_map: Mutex::new(CodeMap::new()),
             lists: Mutex::new(TypeLists::new()),
             lambda_types: Mutex::new(LambdaTypes::new()),

--- a/dora/src/vm/fct.rs
+++ b/dora/src/vm/fct.rs
@@ -1,6 +1,7 @@
 use crate::compiler::fct::JitFctId;
 use crate::ty::TypeList;
 use parking_lot::RwLock;
+use std::collections::HashMap;
 
 use std::sync::Arc;
 
@@ -66,6 +67,8 @@ pub struct Fct<'ast> {
 
     pub type_params: Vec<TypeParam>,
     pub kind: FctKind,
+
+    pub specializations_fct_def: RwLock<HashMap<(TypeList, TypeList), FctDefId>>,
 }
 
 impl<'ast> Fct<'ast> {

--- a/dora/src/vm/fct.rs
+++ b/dora/src/vm/fct.rs
@@ -1,4 +1,3 @@
-use crate::compiler::fct::JitFctId;
 use crate::ty::TypeList;
 use parking_lot::RwLock;
 use std::collections::HashMap;
@@ -447,5 +446,4 @@ pub struct FctDef {
     pub fct_id: FctId,
     pub cls_type_params: TypeList,
     pub fct_type_params: TypeList,
-    pub jit_fct_id: Option<JitFctId>,
 }

--- a/dora/src/vm/fct.rs
+++ b/dora/src/vm/fct.rs
@@ -67,7 +67,7 @@ pub struct Fct<'ast> {
     pub type_params: Vec<TypeParam>,
     pub kind: FctKind,
 
-    pub specializations_fct_def: RwLock<HashMap<(TypeList, TypeList), FctDefId>>,
+    pub specializations: RwLock<HashMap<(TypeList, TypeList), FctDefId>>,
 }
 
 impl<'ast> Fct<'ast> {

--- a/dora/src/vm/fct.rs
+++ b/dora/src/vm/fct.rs
@@ -446,6 +446,6 @@ pub struct FctDef {
     pub id: FctDefId,
     pub fct_id: FctId,
     pub cls_type_params: TypeList,
-    pub type_params: TypeList,
+    pub fct_type_params: TypeList,
     pub jit_fct_id: Option<JitFctId>,
 }

--- a/dora/src/vm/fct.rs
+++ b/dora/src/vm/fct.rs
@@ -1,3 +1,5 @@
+use crate::compiler::fct::JitFctId;
+use crate::ty::TypeList;
 use parking_lot::RwLock;
 
 use std::sync::Arc;
@@ -413,4 +415,34 @@ pub enum Intrinsic {
     DoubleArrayLen,
     DoubleArrayGet,
     DoubleArraySet,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct FctDefId(pub usize);
+
+impl FctDefId {
+    pub fn to_usize(self) -> usize {
+        self.0
+    }
+}
+
+impl From<usize> for FctDefId {
+    fn from(data: usize) -> FctDefId {
+        FctDefId(data)
+    }
+}
+
+impl<'ast> GrowableVec<RwLock<FctDef>> {
+    pub fn idx(&self, index: FctDefId) -> Arc<RwLock<FctDef>> {
+        self.idx_usize(index.0)
+    }
+}
+
+#[derive(Debug)]
+pub struct FctDef {
+    pub id: FctDefId,
+    pub fct_id: FctId,
+    pub cls_type_params: TypeList,
+    pub type_params: TypeList,
+    pub jit_fct_id: Option<JitFctId>,
 }


### PR DESCRIPTION
As discussed, to support function and class type params when calling a method, I added a `FctDef`. This is similar to `ClassDef` the specialization of a `Fct` with the corresponding type params.

The bytecode now uses the `FctDefId` instead of `FctDef` when referencing to a function. Cannon then uses this id to retrieve the corresponding type params and will generate the machine code accordingly.

