### PR TITLE
cannon: support for array

### DIFF
--- a/dora/src/bytecode/data.rs
+++ b/dora/src/bytecode/data.rs
@@ -315,6 +315,7 @@ pub enum BytecodeOpcode {
     InvokeStaticPtr,
 
     NewObject,
+    NewArray,
 
     RetVoid,
     RetBool,
@@ -378,6 +379,7 @@ impl BytecodeOpcode {
             | BytecodeOpcode::InvokeStaticDouble
             | BytecodeOpcode::InvokeStaticPtr
             | BytecodeOpcode::NewObject
+            | BytecodeOpcode::NewArray
             | BytecodeOpcode::Assert => true,
             _ => false,
         }

--- a/dora/src/bytecode/dumper.rs
+++ b/dora/src/bytecode/dumper.rs
@@ -102,6 +102,12 @@ impl<'a> BytecodeDumper<'a> {
         writeln!(self.w, " {}, {}", r1, cls.to_usize()).expect("write! failed");
     }
 
+    fn emit_new_array(&mut self, name: &str, r1: Register, cls: ClassDefId, length: Register) {
+        self.emit_start(name);
+        writeln!(self.w, " {}, {}, {}", r1, cls.to_usize(), length.to_usize())
+            .expect("write! failed");
+    }
+
     fn emit_start(&mut self, name: &str) {
         write!(self.w, "{}: {}", self.pos.to_usize(), name).expect("write! failed");
     }
@@ -909,6 +915,9 @@ impl<'a> BytecodeVisitor for BytecodeDumper<'a> {
 
     fn visit_new_object(&mut self, dest: Register, cls: ClassDefId) {
         self.emit_new("NewObject", dest, cls);
+    }
+    fn visit_new_array(&mut self, dest: Register, cls: ClassDefId, length: Register) {
+        self.emit_new_array("NewArray", dest, cls, length);
     }
 
     fn visit_ret_void(&mut self) {

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -10,6 +10,7 @@ use dora_parser::lexer::token::{FloatSuffix, IntSuffix};
 use crate::bytecode::{BytecodeFunction, BytecodeType, BytecodeWriter, Label, Register};
 use crate::semck::expr_block_always_returns;
 use crate::semck::specialize::{specialize_class_ty, specialize_type};
+use crate::size::InstanceSize;
 use crate::ty::{BuiltinType, TypeList};
 use crate::vm::{
     CallType, Fct, FctDef, FctDefId, FctId, FctKind, FctSrc, IdentType, Intrinsic, VarId, VM,
@@ -384,6 +385,11 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             _ => 0,
         };
 
+        for (idx, arg) in expr.args.iter().enumerate() {
+            let arg_reg = start_reg.offset(idx + arg_start_reg);
+            self.visit_expr(arg, DataDest::Reg(arg_reg));
+        }
+
         match *call_type {
             CallType::CtorNew(_, _) => {
                 let ty = fct.params_with_self()[0];
@@ -391,7 +397,21 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                 let ty = self.specialize_type(ty);
                 let cls_id = specialize_class_ty(self.vm, ty);
 
-                self.gen.emit_new_object(start_reg, cls_id);
+                let cls = self.vm.class_defs.idx(cls_id);
+                let cls = cls.read();
+
+                match cls.size {
+                    InstanceSize::Fixed(_) => {
+                        self.gen.emit_new_object(start_reg, cls_id);
+                    }
+                    InstanceSize::Array(_) => {
+                        let length_arg = start_reg.offset(1);
+                        self.gen.emit_new_array(start_reg, cls_id, length_arg);
+                    }
+                    _ => {
+                        unimplemented!();
+                    }
+                }
             }
             CallType::Method(_, _, _) => {
                 let obj_expr = expr.object().expect("method target required");
@@ -400,10 +420,6 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             _ => {}
         };
 
-        for (idx, arg) in expr.args.iter().enumerate() {
-            let arg_reg = start_reg.offset(idx + arg_start_reg);
-            self.visit_expr(arg, DataDest::Reg(arg_reg));
-        }
         self.gen.set_position(expr.pos);
 
         match *call_type {

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -416,7 +416,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                 }
             }
             _ => {}
-        };
+        }
 
         self.gen.set_position(expr.pos);
 

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -1,4 +1,3 @@
-use crate::semck::specialize::specialize_for_call_type;
 use dora_parser::lexer::position::Position;
 use std::collections::HashMap;
 
@@ -397,10 +396,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         }
 
         match *call_type {
-            CallType::CtorNew(_, _) => {
-                let ty = fct.params_with_self()[0];
-                let ty = specialize_for_call_type(&call_type, ty, self.vm);
-                let ty = self.specialize_type(ty);
+            CallType::CtorNew(ty, _) => {
                 let cls_id = specialize_class_ty(self.vm, ty);
 
                 let cls = self.vm.class_defs.idx(cls_id);

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -381,7 +381,13 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         self.gen.set_position(expr.pos);
 
         let arg_start_reg = match *call_type {
-            CallType::CtorNew(_, _) | CallType::Method(_, _, _) => 1,
+            CallType::CtorNew(_, _) => 1,
+            CallType::Method(_, _, _) => {
+                let obj_expr = expr.object().expect("method target required");
+                self.visit_expr(obj_expr, DataDest::Reg(start_reg));
+
+                1
+            }
             _ => 0,
         };
 
@@ -412,10 +418,6 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                         unimplemented!();
                     }
                 }
-            }
-            CallType::Method(_, _, _) => {
-                let obj_expr = expr.object().expect("method target required");
-                self.visit_expr(obj_expr, DataDest::Reg(start_reg));
             }
             _ => {}
         };

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -1430,8 +1430,8 @@ fn gen_method_call_void_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(1), r(0)),
                 ConstInt(r(2), 1),
