### PR TITLE
test-runner: allow to define timeout for test cases

### DIFF
--- a/tools/tester.rb
+++ b/tools/tester.rb
@@ -41,30 +41,28 @@ class TestUtility
     out_reader = nil
     err_reader = nil
 
-    begin
-      Open3.popen3(cmd) do | stdin, stdout, stderr, wait_thr |
-        Timeout.timeout(timeout) do
-          result[:pid] = wait_thr.pid
+    Open3.popen3(cmd) do | stdin, stdout, stderr, wait_thr |
+      Timeout.timeout(timeout) do
+        result[:pid] = wait_thr.pid
 
-          stdin.close
-          out_reader = Thread.new { stdout.read }
-          err_reader = Thread.new { stderr.read }
+        stdin.close
+        out_reader = Thread.new { stdout.read }
+        err_reader = Thread.new { stderr.read }
 
-          result[:status] = wait_thr.value
-        end
-      rescue Timeout::Error
-        result[:timeout] = true
-        out_reader = out_reader.kill
-        err_reader = err_reader.kill
-
-        Process.kill(:TERM, result[:pid])
-      ensure
-        result[:status] = wait_thr.value if wait_thr
-        result[:stdout] = out_reader.value if out_reader
-        result[:stderr] = err_reader.value if err_reader
-        stdout.close unless stdout.closed?
-        stderr.close unless stderr.closed?
+        result[:status] = wait_thr.value
       end
+    rescue Timeout::Error
+      result[:timeout] = true
+      out_reader = out_reader.kill
+      err_reader = err_reader.kill
+
+      Process.kill(:TERM, result[:pid])
+    ensure
+      result[:status] = wait_thr.value if wait_thr
+      result[:stdout] = out_reader.value if out_reader
+      result[:stderr] = err_reader.value if err_reader
+      stdout.close unless stdout.closed?
+      stderr.close unless stderr.closed?
     end
 
     result
@@ -154,9 +152,9 @@ class TestCase
     if $no_capture || result != true
       mutex.synchronize do
         puts "#==== STDOUT"
-        puts process_result[:stdout] unless process_result[:stdout] == nil || process_result[:stdout].empty?
+        puts process_result[:stdout] unless process_result[:stdout].to_s.empty?
         puts "#==== STDERR"
-        puts process_result[:stderr] unless process_result[:stderr] == nil || process_result[:stderr].empty?
+        puts process_result[:stderr] unless process_result[:stderr].to_s.empty?
         puts "RUN: #{cmdline}"
         STDOUT.flush
       end

--- a/tools/tester.rb
+++ b/tools/tester.rb
@@ -302,10 +302,12 @@ def run_tests
   if faillist.any?
     puts "failed tests:"
 
-    faillist.each { |test_case| test_case.results
-      .filter { |run_name, run_result| run_result != true }
-      .each_key { |run_name| puts "    #{test_case.file}.#{run_name}" }
-    }
+    for test_case in faillist
+      for run_name, run_result in test_case.results
+        next if run_result == true
+        puts "    #{test_case.file}.#{run_name}"
+      end
+    end
   end
 
   passed = "#{passed} #{test_name(passed)} passed"

--- a/tools/tester.rb
+++ b/tools/tester.rb
@@ -29,63 +29,7 @@ $ARGS.delete_if do |arg|
 end
 
 class TestUtility
