### PR TITLE
Implement {Float,Double}#compareTo in Dora, fixes 'unknown intrinsic FloatCmp/DoubleCmp'

### DIFF
--- a/dora/src/semck/prelude.rs
+++ b/dora/src/semck/prelude.rs
@@ -306,7 +306,6 @@ pub fn internal_functions<'ast>(vm: &mut VM<'ast>) {
     intrinsic_method(vm, clsid, "asInt", Intrinsic::FloatAsInt);
 
     intrinsic_method(vm, clsid, "equals", Intrinsic::FloatEq);
-    intrinsic_method(vm, clsid, "compareTo", Intrinsic::FloatCmp);
 
     intrinsic_method(vm, clsid, "plus", Intrinsic::FloatAdd);
     intrinsic_method(vm, clsid, "minus", Intrinsic::FloatSub);
@@ -328,7 +327,6 @@ pub fn internal_functions<'ast>(vm: &mut VM<'ast>) {
     intrinsic_method(vm, clsid, "asLong", Intrinsic::DoubleAsLong);
 
     intrinsic_method(vm, clsid, "equals", Intrinsic::DoubleEq);
-    intrinsic_method(vm, clsid, "compareTo", Intrinsic::DoubleCmp);
 
     intrinsic_method(vm, clsid, "plus", Intrinsic::DoubleAdd);
     intrinsic_method(vm, clsid, "minus", Intrinsic::DoubleSub);

--- a/dora/stdlib/Double.dora
+++ b/dora/stdlib/Double.dora
@@ -7,7 +7,13 @@
   @internal fun asLong() -> Long;
 
   @internal fun equals(rhs: Double) -> Bool;
-  @internal fun compareTo(rhs: Double) -> Int;
+  fun compareTo(rhs: Double) -> Int {
+    if self.isNan() || rhs.isNan() {
+      Int::minValue()
+    } else {
+      self.sortsAs(rhs)
+    }
+  }
   fun sortsAs(rhs: Double) -> Int {
     var ix = self.asLong();
     var iy = rhs.asLong();

--- a/dora/stdlib/Float.dora
+++ b/dora/stdlib/Float.dora
@@ -7,7 +7,13 @@
   @internal fun asInt() -> Int;
 
   @internal fun equals(rhs: Float) -> Bool;
-  @internal fun compareTo(rhs: Float) -> Int;
+  fun compareTo(rhs: Float) -> Int {
+    if self.isNan() || rhs.isNan() {
+      Int::minValue()
+    } else {
+      self.sortsAs(rhs)
+    }
+  }
   fun sortsAs(rhs: Float) -> Int {
     var ix = self.asInt();
     var iy = rhs.asInt();

--- a/tests/cmp.dora
+++ b/tests/cmp.dora
@@ -1,0 +1,85 @@
+fun main() {
+    assert(0.0F.compareTo(0.0F) == 0);
+    assert((-0.0F).compareTo(-0.0F) == 0);
+    assert(1.0F.compareTo(1.0F) == 0);
+    assert(0.0F.compareTo(1.0F) == -1);
+    assert(1.0F.compareTo(0.0F) == 1);
+    assert((-0.0F).compareTo(0.0F) == -1);
+    assert(0.0F.compareTo(-0.0F) == 1);
+    assert((0.0F/0.0F).compareTo(0.0F/0.0F) == Int::minValue());
+
+    assert(0.0.compareTo(0.0) == 0);
+    assert((-0.0).compareTo(-0.0) == 0);
+    assert(1.0.compareTo(1.0) == 0);
+    assert(0.0.compareTo(1.0) == -1);
+    assert(1.0.compareTo(0.0) == 1);
+    assert((-0.0).compareTo(0.0) == -1);
+    assert(0.0.compareTo(-0.0) == 1);
+    assert((0.0/0.0).compareTo(0.0/0.0) == Int::minValue());
+
+    // 11111111110000000000000000000000
+    let nanQuietNegative = (-4194304).asFloat();
+    // 11111111100000000000000000000001
+    let nanSignaNegative = (-8388607).asFloat();
+    // 11111111100000000000000000000000
+    let infNegative = (-8388608).asFloat();
+    // negative numbers
+    // positive numbers
+    // 01111111100000000000000000000000
+    let infPositive = 2139095040.asFloat();
+    // 01111111100000000000000000000001
+    let nanSignaPositive = 2139095041.asFloat();
+    // 01111111110000000000000000000000
+    let nanQuietPositive = 2143289344.asFloat();
+
+    assert(nanQuietNegative.compareTo(nanSignaNegative) == Int::minValue());
+    assert(nanSignaNegative.compareTo(infNegative) == Int::minValue());
+    assert(infNegative.compareTo(infPositive) == -1);
+    assert(infPositive.compareTo(nanSignaPositive) == Int::minValue());
+    assert(nanSignaPositive.compareTo(nanQuietPositive) == Int::minValue());
+
+    assert(nanQuietNegative.compareTo(-1.0F) == Int::minValue());
+    assert(nanSignaNegative.compareTo(-1.0F) == Int::minValue());
+    assert(infNegative.compareTo(-1.0F) == -1);
+    assert(infPositive.compareTo(-1.0F) == 1);
+    assert(nanSignaPositive.compareTo(-1.0F) == Int::minValue());
+
+    assert(nanQuietNegative.compareTo(1.0F) == Int::minValue());
+    assert(nanSignaNegative.compareTo(1.0F) == Int::minValue());
+    assert(infNegative.compareTo(1.0F) == -1);
+    assert(infPositive.compareTo(1.0F) == 1);
+    assert(nanSignaPositive.compareTo(1.0F) == Int::minValue());
+
+    // 1111111111111000000000000000000000000000000000000000000000000000
+    let nanQuietNegative = (-2251799813685248L).asDouble();
+    // 1111111111110000000000000000000000000000000000000000000000000001
+    let nanSignaNegative = (-4503599627370495L).asDouble();
+    // 1111111111110000000000000000000000000000000000000000000000000000
+    let infNegative = (-4503599627370496L).asDouble();
+    // negative numbers
+    // positive numbers
+    // 0111111111110000000000000000000000000000000000000000000000000000
+    let infPositive = 9218868437227405312L.asDouble();
+    // 0111111111110000000000000000000000000000000000000000000000000001
+    let nanSignaPositive = 9218868437227405313L.asDouble();
+    // 0111111111111000000000000000000000000000000000000000000000000000
+    let nanQuietPositive = 9221120237041090560L.asDouble();
+
+    assert(nanQuietNegative.compareTo(nanSignaNegative) == Int::minValue());
+    assert(nanSignaNegative.compareTo(infNegative) == Int::minValue());
+    assert(infNegative.compareTo(infPositive) == -1);
+    assert(infPositive.compareTo(nanSignaPositive) == Int::minValue());
+    assert(nanSignaPositive.compareTo(nanQuietPositive) == Int::minValue());
+
+    assert(nanQuietNegative.compareTo(-1.0) == Int::minValue());
+    assert(nanSignaNegative.compareTo(-1.0) == Int::minValue());
+    assert(infNegative.compareTo(-1.0) == -1);
+    assert(infPositive.compareTo(-1.0) == 1);
+    assert(nanSignaPositive.compareTo(-1.0) == Int::minValue());
+
+    assert(nanQuietNegative.compareTo(1.0) == Int::minValue());
+    assert(nanSignaNegative.compareTo(1.0) == Int::minValue());
+    assert(infNegative.compareTo(1.0) == -1);
+    assert(infPositive.compareTo(1.0) == 1);
+    assert(nanSignaPositive.compareTo(1.0) == Int::minValue());
+}


### PR DESCRIPTION
Fixes https://github.com/dinfuehr/dora/issues/118.

It would be nicer to deal with this in assembly, but as long as I can't figure out what's wrong with `sortsAs` in assembly (https://github.com/dinfuehr/dora/compare/master...soc:topic/total-order?expand=1), this seems to be out of reach. So at least fix the crash for now.