+                MovPtr(r(1), r(0)),
                 InvokeDirectVoid(fct_id, r(1), 2),
                 RetVoid,
             ];
@@ -1454,10 +1454,10 @@ fn gen_method_call_void_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(1), r(0)),
                 ConstInt(r(2), 1),
                 ConstInt(r(3), 2),
                 ConstInt(r(4), 3),
+                MovPtr(r(1), r(0)),
                 InvokeDirectVoid(fct_id, r(1), 4),
                 RetVoid,
             ];
@@ -1526,8 +1526,8 @@ fn gen_method_call_bool_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstTrue(r(3)),
+                MovPtr(r(2), r(0)),
                 InvokeDirectBool(r(1), fct_id, r(2), 2),
                 RetBool(r(1)),
             ];
@@ -1550,10 +1550,10 @@ fn gen_method_call_bool_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstTrue(r(3)),
                 ConstFalse(r(4)),
                 ConstTrue(r(5)),
+                MovPtr(r(2), r(0)),
                 InvokeDirectBool(r(1), fct_id, r(2), 4),
                 RetBool(r(1)),
             ];
@@ -1622,8 +1622,8 @@ fn gen_method_call_byte_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstByte(r(3), 1),
+                MovPtr(r(2), r(0)),
                 InvokeDirectByte(r(1), fct_id, r(2), 2),
                 RetByte(r(1)),
             ];
@@ -1646,10 +1646,10 @@ fn gen_method_call_byte_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstByte(r(3), 1),
                 ConstByte(r(4), 2),
                 ConstByte(r(5), 3),
+                MovPtr(r(2), r(0)),
                 InvokeDirectByte(r(1), fct_id, r(2), 4),
                 RetByte(r(1)),
             ];
@@ -1718,8 +1718,8 @@ fn gen_method_call_char_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstChar(r(3), '1'),
+                MovPtr(r(2), r(0)),
                 InvokeDirectChar(r(1), fct_id, r(2), 2),
                 RetChar(r(1)),
             ];
