### PR TITLE
Module methods

### DIFF
--- a/dora/src/baseline/codegen.rs
+++ b/dora/src/baseline/codegen.rs
@@ -1342,6 +1342,7 @@ where
             &IdentType::Fct(_) | &IdentType::FctType(_, _) => unreachable!(),
             &IdentType::Class(_) | &IdentType::ClassType(_, _) => unreachable!(),
             &IdentType::Module(_) => unreachable!(),
+            &IdentType::ClassAndModule(_, _) => unreachable!(),
             &IdentType::Method(_, _) | &IdentType::MethodType(_, _, _) => unreachable!(),
             &IdentType::TypeParam(_) | &IdentType::TypeParamStaticMethod(_, _) => unreachable!(),
             &IdentType::StaticMethod(_, _) | &IdentType::StaticMethodType(_, _, _) => {
@@ -1716,6 +1717,7 @@ where
             &IdentType::Fct(_) | &IdentType::FctType(_, _) => unreachable!(),
             &IdentType::Class(_) | &IdentType::ClassType(_, _) => unreachable!(),
             &IdentType::Module(_) => unreachable!(),
+            &IdentType::ClassAndModule(_, _) => unreachable!(),
             &IdentType::Method(_, _) | &IdentType::MethodType(_, _, _) => unreachable!(),
             &IdentType::TypeParam(_) | &IdentType::TypeParamStaticMethod(_, _) => unreachable!(),
             &IdentType::StaticMethod(_, _) | &IdentType::StaticMethodType(_, _, _) => {
@@ -1963,6 +1965,8 @@ where
                         fct_id
                     }
                 }
+
+                CallType::ModuleMethod(_, fct_id, _) => fct_id,
 
                 CallType::Fct(fid, _, _) => fid,
 
@@ -3639,6 +3643,13 @@ where
             }
 
             CallType::Method(ty, _, ref type_params) => {
+                let ty = self.specialize_type(ty);
+
+                cls_type_params = ty.type_params(self.vm);
+                fct_type_params = type_params.clone();
+            }
+
+            CallType::ModuleMethod(ty, _, ref type_params) => {
                 let ty = self.specialize_type(ty);
 
                 cls_type_params = ty.type_params(self.vm);

--- a/dora/src/semck/clsdefck.rs
+++ b/dora/src/semck/clsdefck.rs
@@ -317,8 +317,7 @@ impl<'x, 'ast> Visitor<'ast> for ClsDefCheck<'x, 'ast> {
             has_optimize_immediately: f.has_optimize_immediately,
             variadic_arguments: false,
 
-            // abstract for methods also means that method is open to
-            // override
+            // abstract for methods also means that method is open to override
             has_open: f.has_open || f.is_abstract,
             has_final: f.has_final,
             is_pub: f.is_pub,

--- a/dora/src/semck/fctdefck.rs
+++ b/dora/src/semck/fctdefck.rs
@@ -186,6 +186,12 @@ pub fn check<'a, 'ast>(vm: &VM<'ast>) {
                 check_against_methods(vm, &*fct, &ximpl.methods);
             }
 
+            FctParent::Module(modid) => {
+                let module = vm.modules.idx(modid);
+                let module = module.read();
+                check_against_methods(vm, &*fct, &module.methods);
+            }
+
             _ => {}
         }
 

