### PR TITLE
Split terms and types into separate namespaces

### DIFF
--- a/dora/src/error/msg.rs
+++ b/dora/src/error/msg.rs
@@ -25,7 +25,9 @@ pub enum SemError {
     ShadowFunction(String),
     ShadowParam(String),
     ShadowClass(String),
+    ShadowClassConstructor(String),
     ShadowStruct(String),
+    ShadowStructConstructor(String),
     ShadowTrait(String),
     ShadowField(String),
     ShadowGlobal(String),
@@ -207,7 +209,13 @@ impl SemError {
             SemError::ShadowFunction(ref name) => format!("can not shadow function `{}`.", name),
             SemError::ShadowParam(ref name) => format!("can not shadow param `{}`.", name),
             SemError::ShadowClass(ref name) => format!("can not shadow class `{}`.", name),
+            SemError::ShadowClassConstructor(ref name) => {
+                format!("can not shadow constructor of class `{}`.", name)
+            }
             SemError::ShadowStruct(ref name) => format!("can not shadow struct `{}`.", name),
+            SemError::ShadowStructConstructor(ref name) => {
+                format!("can not shadow constructor of struct `{}`.", name)
+            }
             SemError::ShadowTrait(ref name) => format!("can not shadow trait `{}`.", name),
             SemError::ShadowField(ref name) => {
                 format!("field with name `{}` already exists.", name)

--- a/dora/src/semck/fctdefck.rs
+++ b/dora/src/semck/fctdefck.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::error::msg::SemError;
 use crate::semck;
-use crate::sym::Sym;
+use crate::sym::TypeSym;
 use crate::ty::BuiltinType;
 use crate::vm::{self, Fct, FctId, FctParent, FctSrc, VM};
 use dora_parser::ast::visit::*;
@@ -32,8 +32,8 @@ pub fn check<'a, 'ast>(vm: &VM<'ast>) {
                 let mut type_param_id = 0;
 
                 for param in &cls.type_params {
-                    let sym = Sym::SymClassTypeParam(cls.id, type_param_id.into());
-                    vm.sym.lock().insert(param.name, sym);
+                    let sym = TypeSym::SymClassTypeParam(cls.id, type_param_id.into());
+                    vm.sym.lock().insert_type(param.name, sym);
                     type_param_id += 1;
                 }
 
@@ -107,8 +107,8 @@ pub fn check<'a, 'ast>(vm: &VM<'ast>) {
                         }
                     }
 
-                    let sym = Sym::SymFctTypeParam(fct.id, type_param_id.into());
-                    vm.sym.lock().insert(type_param.name, sym);
+                    let sym = TypeSym::SymFctTypeParam(fct.id, type_param_id.into());
+                    vm.sym.lock().insert_type(type_param.name, sym);
                     type_param_id += 1;
                 }
             } else {

--- a/dora/src/semck/impldefck.rs
+++ b/dora/src/semck/impldefck.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::error::msg::SemError;
 use crate::semck;
-use crate::sym::Sym;
+use crate::sym::TypeSym;
 use crate::ty::BuiltinType;
 use crate::vm::{Fct, FctId, FctKind, FctParent, FctSrc, FileId, ImplId, NodeMap, VM};
 
@@ -53,7 +53,7 @@ impl<'x, 'ast> ImplCheck<'x, 'ast> {
 
         if let Some(ref trait_type) = i.trait_type {
             if let Some(trait_name) = trait_type.to_basic_without_type_params() {
-                if let Some(Sym::SymTrait(trait_id)) = self.vm.sym.lock().get(trait_name) {
+                if let Some(TypeSym::SymTrait(trait_id)) = self.vm.sym.lock().get_type(trait_name) {
                     ximpl.trait_id = Some(trait_id);
                 } else {
                     let name = self.vm.interner.str(trait_name).to_string();

--- a/dora/src/semck/moduledefck.rs
+++ b/dora/src/semck/moduledefck.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::error::msg::SemError;
 use crate::semck;
-use crate::sym::Sym;
+use crate::sym::TypeSym;
 use crate::ty::{BuiltinType, TypeList};
 
 use crate::vm::module::ModuleId;
@@ -66,10 +66,10 @@ impl<'x, 'ast> ModuleCheck<'x, 'ast> {
 
     fn check_parent_class(&mut self, parent_class: &'ast ast::ParentClass) {
         let name = self.vm.interner.str(parent_class.name).to_string();
-        let sym = self.vm.sym.lock().get(parent_class.name);
+        let sym = self.vm.sym.lock().get_type(parent_class.name);
 
         match sym {
-            Some(Sym::SymClass(cls_id)) => {
+            Some(TypeSym::SymClass(cls_id)) => {
                 let super_cls = self.vm.classes.idx(cls_id);
                 let super_cls = super_cls.read();
 

--- a/dora/src/semck/nameck.rs
+++ b/dora/src/semck/nameck.rs
@@ -8,8 +8,11 @@ use dora_parser::ast::*;
 use dora_parser::interner::Name;
 use dora_parser::lexer::position::Position;
 
-use crate::sym::Sym;
-use crate::sym::Sym::*;
+use crate::semck::globaldef::{report_term_shadow, report_type_shadow};
+use crate::sym::TermSym::{
+    SymClassConstructor, SymConst, SymFct, SymGlobal, SymModule, SymStructConstructor, SymVar,
+};
+use crate::sym::TypeSym::{SymClass, SymClassTypeParam, SymEnum, SymFctTypeParam, SymStruct};
 use crate::ty::BuiltinType;
 
 pub fn check<'ast>(vm: &VM<'ast>) {
@@ -59,7 +62,7 @@ impl<'a, 'ast> NameCheck<'a, 'ast> {
                 self.vm
                     .sym
                     .lock()
-                    .insert(tp.name, SymClassTypeParam(cls_id, tpid.into()));
+                    .insert_type(tp.name, SymClassTypeParam(cls_id, tpid.into()));
             }
         }
 
@@ -68,7 +71,7 @@ impl<'a, 'ast> NameCheck<'a, 'ast> {
                 self.vm
                     .sym
                     .lock()
-                    .insert(tp.name, SymFctTypeParam(self.fct.id, tpid.into()));
+                    .insert_type(tp.name, SymFctTypeParam(self.fct.id, tpid.into()));
             }
         }
 
@@ -130,33 +133,16 @@ impl<'a, 'ast> NameCheck<'a, 'ast> {
         self.src.vars.push(var);
     }
 
-    pub fn add_var<F>(&mut self, mut var: Var, replaceable: F) -> Result<VarId, Sym>
-    where
-        F: FnOnce(&Sym) -> bool,
-    {
+    pub fn add_var(&mut self, mut var: Var) -> VarId {
         let name = var.name;
         let var_id = VarId(self.src.vars.len());
 
         var.id = var_id;
 
-        let result = match self.vm.sym.lock().get(name) {
-            Some(sym) => {
-                if replaceable(&sym) {
-                    Ok(var_id)
-                } else {
-                    Err(sym)
-                }
-            }
-            None => Ok(var_id),
-        };
-
-        if result.is_ok() {
-            self.vm.sym.lock().insert(name, SymVar(var_id));
-        }
-
+        self.vm.sym.lock().insert_term(name, SymVar(var_id));
         self.src.vars.push(var);
 
-        result
+        var_id
     }
 
     fn check_stmt_var(&mut self, var: &'ast StmtVarType) {
@@ -172,104 +158,105 @@ impl<'a, 'ast> NameCheck<'a, 'ast> {
             self.visit_expr(expr);
         }
 
-        // variables are not allowed to replace types, other variables
-        // and functions can be replaced
-        match self.add_var(var_ctxt, |sym| !sym.is_class()) {
-            Ok(var_id) => {
-                self.src.map_vars.insert(var.id, var_id);
+        let type_sym = self.vm.sym.lock().get_type(var.name);
+        match type_sym {
+            Some(SymClass(_)) | Some(SymStruct(_)) => {
+                report_type_shadow(self.vm, var.name, self.fct.file, var.pos, type_sym.unwrap())
             }
-
-            Err(_) => {
-                let name = str(self.vm, var.name);
-                report(self.vm, self.fct.file, var.pos, SemError::ShadowClass(name));
+            _ => {
+                let var_id = self.add_var(var_ctxt);
+                self.src.map_vars.insert(var.id, var_id)
             }
         }
     }
 
-    fn check_stmt_for(&mut self, for_loop: &'ast StmtForType) {
-        self.visit_expr(&for_loop.expr);
+    fn check_stmt_for(&mut self, fl: &'ast StmtForType) {
+        self.visit_expr(&fl.expr);
 
         self.vm.sym.lock().push_level();
 
         let var_ctxt = Var {
             id: VarId(0),
-            name: for_loop.name,
+            name: fl.name,
             reassignable: false,
             ty: BuiltinType::Unit,
-            node_id: for_loop.id,
+            node_id: fl.id,
         };
-
-        match self.add_var(var_ctxt, |sym| !sym.is_class()) {
-            Ok(var_id) => {
-                self.src.map_vars.insert(for_loop.id, var_id);
+        let type_sym = self.vm.sym.lock().get_type(fl.name);
+        match type_sym {
+            Some(SymClass(_)) | Some(SymStruct(_)) => {
+                report_type_shadow(self.vm, fl.name, self.fct.file, fl.pos, type_sym.unwrap())
             }
-
-            Err(_) => {
-                let name = str(self.vm, for_loop.name);
-                report(
-                    self.vm,
-                    self.fct.file,
-                    for_loop.pos,
-                    SemError::ShadowClass(name),
-                );
+            _ => {
+                let var_id = self.add_var(var_ctxt);
+                self.src.map_vars.insert(fl.id, var_id);
             }
         }
 
-        self.visit_stmt(&for_loop.block);
+        self.visit_stmt(&fl.block);
         self.vm.sym.lock().pop_level();
     }
 
     fn check_expr_ident(&mut self, ident: &'ast ExprIdentType) {
-        let sym = self.vm.sym.lock().get(ident.name);
+        let term_sym = self.vm.sym.lock().get_term(ident.name);
+        let type_sym = self.vm.sym.lock().get_type(ident.name);
 
-        match sym {
-            Some(SymVar(id)) => {
+        match (term_sym, type_sym) {
+            (Some(SymVar(id)), None) => {
                 self.src.map_idents.insert(ident.id, IdentType::Var(id));
             }
 
-            Some(SymGlobal(id)) => {
+            (Some(SymGlobal(id)), None) => {
                 self.src.map_idents.insert(ident.id, IdentType::Global(id));
             }
 
-            Some(SymStruct(id)) => {
-                self.src.map_idents.insert(ident.id, IdentType::Struct(id));
-            }
-
-            Some(SymConst(id)) => {
+            (Some(SymConst(id)), None) => {
                 self.src.map_idents.insert(ident.id, IdentType::Const(id));
             }
 
-            Some(SymFct(id)) => {
+            (Some(SymFct(id)), None) => {
                 self.src.map_idents.insert(ident.id, IdentType::Fct(id));
             }
 
-            Some(SymClass(id)) => {
-                self.src.map_idents.insert(ident.id, IdentType::Class(id));
-            }
-
-            Some(SymModule(id)) => {
+            (Some(SymModule(id)), None) => {
                 self.src.map_idents.insert(ident.id, IdentType::Module(id));
             }
 
-            Some(SymFctTypeParam(fct_id, id)) => {
+            (None, Some(SymStruct(id))) => {
+                self.src.map_idents.insert(ident.id, IdentType::Struct(id));
+            }
+
+            (None, Some(SymClass(id))) => {
+                self.src.map_idents.insert(ident.id, IdentType::Class(id));
+            }
+
+            (None, Some(SymFctTypeParam(fct_id, id))) => {
                 let ty = BuiltinType::FctTypeParam(fct_id, id);
                 self.src
                     .map_idents
                     .insert(ident.id, IdentType::TypeParam(ty));
             }
 
-            Some(SymClassTypeParam(cls_id, id)) => {
+            (None, Some(SymClassTypeParam(cls_id, id))) => {
                 let ty = BuiltinType::ClassTypeParam(cls_id, id);
                 self.src
                     .map_idents
                     .insert(ident.id, IdentType::TypeParam(ty));
             }
 
-            Some(SymEnum(id)) => {
+            (None, Some(SymEnum(id))) => {
                 self.src.map_idents.insert(ident.id, IdentType::Enum(id));
             }
 
-            _ => {
+            (Some(SymClassConstructor(id)), _) => {
+                self.src.map_idents.insert(ident.id, IdentType::Class(id))
+            }
+
+            (Some(SymStructConstructor(id)), _) => {
+                self.src.map_idents.insert(ident.id, IdentType::Struct(id))
+            }
+
+            (None, None) => {
                 let name = self.vm.interner.str(ident.name).to_string();
                 report(
                     self.vm,
@@ -278,6 +265,8 @@ impl<'a, 'ast> NameCheck<'a, 'ast> {
                     SemError::UnknownIdentifier(name),
                 );
             }
+
+            _ => unreachable!(),
         }
     }
 
@@ -316,22 +305,15 @@ impl<'a, 'ast> Visitor<'ast> for NameCheck<'a, 'ast> {
             node_id: p.id,
         };
 
-        // params are only allowed to replace functions,
-        // types and vars cannot be replaced
-        match self.add_var(var_ctxt, |sym| sym.is_fct()) {
-            Ok(var_id) => {
-                self.src.map_vars.insert(p.id, var_id);
+        // params are only allowed to replace functions, vars cannot be replaced
+        let term_sym = self.vm.sym.lock().get_term(p.name);
+        match term_sym {
+            Some(SymFct(_)) | None => {
+                let var_id = self.add_var(var_ctxt);
+                self.src.map_vars.insert(p.id, var_id)
             }
-
-            Err(sym) => {
-                let name = str(self.vm, p.name);
-                let msg = if sym.is_class() {
-                    SemError::ShadowClass(name)
-                } else {
-                    SemError::ShadowParam(name)
-                };
-
-                report(self.vm, self.fct.file, p.pos, msg);
+            Some(conflict_sym) => {
+                report_term_shadow(self.vm, p.name, self.fct.file, p.pos, conflict_sym)
             }
         }
     }
@@ -370,6 +352,7 @@ fn str(vm: &VM, name: Name) -> String {
 #[cfg(test)]
 mod tests {
     use crate::error::msg::SemError;
+    use crate::error::msg::SemError::ShadowClassConstructor;
     use crate::semck::tests::*;
 
     #[test]
@@ -391,7 +374,7 @@ mod tests {
         err(
             "fun Int() {}",
             pos(1, 1),
-            SemError::ShadowClass("Int".into()),
+            SemError::ShadowClassConstructor("Int".into()),
         );
     }
 
@@ -400,7 +383,7 @@ mod tests {
         err(
             "fun test(Bool: String) {}",
             pos(1, 10),
-            SemError::ShadowClass("Bool".into()),
+            ShadowClassConstructor("Bool".into()),
         );
     }
 

--- a/dora/src/stdlib.rs
+++ b/dora/src/stdlib.rs
@@ -11,7 +11,7 @@ use crate::gc::{Address, GcReason};
 use crate::handle::{scope as handle_scope, Handle};
 use crate::object::{ByteArray, Obj, Ref, Str};
 use crate::stack::stacktrace_from_last_dtn;
-use crate::sym::Sym::SymFct;
+use crate::sym::TermSym::SymFct;
 use crate::threads::{DoraThread, STACK_SIZE, THREAD};
 use crate::ty::TypeList;
 use crate::vm::{get_vm, stack_pointer, Trap};
@@ -124,7 +124,7 @@ pub extern "C" fn call(fct: Handle<Str>) {
     let vm = get_vm();
     let name = vm.interner.intern(fct_name);
 
-    let sym = vm.sym.lock().get(name);
+    let sym = vm.sym.lock().get_term(name);
 
     match sym {
         Some(SymFct(fct_id)) => {

--- a/dora/src/typeck/expr.rs
+++ b/dora/src/typeck/expr.rs
@@ -7,7 +7,7 @@ use crate::error::msg::SemError;
 use crate::semck::specialize::replace_type_param;
 use crate::semck::typeparamck;
 use crate::semck::{always_returns, expr_always_returns};
-use crate::sym::Sym::SymClass;
+use crate::sym::TypeSym::SymClass;
 use crate::ty::{BuiltinType, TypeList, TypeParamId};
 use crate::typeck::lookup::MethodLookup;
 use crate::vm::{
@@ -1421,7 +1421,7 @@ impl<'a, 'ast> TypeCheck<'a, 'ast> {
             return;
         }
 
-        match self.vm.sym.lock().get(class) {
+        match self.vm.sym.lock().get_type(class) {
             Some(SymClass(cls_id)) => {
                 let mut lookup = MethodLookup::new(self.vm, self.file)
                     .pos(e.pos)

--- a/dora/src/typeck/tests.rs
+++ b/dora/src/typeck/tests.rs
@@ -619,6 +619,7 @@ fn access_super_class_field() {
 #[test]
 fn same_names() {
     ok("class Foo { var Foo: Foo = Foo(); }");
+    ok("class Foo fun foo() { let Foo: Int = 1; }");
     err(
         "class Foo { var Foo: Foo = Foo(); } module Foo { fun Foo() -> Foo = nil; }",
         pos(1, 37),

--- a/dora/src/typeck/tests.rs
+++ b/dora/src/typeck/tests.rs
@@ -429,7 +429,7 @@ fn type_function_params() {
 #[test]
 fn type_return_nil() {
     ok("fun foo() -> String { return nil; }");
-    ok("class Foo fun foo() -> Foo { return nil; }");
+    ok("class Bar fun foo() -> Bar { return nil; }");
     err(
         "fun foo() -> Int { return nil; }",
         pos(1, 20),
@@ -614,6 +614,16 @@ fn super_class() {
 fn access_super_class_field() {
     ok("@open class A(var a: Int) class B(x: Int): A(x*2)
             fun foo(b: B) { b.a = b.a + 10; }");
+}
+
+#[test]
+fn same_names() {
+    ok("class Foo { var Foo: Foo = Foo(); }");
+    err(
+        "class Foo { var Foo: Foo = Foo(); } module Foo { fun Foo() -> Foo = nil; }",
+        pos(1, 37),
+        SemError::ShadowClassConstructor("Foo".into()),
+    );
 }
 
 #[test]

--- a/dora/src/vm.rs
+++ b/dora/src/vm.rs
@@ -16,11 +16,12 @@ use crate::object::{Ref, Testing};
 use crate::safepoint;
 use crate::stack::DoraToNativeInfo;
 use crate::stdlib;
-use crate::sym::Sym::*;
-use crate::sym::*;
+use crate::sym::TermSym::SymFct;
+use crate::sym::{SymTable, TermSym};
 use crate::threads::{Threads, STACK_SIZE, THREAD};
 use crate::ty::{BuiltinType, LambdaTypes, TypeList, TypeLists, TypeParamId};
 use crate::utils::GrowableVec;
+use crate::vm::module::{Module, ModuleDef, ModuleId};
 
 use dora_parser::ast;
 use dora_parser::interner::*;
@@ -47,7 +48,6 @@ pub use self::strct::{
 pub use self::traits::{TraitData, TraitId};
 pub use self::tuple::{ensure_tuple, TupleId, Tuples};
 pub use self::vip::{KnownClasses, KnownElements, KnownFunctions};
-use crate::vm::module::{Module, ModuleDef, ModuleId};
 
 pub mod class;
 mod cnst;
@@ -282,16 +282,16 @@ impl<'ast> VM<'ast> {
         fctid
     }
 
-    pub fn add_fct_to_sym(&mut self, fct: Fct<'ast>) -> Result<FctId, Sym> {
+    pub fn add_fct_to_sym(&mut self, fct: Fct<'ast>) -> Result<FctId, TermSym> {
         let name = fct.name;
         let fctid = self.add_fct(fct);
 
         let mut sym = self.sym.lock();
 
-        match sym.get(name) {
+        match sym.get_term(name) {
             Some(sym) => Err(sym),
             None => {
-                assert!(sym.insert(name, SymFct(fctid)).is_none());
+                assert!(sym.insert_term(name, SymFct(fctid)).is_none());
 
                 Ok(fctid)
             }


### PR DESCRIPTION
This reduces the amount of "surprising" name clashes¹ and
is required for both modules and annotations to work well:

- It allows modules to have the same name as a class or struct.
  This is a stepping stone to replacing @static members with members inside modules.
- It avoids annotation names clashing with function names (like in `fun test()`).¹

¹ Annotations (which are types) start with a lowercase letter because it looks more familiar/
  more like a modifier and draws away less attention from the keywords that follows.
  Nevertheless, we get some additional benefit out of it:
  It makes annotations unlikely to ever clash with another type definition,
  because classes, traits, structs all start with an uppercase letter by convention.