@@ -1742,10 +1742,10 @@ fn gen_method_call_char_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstChar(r(3), '1'),
                 ConstChar(r(4), '2'),
                 ConstChar(r(5), '3'),
+                MovPtr(r(2), r(0)),
                 InvokeDirectChar(r(1), fct_id, r(2), 4),
                 RetChar(r(1)),
             ];
@@ -1814,8 +1814,8 @@ fn gen_method_call_int_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstInt(r(3), 1),
+                MovPtr(r(2), r(0)),
                 InvokeDirectInt(r(1), fct_id, r(2), 2),
                 RetInt(r(1)),
             ];
@@ -1838,10 +1838,10 @@ fn gen_method_call_int_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstInt(r(3), 1),
                 ConstInt(r(4), 2),
                 ConstInt(r(5), 3),
+                MovPtr(r(2), r(0)),
                 InvokeDirectInt(r(1), fct_id, r(2), 4),
                 RetInt(r(1)),
             ];
@@ -1910,8 +1910,8 @@ fn gen_method_call_long_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstLong(r(3), 1),
+                MovPtr(r(2), r(0)),
                 InvokeDirectLong(r(1), fct_id, r(2), 2),
                 RetLong(r(1)),
             ];
@@ -1934,10 +1934,10 @@ fn gen_method_call_long_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstLong(r(3), 1),
                 ConstLong(r(4), 2),
                 ConstLong(r(5), 3),
+                MovPtr(r(2), r(0)),
                 InvokeDirectLong(r(1), fct_id, r(2), 4),
                 RetLong(r(1)),
             ];
@@ -2006,8 +2006,8 @@ fn gen_method_call_float_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstFloat(r(3), 1_f32),
+                MovPtr(r(2), r(0)),
                 InvokeDirectFloat(r(1), fct_id, r(2), 2),
                 RetFloat(r(1)),
             ];
@@ -2030,10 +2030,10 @@ fn gen_method_call_float_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstFloat(r(3), 1_f32),
                 ConstFloat(r(4), 2_f32),
                 ConstFloat(r(5), 3_f32),
+                MovPtr(r(2), r(0)),
                 InvokeDirectFloat(r(1), fct_id, r(2), 4),
                 RetFloat(r(1)),
             ];
@@ -2102,8 +2102,8 @@ fn gen_method_call_double_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstDouble(r(3), 1_f64),
+                MovPtr(r(2), r(0)),
                 InvokeDirectDouble(r(1), fct_id, r(2), 2),
                 RetDouble(r(1)),
             ];
@@ -2126,10 +2126,10 @@ fn gen_method_call_double_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstDouble(r(3), 1_f64),
                 ConstDouble(r(4), 2_f64),
                 ConstDouble(r(5), 3_f64),
+                MovPtr(r(2), r(0)),
                 InvokeDirectDouble(r(1), fct_id, r(2), 4),
                 RetDouble(r(1)),
             ];
@@ -2198,8 +2198,8 @@ fn gen_method_call_ptr_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstString(r(3), "1".to_string()),
+                MovPtr(r(2), r(0)),
                 InvokeDirectPtr(r(1), fct_id, r(2), 2),
                 RetPtr(r(1)),
             ];
@@ -2222,10 +2222,10 @@ fn gen_method_call_ptr_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(2), r(0)),
                 ConstString(r(3), "1".to_string()),
                 ConstString(r(4), "2".to_string()),
                 ConstString(r(5), "3".to_string()),
+                MovPtr(r(2), r(0)),
                 InvokeDirectPtr(r(1), fct_id, r(2), 4),
                 RetPtr(r(1)),
             ];
@@ -2303,8 +2303,8 @@ fn gen_virtual_method_call_void_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(1), r(0)),
                 ConstInt(r(2), 1),