--- a/dora/src/semck/moduledefck.rs
+++ b/dora/src/semck/moduledefck.rs
@@ -341,6 +341,11 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_module_fun_call() {
+        ok("module Foo { fun foo() {} } fun main() { Foo::foo(); }");
+    }
+
     #[ignore]
     #[test] // should fail but doesn't
     fn field_self_assignment() {

--- a/dora/src/semck/nameck.rs
+++ b/dora/src/semck/nameck.rs
@@ -187,6 +187,12 @@ impl<'a, 'ast> NameCheck<'a, 'ast> {
         let type_sym = self.vm.sym.lock().get_type(ident.name);
 
         match (term_sym, type_sym) {
+            (Some(SymModule(module_id)), Some(SymClass(class_id))) => {
+                self.src
+                    .map_idents
+                    .insert(ident.id, IdentType::ClassAndModule(class_id, module_id));
+            }
+
             (Some(SymVar(id)), None) => {
                 self.src.map_idents.insert(ident.id, IdentType::Var(id));
             }

--- a/dora/src/semck/specialize.rs
+++ b/dora/src/semck/specialize.rs
@@ -452,6 +452,11 @@ pub fn specialize_for_call_type(call_type: &CallType, ty: BuiltinType, vm: &VM) 
             _ => ty,
         },
 
+        CallType::ModuleMethod(mod_ty, _, ref fct_type_params) => {
+            let cls_type_params = mod_ty.type_params(vm);
+            specialize_type(vm, ty, &cls_type_params, fct_type_params)
+        }
+
         CallType::Expr(ty, _) => {
             let cls_type_params = ty.type_params(vm);
             specialize_type(vm, ty, &cls_type_params, &TypeList::empty())

--- a/dora/src/ty.rs
+++ b/dora/src/ty.rs
@@ -719,7 +719,7 @@ impl Index<usize> for TypeList {
 
     fn index(&self, idx: usize) -> &BuiltinType {
         match self {
-            &TypeList::Empty => panic!("out-of-bounds"),
+            &TypeList::Empty => panic!("type list index out-of-bounds"),
             &TypeList::List(ref params) => &params[idx],
         }
     }

--- a/dora/src/typeck/lookup.rs
+++ b/dora/src/typeck/lookup.rs
@@ -292,7 +292,6 @@ impl<'a, 'ast> MethodLookup<'a, 'ast> {
                 let list_id = self.vm.lists.lock().insert(cls_tps);
                 BuiltinType::Class(cls_id, list_id)
             }
-
             _ => replace_type_param(self.vm, fct.return_type, &cls_tps, &fct_tps, None),
         };
 

--- a/dora/src/vm/module.rs
+++ b/dora/src/vm/module.rs
@@ -71,7 +71,7 @@ pub fn find_methods_in_module(
     let mut module_type = object_type;
 
     loop {
-        let module_id = module_type.module_id().expect("no class");
+        let module_id = module_type.module_id().expect("no module");
         let module = vm.modules.idx(module_id);
         let module = module.read();
 

--- a/dora/src/vm/src.rs
+++ b/dora/src/vm/src.rs
@@ -164,8 +164,11 @@ pub enum IdentType {
     // name of class with type params: SomeClass[T1, T2, ...]
     ClassType(ClassId, TypeList),
 
-    // name of method
+    // name of module
     Module(ModuleId),
+
+    // name of class and module
+    ClassAndModule(ClassId, ModuleId),
 
     // method expression: <expr>.<method_name>
     Method(BuiltinType, Name),
@@ -254,6 +257,9 @@ pub enum CallType {
     // Direct or virtual method calls, e.g. obj.method(<args>)
     Method(BuiltinType, FctId, TypeList),
 
+    // Module method call, e.g. Module::method(<args>)
+    ModuleMethod(BuiltinType, FctId, TypeList),
+
     // Constructor call Class(<args>)
     CtorNew(BuiltinType, FctId),
     Ctor(BuiltinType, FctId),
@@ -311,6 +317,7 @@ impl CallType {
         match *self {
             CallType::Fct(fctid, _, _) => Some(fctid),
             CallType::Method(_, fctid, _) => Some(fctid),
+            CallType::ModuleMethod(_, fctid, _) => Some(fctid),
             CallType::CtorNew(_, fctid) => Some(fctid),
             CallType::Ctor(_, fctid) => Some(fctid),
             CallType::Expr(_, fctid) => Some(fctid),

--- a/tests/module/module1.dora
+++ b/tests/module/module1.dora
@@ -1,13 +1,30 @@
 //= cannon
 
 module Foo {
-  fun foo() -> String = "bar";
+  fun foo() -> String = "module";
+  fun bar() -> String = Foo().foo();
+  fun baz() -> String = Foo::foo();
 }
 
-module Bar {
-  let bar: Int32 = 0;
+
+class Foo() {
+  fun foo() -> String = "class";
+}
+
+module Qux {
+  fun qux() -> String = "plain_module";
+}
+
+class Qux[T]() {
+  fun qux() -> String = "generic_class";
 }
 
 fun main() {
-  // assert(Foo::foo() == "bar");
+  assert(Foo().foo() == "class");
+  assert(Foo::foo() == "module");
+  assert(Foo::bar() == "class");
+  assert(Foo::baz() == "module");
+
+  assert(Qux[Int32]().qux() == "generic_class");
+  assert(Qux::qux() == "plain_module");
 }

--- a/tests/module/module2.dora
+++ b/tests/module/module2.dora
@@ -1,0 +1,9 @@
+module Foo {
+  fun foo[T]() -> Bar[T] = Bar[T](23);
+}
+
+class Bar[T](let x: Int32)
+
+fun main() {
+  Foo::foo[Int32]();
+}


### PR DESCRIPTION
This means that

```
module Foo {
  fun foo() -> String = "module";
  fun bar() -> String = Foo().foo();
  fun baz() -> String = Foo::foo();
}

fun main() {
  assert(Foo::foo() == "module");
  assert(Foo::bar() == "class");
  assert(Foo::baz() == "module");
}
```

works now.

The only remaining usages of `@static` in the standard library are in the
`Default` and `Zero` traits – I have a concept for them too, but this requires
additional preparations in other places, which exceed the scope of this PR.