### PR TITLE
Fix the error messages for annotation parsing problems

### DIFF
--- a/dora-parser/src/parser.rs
+++ b/dora-parser/src/parser.rs
@@ -701,10 +701,10 @@ impl<'a> Parser<'a> {
                 "test" => Modifier::Test,
                 "cannon" => Modifier::Cannon,
                 "optimize_immediately" => Modifier::OptimizeImmediately,
-                _ => {
+                annotation => {
                     return Err(ParseErrorAndPos::new(
                         self.token.position,
-                        ParseError::UnknownAnnotation(self.token.to_string()),
+                        ParseError::UnknownAnnotation(annotation.into()),
                     ));
                 }
             };
@@ -712,7 +712,7 @@ impl<'a> Parser<'a> {
             if modifiers.contains(modifier) {
                 return Err(ParseErrorAndPos::new(
                     self.token.position,
-                    ParseError::RedundantAnnotation(self.token.name()),
+                    ParseError::RedundantAnnotation(modifier.name().into()),
                 ));
             }
 


### PR DESCRIPTION
The keyword was printed instead of the offending annotation, e. g.:

    @open @open
    class Foo()

Before: redundant annotation class
After:  redundant annotation open