+                MovPtr(r(1), r(0)),
                 InvokeVirtualVoid(fct_id, r(1), 2),
                 RetVoid,
             ];
@@ -2330,10 +2330,10 @@ fn gen_virtual_method_call_void_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(1), r(0)),
                 ConstInt(r(2), 1),
                 ConstInt(r(3), 2),
                 ConstInt(r(4), 3),
+                MovPtr(r(1), r(0)),
                 InvokeVirtualVoid(fct_id, r(1), 4),
                 RetVoid,
             ];
@@ -2385,8 +2385,8 @@ fn gen_virtual_method_call_int_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(1), r(0)),
                 ConstInt(r(2), 1),
+                MovPtr(r(1), r(0)),
                 InvokeVirtualVoid(fct_id, r(1), 2),
                 RetVoid,
             ];
@@ -2412,10 +2412,10 @@ fn gen_virtual_method_call_int_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                MovPtr(r(1), r(0)),
                 ConstInt(r(2), 1),
                 ConstInt(r(3), 2),
                 ConstInt(r(4), 3),
+                MovPtr(r(1), r(0)),
                 InvokeVirtualVoid(fct_id, r(1), 4),
                 RetVoid,
             ];
@@ -2474,10 +2474,10 @@ fn gen_new_object_with_multiple_args() {
             let cls_id = vm.cls_def_by_name("Foo");
             let ctor_id = vm.ctor_def_by_name("Foo");
             let expected = vec![
-                NewObject(r(0), cls_id),
                 ConstInt(r(1), 1),
                 ConstInt(r(2), 2),
                 ConstInt(r(3), 3),
+                NewObject(r(0), cls_id),
                 InvokeDirectVoid(ctor_id, r(0), 4),
                 RetPtr(r(0)),
             ];
@@ -2493,7 +2493,7 @@ fn gen_position_new_object_with_multiple_args() {
             class Foo(a: Int, b: Int, c: Int)
             fun f() -> Foo { return Foo(1, 2, 3); }",
     );
-    let expected = vec![(0, p(3, 40))];
+    let expected = vec![(9, p(3, 40))];
     assert_eq!(expected, result);
 }
 

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -1430,8 +1430,8 @@ fn gen_method_call_void_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstInt(r(2), 1),
                 MovPtr(r(1), r(0)),
+                ConstInt(r(2), 1),
                 InvokeDirectVoid(fct_id, r(1), 2),
                 RetVoid,
             ];
@@ -1454,10 +1454,10 @@ fn gen_method_call_void_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(1), r(0)),
                 ConstInt(r(2), 1),
                 ConstInt(r(3), 2),
                 ConstInt(r(4), 3),
-                MovPtr(r(1), r(0)),
                 InvokeDirectVoid(fct_id, r(1), 4),
                 RetVoid,
             ];
@@ -1526,8 +1526,8 @@ fn gen_method_call_bool_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstTrue(r(3)),
                 MovPtr(r(2), r(0)),
+                ConstTrue(r(3)),
                 InvokeDirectBool(r(1), fct_id, r(2), 2),
                 RetBool(r(1)),
             ];
@@ -1550,10 +1550,10 @@ fn gen_method_call_bool_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(2), r(0)),
                 ConstTrue(r(3)),
                 ConstFalse(r(4)),
                 ConstTrue(r(5)),
-                MovPtr(r(2), r(0)),
                 InvokeDirectBool(r(1), fct_id, r(2), 4),
                 RetBool(r(1)),
             ];
@@ -1622,8 +1622,8 @@ fn gen_method_call_byte_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstByte(r(3), 1),
                 MovPtr(r(2), r(0)),
+                ConstByte(r(3), 1),
                 InvokeDirectByte(r(1), fct_id, r(2), 2),
                 RetByte(r(1)),
             ];
@@ -1646,10 +1646,10 @@ fn gen_method_call_byte_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(2), r(0)),
                 ConstByte(r(3), 1),
                 ConstByte(r(4), 2),
                 ConstByte(r(5), 3),