-  # https://gist.github.com/pasela/9392115
-  # Capture the standard output and the standard error of a command.
-  # Almost same as Open3.capture3 method except for timeout handling and return value.
-  # See Open3.capture3.
-  #
-  #   result = capture3_with_timeout([env,] cmd... [, opts])
-  #
-  # The arguments env, cmd and opts are passed to Process.spawn except
-  # opts[:stdin_data], opts[:binmode], opts[:timeout], opts[:signal]
-  # and opts[:kill_after].  See Process.spawn.
-  #
-  # If opts[:stdin_data] is specified, it is sent to the command's standard input.
-  #
-  # If opts[:binmode] is true, internal pipes are set to binary mode.
-  #
-  # If opts[:timeout] is specified, SIGTERM is sent to the command after specified seconds.
-  #
-  # If opts[:signal] is specified, it is used instead of SIGTERM on timeout.
-  #
-  # If opts[:kill_after] is specified, also send a SIGKILL after specified seconds.
-  # it is only sent if the command is still running after the initial signal was sent.
-  #
-  # The return value is a Hash as shown below.
-  #
-  #   {
-  #     :pid     => PID of the command,
-  #     :status  => Process::Status of the command,
-  #     :stdout  => the standard output of the command,
-  #     :stderr  => the standard error of the command,
-  #     :timeout => whether the command was timed out,
-  #   }
-
-  def self.capture3_with_timeout(*cmd)
-    spawn_opts = Hash === cmd.last ? cmd.pop.dup : {}
-    opts = {
-      :stdin_data => spawn_opts.delete(:stdin_data) || "",
-      :binmode    => spawn_opts.delete(:binmode) || false,
-      :timeout    => spawn_opts.delete(:timeout),
-      :signal     => spawn_opts.delete(:signal) || :TERM,
-      :kill_after => spawn_opts.delete(:kill_after),
-    }
-
-    in_r,  in_w  = IO.pipe
-    out_r, out_w = IO.pipe
-    err_r, err_w = IO.pipe
-    in_w.sync = true
-
-    if opts[:binmode]
-      in_w.binmode
-      out_r.binmode
-      err_r.binmode
-    end
-
-    spawn_opts[:in]  = in_r
-    spawn_opts[:out] = out_w
-    spawn_opts[:err] = err_w
-
+  def self.spawn_with_timeout(cmd, timeout)
     result = {
       :pid     => nil,
       :status  => nil,
@@ -96,39 +40,31 @@ class TestUtility
 
     out_reader = nil
     err_reader = nil
-    wait_thr = nil
 
     begin
-      Timeout.timeout(opts[:timeout]) do
-        result[:pid] = spawn(*cmd, spawn_opts)
-        wait_thr = Process.detach(result[:pid])
-        in_r.close
-        out_w.close
-        err_w.close
+      Open3.popen3(cmd) do | stdin, stdout, stderr, wait_thr |
+        Timeout.timeout(timeout) do
+          result[:pid] = wait_thr.pid
 
-        out_reader = Thread.new { out_r.read }
-        err_reader = Thread.new { err_r.read }
+          stdin.close
+          out_reader = Thread.new { stdout.read }
+          err_reader = Thread.new { stderr.read }
 
-        in_w.write opts[:stdin_data]
-        in_w.close
-
-        result[:status] = wait_thr.value
-      end
-    rescue Timeout::Error
-      result[:timeout] = true
-      pid = spawn_opts[:pgroup] ? -result[:pid] : result[:pid]
-      Process.kill(opts[:signal], pid)
-      if opts[:kill_after]
-        unless wait_thr.join(opts[:kill_after])
-          Process.kill(:KILL, pid)
+          result[:status] = wait_thr.value
         end
+      rescue Timeout::Error
+        result[:timeout] = true
+        out_reader = out_reader.kill
+        err_reader = err_reader.kill
+
+        Process.kill(:TERM, result[:pid])
+      ensure
+        result[:status] = wait_thr.value if wait_thr
+        result[:stdout] = out_reader.value if out_reader
+        result[:stderr] = err_reader.value if err_reader
+        stdout.close unless stdout.closed?
+        stderr.close unless stderr.closed?
       end
-    ensure
-      result[:status] = wait_thr.value if wait_thr
-      result[:stdout] = out_reader.value if out_reader
-      result[:stderr] = err_reader.value if err_reader
-      out_r.close unless out_r.closed?
-      err_r.close unless err_r.closed?
     end
 
     result
@@ -213,14 +149,14 @@ class TestCase
   def run_test(optional_vm_args, mutex)
     temp_out = Tempfile.new("dora-test-runner")
     cmdline = "#{binary} #{vm_args} #{optional_vm_args} #{test_file} #{args}"
-    process_result = TestUtility.capture3_with_timeout(cmdline, :timeout => self.timeout)
+    process_result = TestUtility.spawn_with_timeout(cmdline, self.timeout)
     result = check_test_run_result(process_result)
     if $no_capture || result != true
       mutex.synchronize do
         puts "#==== STDOUT"
-        puts process_result[:stdout] unless process_result[:stdout].empty?
+        puts process_result[:stdout] unless process_result[:stdout] == nil || process_result[:stdout].empty?
         puts "#==== STDERR"
-        puts process_result[:stderr] unless process_result[:stderr].empty?
+        puts process_result[:stderr] unless process_result[:stderr] == nil || process_result[:stderr].empty?
         puts "RUN: #{cmdline}"
         STDOUT.flush
       end

--- a/tools/tester.rb
+++ b/tools/tester.rb
@@ -53,8 +53,6 @@ class TestUtility
       end
     rescue Timeout::Error
       result[:timeout] = true
-      out_reader = out_reader.kill
-      err_reader = err_reader.kill
 
       Process.kill(:TERM, result[:pid])
     ensure
@@ -145,16 +143,15 @@ class TestCase
 
   private
   def run_test(optional_vm_args, mutex)
-    temp_out = Tempfile.new("dora-test-runner")
     cmdline = "#{binary} #{vm_args} #{optional_vm_args} #{test_file} #{args}"
     process_result = TestUtility.spawn_with_timeout(cmdline, self.timeout)
     result = check_test_run_result(process_result)
     if $no_capture || result != true
       mutex.synchronize do
         puts "#==== STDOUT"
-        puts process_result[:stdout] unless process_result[:stdout].to_s.empty?
+        puts process_result[:stdout] unless process_result[:stdout].empty?
         puts "#==== STDERR"
-        puts process_result[:stderr] unless process_result[:stderr].to_s.empty?
+        puts process_result[:stderr] unless process_result[:stderr].empty?
         puts "RUN: #{cmdline}"
         STDOUT.flush
       end

--- a/tools/tester.rb
+++ b/tools/tester.rb
@@ -281,7 +281,7 @@ def run_tests
         end
 
         mutex.synchronize do
-          faillist.push(test_case) if test_results.any?{|key,value| key == :failed && value > 0}
+          faillist.push(test_case) if test_results.any? { |key,value| key == :failed && value > 0 }
           test_case.print_results
           STDOUT.flush
 
@@ -302,9 +302,9 @@ def run_tests
   if faillist.any?
     puts "failed tests:"
 
-    faillist.each{|test_case| test_case.results
-      .filter{|run_name, run_result| run_result != true}
-      .each_key{|run_name| puts "    #{test_case.file}.#{run_name}" }
+    faillist.each { |test_case| test_case.results
+      .filter { |run_name, run_result| run_result != true }
+      .each_key { |run_name| puts "    #{test_case.file}.#{run_name}" }
     }
   end
 

--- a/tools/tester.rb
+++ b/tools/tester.rb
@@ -277,16 +277,11 @@ def run_tests
         test_results.each_pair do |key, value|
           passed += value if key == :passed
           ignore += value if key == :ignore
-          if key == :failed
-            failed += value
-
-            test_case.results
-              .filter{|run_name, run_result| run_result != true}
-              .each_key{|run_name| faillist.push("#{test_case.file}.#{run_name}")}
-          end
+          failed += value if key == :failed
         end
 
         mutex.synchronize do
+          faillist.push(test_case) if test_results.any?{|key,value| key == :failed && value > 0}
           test_case.print_results
           STDOUT.flush
 
@@ -306,7 +301,11 @@ def run_tests
 
   if faillist.any?
     puts "failed tests:"
-    faillist.each{|x| puts "    #{x}"}
+
+    faillist.each{|test_case| test_case.results
+      .filter{|run_name, run_result| run_result != true}
+      .each_key{|run_name| puts "    #{test_case.file}.#{run_name}" }
+    }
   end
 
   passed = "#{passed} #{test_name(passed)} passed"

--- a/tools/tester.rb
+++ b/tools/tester.rb
@@ -166,7 +166,7 @@ class TestCase
     self.optional_configs = [:main]
     self.results = {}
     self.args = self.vm_args = ""
-    self.timeout = nil
+    self.timeout = 60
   end
 
   def run(mutex)
@@ -213,17 +213,7 @@ class TestCase
   def run_test(optional_vm_args, mutex)
     temp_out = Tempfile.new("dora-test-runner")
     cmdline = "#{binary} #{vm_args} #{optional_vm_args} #{test_file} #{args}"
-    if timeout != nil
-      process_result = TestUtility.capture3_with_timeout(cmdline, :timeout => self.timeout)
-    else
-      stdout, stderr, status = Open3.capture3(cmdline)
-      process_result = {
-        :stdout => stdout,
-        :stderr => stderr,
-        :status => status,
-        :timeout => false
-      }
-    end
+    process_result = TestUtility.capture3_with_timeout(cmdline, :timeout => self.timeout)
     result = check_test_run_result(process_result)
     if $no_capture || result != true
       mutex.synchronize do


### PR DESCRIPTION
This PR adds the possibility to define a time-out for a test file  with `//= timeout <value>`. Currently, the timeout is optional. Tests without it, run as before. Should we set a time-out as default, so we can guarantee, that the tests don't run indefinitely?

The function to start the process within a time-out block is from https://gist.github.com/pasela/9392115. I used this, as there is a lot of text to find on problems with time-out in ruby (e.g. https://redmine.ruby-lang.org/issues/4681)  and it would be pointless to invest a lot of time in this problem. ;)