-                MovPtr(r(2), r(0)),
                 InvokeDirectByte(r(1), fct_id, r(2), 4),
                 RetByte(r(1)),
             ];
@@ -1718,8 +1718,8 @@ fn gen_method_call_char_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstChar(r(3), '1'),
                 MovPtr(r(2), r(0)),
+                ConstChar(r(3), '1'),
                 InvokeDirectChar(r(1), fct_id, r(2), 2),
                 RetChar(r(1)),
             ];
@@ -1742,10 +1742,10 @@ fn gen_method_call_char_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(2), r(0)),
                 ConstChar(r(3), '1'),
                 ConstChar(r(4), '2'),
                 ConstChar(r(5), '3'),
-                MovPtr(r(2), r(0)),
                 InvokeDirectChar(r(1), fct_id, r(2), 4),
                 RetChar(r(1)),
             ];
@@ -1814,8 +1814,8 @@ fn gen_method_call_int_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstInt(r(3), 1),
                 MovPtr(r(2), r(0)),
+                ConstInt(r(3), 1),
                 InvokeDirectInt(r(1), fct_id, r(2), 2),
                 RetInt(r(1)),
             ];
@@ -1838,10 +1838,10 @@ fn gen_method_call_int_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(2), r(0)),
                 ConstInt(r(3), 1),
                 ConstInt(r(4), 2),
                 ConstInt(r(5), 3),
-                MovPtr(r(2), r(0)),
                 InvokeDirectInt(r(1), fct_id, r(2), 4),
                 RetInt(r(1)),
             ];
@@ -1910,8 +1910,8 @@ fn gen_method_call_long_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstLong(r(3), 1),
                 MovPtr(r(2), r(0)),
+                ConstLong(r(3), 1),
                 InvokeDirectLong(r(1), fct_id, r(2), 2),
                 RetLong(r(1)),
             ];
@@ -1934,10 +1934,10 @@ fn gen_method_call_long_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(2), r(0)),
                 ConstLong(r(3), 1),
                 ConstLong(r(4), 2),
                 ConstLong(r(5), 3),
-                MovPtr(r(2), r(0)),
                 InvokeDirectLong(r(1), fct_id, r(2), 4),
                 RetLong(r(1)),
             ];
@@ -2006,8 +2006,8 @@ fn gen_method_call_float_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstFloat(r(3), 1_f32),
                 MovPtr(r(2), r(0)),
+                ConstFloat(r(3), 1_f32),
                 InvokeDirectFloat(r(1), fct_id, r(2), 2),
                 RetFloat(r(1)),
             ];
@@ -2030,10 +2030,10 @@ fn gen_method_call_float_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(2), r(0)),
                 ConstFloat(r(3), 1_f32),
                 ConstFloat(r(4), 2_f32),
                 ConstFloat(r(5), 3_f32),
-                MovPtr(r(2), r(0)),
                 InvokeDirectFloat(r(1), fct_id, r(2), 4),
                 RetFloat(r(1)),
             ];
@@ -2102,8 +2102,8 @@ fn gen_method_call_double_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstDouble(r(3), 1_f64),
                 MovPtr(r(2), r(0)),
+                ConstDouble(r(3), 1_f64),
                 InvokeDirectDouble(r(1), fct_id, r(2), 2),
                 RetDouble(r(1)),
             ];
@@ -2126,10 +2126,10 @@ fn gen_method_call_double_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(2), r(0)),
                 ConstDouble(r(3), 1_f64),
                 ConstDouble(r(4), 2_f64),
                 ConstDouble(r(5), 3_f64),
-                MovPtr(r(2), r(0)),
                 InvokeDirectDouble(r(1), fct_id, r(2), 4),
                 RetDouble(r(1)),
             ];
@@ -2198,8 +2198,8 @@ fn gen_method_call_ptr_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstString(r(3), "1".to_string()),
                 MovPtr(r(2), r(0)),
+                ConstString(r(3), "1".to_string()),
                 InvokeDirectPtr(r(1), fct_id, r(2), 2),
                 RetPtr(r(1)),
             ];
@@ -2222,10 +2222,10 @@ fn gen_method_call_ptr_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(2), r(0)),
                 ConstString(r(3), "1".to_string()),
                 ConstString(r(4), "2".to_string()),
                 ConstString(r(5), "3".to_string()),
-                MovPtr(r(2), r(0)),
                 InvokeDirectPtr(r(1), fct_id, r(2), 4),
                 RetPtr(r(1)),
             ];
@@ -2303,8 +2303,8 @@ fn gen_virtual_method_call_void_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstInt(r(2), 1),
                 MovPtr(r(1), r(0)),
+                ConstInt(r(2), 1),
                 InvokeVirtualVoid(fct_id, r(1), 2),
                 RetVoid,
             ];
@@ -2330,10 +2330,10 @@ fn gen_virtual_method_call_void_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(1), r(0)),
                 ConstInt(r(2), 1),
                 ConstInt(r(3), 2),
                 ConstInt(r(4), 3),
-                MovPtr(r(1), r(0)),
                 InvokeVirtualVoid(fct_id, r(1), 4),
                 RetVoid,
             ];
@@ -2385,8 +2385,8 @@ fn gen_virtual_method_call_int_with_1_arg() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
-                ConstInt(r(2), 1),
                 MovPtr(r(1), r(0)),
+                ConstInt(r(2), 1),
                 InvokeVirtualVoid(fct_id, r(1), 2),
                 RetVoid,
             ];
@@ -2412,10 +2412,10 @@ fn gen_virtual_method_call_int_with_3_args() {
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
             let expected = vec![
+                MovPtr(r(1), r(0)),
                 ConstInt(r(2), 1),
                 ConstInt(r(3), 2),
                 ConstInt(r(4), 3),
-                MovPtr(r(1), r(0)),
                 InvokeVirtualVoid(fct_id, r(1), 4),
                 RetVoid,
             ];

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -2892,6 +2892,7 @@ pub enum Bytecode {
     InvokeStaticPtr(Register, FctDefId, Register, u32),
 
     NewObject(Register, ClassDefId),
+    NewArray(Register, ClassDefId, Register),
 
     RetVoid,
     RetBool(Register),
@@ -3788,6 +3789,9 @@ impl<'a> BytecodeVisitor for BytecodeArrayBuilder<'a> {
 
     fn visit_new_object(&mut self, dest: Register, cls: ClassDefId) {
         self.emit(Bytecode::NewObject(dest, cls));
+    }
+    fn visit_new_array(&mut self, dest: Register, cls: ClassDefId, length: Register) {
+        self.emit(Bytecode::NewArray(dest, cls, length));
     }
 
     fn visit_ret_void(&mut self) {

--- a/dora/src/bytecode/reader.rs
+++ b/dora/src/bytecode/reader.rs
@@ -1110,6 +1110,13 @@ where
                 self.visitor.visit_new_object(dest, cls);
             }
 
+            BytecodeOpcode::NewArray => {
+                let dest = self.read_register(wide);
+                let cls = self.read_class(wide);
+                let length = self.read_register(wide);
+                self.visitor.visit_new_array(dest, cls, length);
+            }
+
             BytecodeOpcode::RetVoid => {
                 self.visitor.visit_ret_void();
             }
@@ -2007,6 +2014,10 @@ pub trait BytecodeVisitor {
     }
 
     fn visit_new_object(&mut self, _dest: Register, _cls: ClassDefId) {
+        unimplemented!();
+    }
+
+    fn visit_new_array(&mut self, _dest: Register, _cls: ClassDefId, _length: Register) {
         unimplemented!();
     }
 

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -1076,6 +1076,10 @@ impl BytecodeWriter {
         self.emit_new(BytecodeOpcode::NewObject, dest, cls_id);
     }
 
+    pub fn emit_new_array(&mut self, dest: Register, cls_id: ClassDefId, length: Register) {
+        self.emit_new_arr(BytecodeOpcode::NewArray, dest, cls_id, length);
+    }
+
     pub fn generate(mut self) -> BytecodeFunction {
         self.resolve_forward_jumps();
 
@@ -1166,6 +1170,15 @@ impl BytecodeWriter {
 
     fn emit_new(&mut self, inst: BytecodeOpcode, r1: Register, cid: ClassDefId) {
         let values = [r1.to_usize() as u32, cid.to_usize() as u32];
+        self.emit_values(inst, &values);
+    }
+
+    fn emit_new_arr(&mut self, inst: BytecodeOpcode, r1: Register, cid: ClassDefId, lth: Register) {
+        let values = [
+            r1.to_usize() as u32,
+            cid.to_usize() as u32,
+            lth.to_usize() as u32,
+        ];
         self.emit_values(inst, &values);
     }
 

--- a/dora/src/cannon/codegen.rs
+++ b/dora/src/cannon/codegen.rs
@@ -2358,6 +2358,10 @@ impl<'a, 'ast: 'a> BytecodeVisitor for CannonCodeGen<'a, 'ast> {
         self.emit_new_object(dest, cls)
     }
 
+    fn visit_new_array(&mut self, dest: Register, cls: ClassDefId, length: Register) {
+        unimplemented!();
+    }
+
     fn visit_ret_void(&mut self) {
         self.emit_epilog();
     }

--- a/tests/cannon/evaluation-order1.dora
+++ b/tests/cannon/evaluation-order1.dora
@@ -1,15 +1,15 @@
 //= stdout "Foo\nsomeInt\nbar\n"
 
-class Foo() {
+@cannon class Foo() {
   println("Foo");
   fun bar(x: Int) { println("bar"); }
 }
 
-fun main() {
+@cannon fun main() {
   Foo().bar(someInt())
 }
 
-fun someInt() -> Int {
+@cannon fun someInt() -> Int {
   println("someInt");
   return 1;
 }

--- a/tests/cannon/evaluation-order1.dora
+++ b/tests/cannon/evaluation-order1.dora
@@ -1,0 +1,15 @@
+//= stdout "Foo\nsomeInt\nbar\n"
+
+class Foo() {
+  println("Foo");
+  fun bar(x: Int) { println("bar"); }
+}
+
+fun main() {
+  Foo().bar(someInt())
+}
+
+fun someInt() -> Int {
+  println("someInt");
+  return 1;
+}

--- a/tests/evaluation-order1.dora
+++ b/tests/evaluation-order1.dora
@@ -1,15 +1,16 @@
+//= cannon
 //= stdout "Foo\nsomeInt\nbar\n"
 
-@cannon class Foo() {
+class Foo() {
   println("Foo");
   fun bar(x: Int) { println("bar"); }
 }
 
-@cannon fun main() {
+fun main() {
   Foo().bar(someInt())
 }
 
-@cannon fun someInt() -> Int {
+fun someInt() -> Int {
   println("someInt");
   return 1;
 }


### PR DESCRIPTION
I started the implementation for array support in cannon. For now, only the allocation of a new Array is supported and only if the array is not a array of tuples, objects or unit, or is of length 0.

Before I continue, I thought it would be a good idea to get your feedback on this. Especially, I would like your opinion on my decision to change the order of how the arguments of a call are handled. The reason behind this decision is the length argument of the array, which is needed to calculate the size of the array. I could have just handled this case differently, but I see no reason, why this would be necessary.

Next, I would add functionality for set&get of array values, before I fill the missing types of arrays and the various edge cases (e.g. no length argument.)
