### PR TITLE
Cleanup parser

### DIFF
--- a/dora-parser/src/ast.rs
+++ b/dora-parser/src/ast.rs
@@ -662,7 +662,6 @@ pub enum Stmt {
     StmtBreak(StmtBreakType),
     StmtContinue(StmtContinueType),
     StmtReturn(StmtReturnType),
-    StmtDefer(StmtDeferType),
     StmtFor(StmtForType),
 }
 
@@ -752,16 +751,6 @@ impl Stmt {
         })
     }
 
-    pub fn create_defer(id: NodeId, pos: Position, span: Span, expr: Box<Expr>) -> Stmt {
-        Stmt::StmtDefer(StmtDeferType {
-            id,
-            pos,
-            span,
-
-            expr,
-        })
-    }
-
     pub fn id(&self) -> NodeId {
         match *self {
             Stmt::StmtVar(ref stmt) => stmt.id,
@@ -771,7 +760,6 @@ impl Stmt {
             Stmt::StmtBreak(ref stmt) => stmt.id,
             Stmt::StmtContinue(ref stmt) => stmt.id,
             Stmt::StmtReturn(ref stmt) => stmt.id,
-            Stmt::StmtDefer(ref stmt) => stmt.id,
         }
     }
 
@@ -784,7 +772,6 @@ impl Stmt {
             Stmt::StmtBreak(ref stmt) => stmt.pos,
             Stmt::StmtContinue(ref stmt) => stmt.pos,
             Stmt::StmtReturn(ref stmt) => stmt.pos,
-            Stmt::StmtDefer(ref stmt) => stmt.pos,
         }
     }
 
@@ -797,21 +784,6 @@ impl Stmt {
             Stmt::StmtBreak(ref stmt) => stmt.span,
             Stmt::StmtContinue(ref stmt) => stmt.span,
             Stmt::StmtReturn(ref stmt) => stmt.span,
-            Stmt::StmtDefer(ref stmt) => stmt.span,
-        }
-    }
-
-    pub fn to_defer(&self) -> Option<&StmtDeferType> {
-        match *self {
-            Stmt::StmtDefer(ref val) => Some(val),
-            _ => None,
-        }
-    }
-
-    pub fn is_defer(&self) -> bool {
-        match *self {
-            Stmt::StmtDefer(_) => true,
-            _ => false,
         }
     }
 
@@ -978,15 +950,6 @@ pub struct StmtContinueType {
     pub id: NodeId,
     pub pos: Position,
     pub span: Span,
-}
-
-#[derive(Clone, Debug)]
-pub struct StmtDeferType {
-    pub id: NodeId,
-    pub pos: Position,
-    pub span: Span,
-
-    pub expr: Box<Expr>,
 }
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]

--- a/dora-parser/src/ast/dump.rs
+++ b/dora-parser/src/ast/dump.rs
@@ -358,7 +358,6 @@ impl<'a> AstDumper<'a> {
             StmtExpr(ref expr) => self.dump_stmt_expr(expr),
             StmtVar(ref stmt) => self.dump_stmt_var(stmt),
             StmtWhile(ref stmt) => self.dump_stmt_while(stmt),
-            StmtDefer(ref stmt) => self.dump_stmt_defer(stmt),
             StmtFor(ref stmt) => self.dump_stmt_for(stmt),
         }
     }
@@ -450,11 +449,6 @@ impl<'a> AstDumper<'a> {
 
     fn dump_stmt_continue(&mut self, stmt: &StmtContinueType) {
         dump!(self, "continue @ {} {}", stmt.pos, stmt.id);
-    }
-
-    fn dump_stmt_defer(&mut self, stmt: &StmtDeferType) {
-        dump!(self, "defer @ {} {}", stmt.pos, stmt.id);
-        self.indent(|d| d.dump_expr(&stmt.expr));
     }
 
     fn dump_expr(&mut self, expr: &Expr) {

--- a/dora-parser/src/ast/visit.rs
+++ b/dora-parser/src/ast/visit.rs
@@ -251,10 +251,6 @@ pub fn walk_stmt<'v, V: Visitor<'v>>(v: &mut V, s: &'v Stmt) {
             }
         }
 
-        StmtDefer(ref value) => {
-            v.visit_expr(&value.expr);
-        }
-
         StmtBreak(_) => {}
         StmtContinue(_) => {}
     }

--- a/dora-parser/src/lexer.rs
+++ b/dora-parser/src/lexer.rs
@@ -236,15 +236,7 @@ impl Lexer {
         let nnch = self.next().unwrap_or('x');
 
         let kind = match ch {
-            '+' => {
-                if nch == '=' {
-                    self.read_char();
-                    TokenKind::AddEq
-                } else {
-                    TokenKind::Add
-                }
-            }
-
+            '+' => TokenKind::Add,
             '-' => {
                 if nch == '>' {
                     self.read_char();
@@ -253,7 +245,6 @@ impl Lexer {
                     TokenKind::Sub
                 }
             }
-
             '*' => TokenKind::Mul,
             '/' => TokenKind::Div,
             '%' => TokenKind::Mod,
@@ -1051,15 +1042,14 @@ mod tests {
 
     #[test]
     fn test_operators() {
-        let mut reader = Lexer::from_str("==+=-*/%.@");
+        let mut reader = Lexer::from_str("==-*/%.@");
         assert_tok(&mut reader, TokenKind::EqEq, 1, 1);
-        assert_tok(&mut reader, TokenKind::AddEq, 1, 3);
-        assert_tok(&mut reader, TokenKind::Sub, 1, 5);
-        assert_tok(&mut reader, TokenKind::Mul, 1, 6);
-        assert_tok(&mut reader, TokenKind::Div, 1, 7);
-        assert_tok(&mut reader, TokenKind::Mod, 1, 8);
-        assert_tok(&mut reader, TokenKind::Dot, 1, 9);
-        assert_tok(&mut reader, TokenKind::At, 1, 10);
+        assert_tok(&mut reader, TokenKind::Sub, 1, 3);
+        assert_tok(&mut reader, TokenKind::Mul, 1, 4);
+        assert_tok(&mut reader, TokenKind::Div, 1, 5);
+        assert_tok(&mut reader, TokenKind::Mod, 1, 6);
+        assert_tok(&mut reader, TokenKind::Dot, 1, 7);
+        assert_tok(&mut reader, TokenKind::At, 1, 8);
 
         let mut reader = Lexer::from_str("<=<>=><");
         assert_tok(&mut reader, TokenKind::Le, 1, 1);

--- a/dora-parser/src/lexer.rs
+++ b/dora-parser/src/lexer.rs
@@ -290,7 +290,7 @@ impl Lexer {
             ':' => {
                 if nch == ':' {
                     self.read_char();
-                    TokenKind::Sep
+                    TokenKind::ColonColon
                 } else {
                     TokenKind::Colon
                 }
@@ -352,7 +352,7 @@ impl Lexer {
                         self.read_char();
                         TokenKind::NeEqEq
                     } else {
-                        TokenKind::Ne
+                        TokenKind::NotEq
                     }
                 } else {
                     TokenKind::Not
@@ -548,37 +548,50 @@ fn is_identifier(ch: Option<char>) -> bool {
 }
 
 fn keywords_in_map() -> HashMap<&'static str, TokenKind> {
-    let mut keywords = HashMap::new();
+    let mut keywords = HashMap::with_capacity(30);
 
-    keywords.insert("class", TokenKind::Class);
-    keywords.insert("self", TokenKind::This);
-    keywords.insert("Self", TokenKind::CapitalThis);
-    keywords.insert("super", TokenKind::Super);
-    keywords.insert("fun", TokenKind::Fun);
-    keywords.insert("let", TokenKind::Let);
-    keywords.insert("var", TokenKind::Var);
-    keywords.insert("while", TokenKind::While);
-    keywords.insert("if", TokenKind::If);
-    keywords.insert("else", TokenKind::Else);
-    keywords.insert("for", TokenKind::For);
-    keywords.insert("in", TokenKind::In);
-    keywords.insert("impl", TokenKind::Impl);
-    keywords.insert("break", TokenKind::Break);
-    keywords.insert("continue", TokenKind::Continue);
-    keywords.insert("return", TokenKind::Return);
+    // literals
     keywords.insert("true", TokenKind::True);
     keywords.insert("false", TokenKind::False);
     keywords.insert("nil", TokenKind::Nil);
+
+    // "big" shapes
+    keywords.insert("class", TokenKind::Class);
     keywords.insert("enum", TokenKind::Enum);
-    keywords.insert("type", TokenKind::Type);
-    keywords.insert("alias", TokenKind::Alias);
     keywords.insert("struct", TokenKind::Struct);
     keywords.insert("trait", TokenKind::Trait);
+    keywords.insert("impl", TokenKind::Impl);
     keywords.insert("module", TokenKind::Module);
-    keywords.insert("defer", TokenKind::Defer);
+
+    // "small" shapes
+    keywords.insert("fun", TokenKind::Fun);
+    keywords.insert("let", TokenKind::Let);
+    keywords.insert("var", TokenKind::Var);
+    keywords.insert("const", TokenKind::Const);
+
+    // control flow
+    keywords.insert("return", TokenKind::Return);
+    keywords.insert("if", TokenKind::If);
+    keywords.insert("else", TokenKind::Else);
+    keywords.insert("while", TokenKind::While);
+    keywords.insert("for", TokenKind::For);
+    keywords.insert("in", TokenKind::In);
+    keywords.insert("break", TokenKind::Break);
+    keywords.insert("continue", TokenKind::Continue);
+
+    // qualifiers
+    keywords.insert("self", TokenKind::This);
+    keywords.insert("super", TokenKind::Super);
+
+    // casting
     keywords.insert("is", TokenKind::Is);
     keywords.insert("as", TokenKind::As);
-    keywords.insert("const", TokenKind::Const);
+
+    // unused
+    keywords.insert("type", TokenKind::Type);
+    keywords.insert("alias", TokenKind::Alias);
+    keywords.insert("Self", TokenKind::CapitalThis);
+    keywords.insert("defer", TokenKind::Defer);
 
     keywords
 }
@@ -1063,7 +1076,7 @@ mod tests {
         assert_tok(&mut reader, TokenKind::Not, 1, 7);
 
         let mut reader = Lexer::from_str("!=!");
-        assert_tok(&mut reader, TokenKind::Ne, 1, 1);
+        assert_tok(&mut reader, TokenKind::NotEq, 1, 1);
         assert_tok(&mut reader, TokenKind::Not, 1, 3);
 
         let mut reader = Lexer::from_str("->");
@@ -1074,6 +1087,6 @@ mod tests {
         assert_tok(&mut reader, TokenKind::LtLt, 1, 3);
         assert_tok(&mut reader, TokenKind::GtGtGt, 1, 5);
         assert_tok(&mut reader, TokenKind::Underscore, 1, 8);
-        assert_tok(&mut reader, TokenKind::Sep, 1, 9);
+        assert_tok(&mut reader, TokenKind::ColonColon, 1, 9);
     }
 }

--- a/dora-parser/src/lexer.rs
+++ b/dora-parser/src/lexer.rs
@@ -581,7 +581,6 @@ fn keywords_in_map() -> HashMap<&'static str, TokenKind> {
     keywords.insert("type", TokenKind::Type);
     keywords.insert("alias", TokenKind::Alias);
     keywords.insert("Self", TokenKind::CapitalThis);
-    keywords.insert("defer", TokenKind::Defer);
 
     keywords
 }
@@ -1035,9 +1034,6 @@ mod tests {
         assert_tok(&mut reader, TokenKind::In, 1, 5);
         assert_tok(&mut reader, TokenKind::Impl, 1, 8);
         assert_tok(&mut reader, TokenKind::CapitalThis, 1, 13);
-
-        let mut reader = Lexer::from_str("defer");
-        assert_tok(&mut reader, TokenKind::Defer, 1, 1);
     }
 
     #[test]

--- a/dora-parser/src/lexer.rs
+++ b/dora-parser/src/lexer.rs
@@ -284,7 +284,6 @@ impl Lexer {
             }
 
             '^' => TokenKind::Caret,
-            '~' => TokenKind::Tilde,
             ',' => TokenKind::Comma,
             ';' => TokenKind::Semicolon,
             ':' => {
@@ -1052,16 +1051,15 @@ mod tests {
 
     #[test]
     fn test_operators() {
-        let mut reader = Lexer::from_str("==+=-*/%~.@");
+        let mut reader = Lexer::from_str("==+=-*/%.@");
         assert_tok(&mut reader, TokenKind::EqEq, 1, 1);
         assert_tok(&mut reader, TokenKind::AddEq, 1, 3);
         assert_tok(&mut reader, TokenKind::Sub, 1, 5);
         assert_tok(&mut reader, TokenKind::Mul, 1, 6);
         assert_tok(&mut reader, TokenKind::Div, 1, 7);
         assert_tok(&mut reader, TokenKind::Mod, 1, 8);
-        assert_tok(&mut reader, TokenKind::Tilde, 1, 9);
-        assert_tok(&mut reader, TokenKind::Dot, 1, 10);
-        assert_tok(&mut reader, TokenKind::At, 1, 11);
+        assert_tok(&mut reader, TokenKind::Dot, 1, 9);
+        assert_tok(&mut reader, TokenKind::At, 1, 10);
 
         let mut reader = Lexer::from_str("<=<>=><");
         assert_tok(&mut reader, TokenKind::Le, 1, 1);

--- a/dora-parser/src/lexer/token.rs
+++ b/dora-parser/src/lexer/token.rs
@@ -5,94 +5,112 @@ use crate::lexer::position::{Position, Span};
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum TokenKind {
+    // literals
     StringTail(String),
     StringExpr(String),
     LitChar(char),
     LitInt(String, IntBase, IntSuffix),
     LitFloat(String, FloatSuffix),
     Identifier(String),
-    End,
-
-    // Keywords
-    Class,
-    This,
-    CapitalThis,
-    Super,
-    Fun,
-    Let,
-    Var,
-    While,
-    If,
-    Else,
-    For,
-    In,
-    Break,
-    Continue,
-    Return,
     True,
     False,
     Nil,
-    At,
+    End,
 
+    // "big" shapes
+    Class,
     Enum,
-    Type,
-    Alias,
     Struct,
     Trait,
     Impl,
     Module,
+
+    // "small" shapes
+    Fun,
+    Let,
+    Var,
     Const,
 
-    Underscore,
-    Defer,
+    // control flow
+    Return,
+    If,
+    Else,
+    While,
+    For,
+    In,
+    Break,
+    Continue,
 
-    // Operators
+    // qualifiers
+    This,
+    Super,
+
+    // casting
+    Is,
+    As,
+
+    // operators – numbers
     Add,
-    AddEq,
     Sub,
     Mul,
     Div,
     Mod,
+
+    // operators – logic
     Not,
-    LParen,
-    RParen,
-    LBracket,
-    RBracket,
-    LBrace,
-    RBrace,
-    Comma,
-    Semicolon,
-    Dot,
-    Colon,
-    Sep, // ::
-    Arrow,
-    Tilde,
     BitOr,
     BitAnd,
     Caret,
     And,
     Or,
 
-    Eq,
+    // operators – comparisons
     EqEq,
-    Ne,
+    NotEq,
+    EqEqEq,
+    NeEqEq,
     Lt,
     Le,
     Gt,
     Ge,
-    EqEqEq,
-    NeEqEq,
-    Is,
-    As,
 
+    // operators – shifts
     GtGt,
     GtGtGt,
     LtLt,
+
+    // basic syntax
+    Eq,
+    Comma,
+    Semicolon,
+    Dot,
+    Colon,
+    ColonColon,
+    At,
+    Arrow,
+
+    // brackets
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    LBrace,
+    RBrace,
+
+    // unused
+    AddEq,
+    Tilde,
+    Type,
+    Alias,
+    CapitalThis,
+    Underscore,
+    Defer,
 }
 
 impl TokenKind {
     pub fn name(&self) -> &str {
         match *self {
+            // literals
             TokenKind::StringTail(_) => "string tail",
             TokenKind::StringExpr(_) => "string epxr",
             TokenKind::LitInt(_, _, suffix) => match suffix {
@@ -100,93 +118,107 @@ impl TokenKind {
                 IntSuffix::Int => "int number",
                 IntSuffix::Long => "long number",
             },
-
             TokenKind::LitChar(_) => "char",
-
             TokenKind::LitFloat(_, suffix) => match suffix {
                 FloatSuffix::Float => "float number",
                 FloatSuffix::Double => "double number",
             },
-
             TokenKind::Identifier(_) => "identifier",
-            TokenKind::End => "<<EOF>>",
-
-            // Keywords
-            TokenKind::Class => "class",
-            TokenKind::This => "self",
-            TokenKind::CapitalThis => "Self",
-            TokenKind::Super => "super",
-            TokenKind::Fun => "fun",
-            TokenKind::Let => "let",
-            TokenKind::Var => "var",
-            TokenKind::While => "while",
-            TokenKind::If => "if",
-            TokenKind::Else => "else",
-            TokenKind::For => "for",
-            TokenKind::In => "in",
-            TokenKind::Break => "break",
-            TokenKind::Continue => "continue",
-            TokenKind::Return => "return",
             TokenKind::True => "true",
             TokenKind::False => "false",
             TokenKind::Nil => "nil",
-            TokenKind::At => "@",
 
+            // "big" shapes
+            TokenKind::Class => "class",
             TokenKind::Enum => "enum",
-            TokenKind::Type => "type",
-            TokenKind::Alias => "alias",
             TokenKind::Struct => "struct",
             TokenKind::Trait => "trait",
             TokenKind::Impl => "impl",
             TokenKind::Module => "module",
+
+            // "small" shapes
+            TokenKind::Fun => "fun",
+            TokenKind::Let => "let",
+            TokenKind::Var => "var",
             TokenKind::Const => "const",
 
-            TokenKind::Underscore => "_",
-            TokenKind::Defer => "defer",
+            // control flow
+            TokenKind::Return => "return",
+            TokenKind::If => "if",
+            TokenKind::Else => "else",
+            TokenKind::While => "while",
+            TokenKind::For => "for",
+            TokenKind::In => "in",
+            TokenKind::Break => "break",
+            TokenKind::Continue => "continue",
 
-            // Operators
+            // qualifiers
+            TokenKind::This => "self",
+            TokenKind::Super => "super",
+
+            // casting
+            TokenKind::Is => "is",
+            TokenKind::As => "as",
+
+            // operators – arithmetic
             TokenKind::Add => "+",
-            TokenKind::AddEq => "+=",
             TokenKind::Sub => "-",
             TokenKind::Mul => "*",
             TokenKind::Div => "/",
             TokenKind::Mod => "%",
+
+            // operators – logic
             TokenKind::Not => "!",
-            TokenKind::LParen => "(",
-            TokenKind::RParen => ")",
-            TokenKind::LBracket => "[",
-            TokenKind::RBracket => "]",
-            TokenKind::LBrace => "{",
-            TokenKind::RBrace => "}",
-            TokenKind::Comma => ",",
-            TokenKind::Semicolon => ";",
-            TokenKind::Dot => ".",
-            TokenKind::Colon => ":",
-            TokenKind::Sep => "::",
-            TokenKind::Arrow => "=>",
-            TokenKind::Tilde => "~",
             TokenKind::BitOr => "|",
             TokenKind::BitAnd => "&",
             TokenKind::Caret => "^",
             TokenKind::And => "&&",
             TokenKind::Or => "||",
 
-            TokenKind::Eq => "=",
+            // operators – comparisons
             TokenKind::EqEq => "==",
-            TokenKind::Ne => "!=",
+            TokenKind::NotEq => "!=",
+            TokenKind::EqEqEq => "===",
+            TokenKind::NeEqEq => "!==",
             TokenKind::Lt => "<",
             TokenKind::Le => "<=",
             TokenKind::Gt => ">",
             TokenKind::Ge => ">=",
 
+            // operators – shifts
             TokenKind::GtGt => ">>",
             TokenKind::GtGtGt => ">>>",
             TokenKind::LtLt => "<<",
 
-            TokenKind::EqEqEq => "===",
-            TokenKind::NeEqEq => "!==",
-            TokenKind::Is => "is",
-            TokenKind::As => "as",
+            // basic syntax
+            TokenKind::Eq => "=",
+            TokenKind::Comma => ",",
+            TokenKind::Semicolon => ";",
+            TokenKind::Dot => ".",
+            TokenKind::Colon => ":",
+            TokenKind::ColonColon => "::",
+            TokenKind::At => "@",
+            TokenKind::Arrow => "=>",
+
+            // brackets
+            TokenKind::LParen => "(",
+            TokenKind::RParen => ")",
+            TokenKind::LBracket => "[",
+            TokenKind::RBracket => "]",
+            TokenKind::LBrace => "{",
+            TokenKind::RBrace => "}",
+
+            // unused
+            TokenKind::AddEq => "+=",
+            TokenKind::Tilde => "~",
+            TokenKind::Type => "type",
+            TokenKind::Alias => "alias",
+            TokenKind::CapitalThis => "Self",
+            TokenKind::Underscore => "_",
+            TokenKind::Defer => "defer",
+
+            // end of file
+            TokenKind::End => "<<EOF>>",
         }
     }
 }

--- a/dora-parser/src/lexer/token.rs
+++ b/dora-parser/src/lexer/token.rs
@@ -102,7 +102,6 @@ pub enum TokenKind {
     Alias,
     CapitalThis,
     Underscore,
-    Defer,
 }
 
 impl TokenKind {
@@ -211,7 +210,6 @@ impl TokenKind {
             TokenKind::Alias => "alias",
             TokenKind::CapitalThis => "Self",
             TokenKind::Underscore => "_",
-            TokenKind::Defer => "defer",
 
             // end of file
             TokenKind::End => "<<EOF>>",

--- a/dora-parser/src/lexer/token.rs
+++ b/dora-parser/src/lexer/token.rs
@@ -98,7 +98,6 @@ pub enum TokenKind {
     RBrace,
 
     // unused
-    AddEq,
     Type,
     Alias,
     CapitalThis,
@@ -208,7 +207,6 @@ impl TokenKind {
             TokenKind::RBrace => "}",
 
             // unused
-            TokenKind::AddEq => "+=",
             TokenKind::Type => "type",
             TokenKind::Alias => "alias",
             TokenKind::CapitalThis => "Self",

--- a/dora-parser/src/lexer/token.rs
+++ b/dora-parser/src/lexer/token.rs
@@ -99,7 +99,6 @@ pub enum TokenKind {
 
     // unused
     AddEq,
-    Tilde,
     Type,
     Alias,
     CapitalThis,
@@ -210,7 +209,6 @@ impl TokenKind {
 
             // unused
             TokenKind::AddEq => "+=",
-            TokenKind::Tilde => "~",
             TokenKind::Type => "type",
             TokenKind::Alias => "alias",
             TokenKind::CapitalThis => "Self",

--- a/dora-parser/src/parser.rs
+++ b/dora-parser/src/parser.rs
@@ -1373,7 +1373,7 @@ impl<'a> Parser<'a> {
             let right_precedence = match self.token.kind {
                 TokenKind::Or => 1,
                 TokenKind::And => 2,
-                TokenKind::Eq | TokenKind::AddEq => 3,
+                TokenKind::Eq => 3,
                 TokenKind::EqEq
                 | TokenKind::NotEq
                 | TokenKind::Lt

--- a/dora-parser/src/parser.rs
+++ b/dora-parser/src/parser.rs
@@ -1363,7 +1363,7 @@ impl<'a> Parser<'a> {
                 TokenKind::And => 2,
                 TokenKind::Eq | TokenKind::AddEq => 3,
                 TokenKind::EqEq
-                | TokenKind::Ne
+                | TokenKind::NotEq
                 | TokenKind::Lt
                 | TokenKind::Le
                 | TokenKind::Gt
@@ -1481,7 +1481,7 @@ impl<'a> Parser<'a> {
                     ))
                 }
 
-                TokenKind::Sep => {
+                TokenKind::ColonColon => {
                     let tok = self.advance_token()?;
                     let rhs = self.parse_factor()?;
                     let span = self.span_from(start);
@@ -1514,7 +1514,7 @@ impl<'a> Parser<'a> {
             TokenKind::Or => BinOp::Or,
             TokenKind::And => BinOp::And,
             TokenKind::EqEq => BinOp::Cmp(CmpOp::Eq),
-            TokenKind::Ne => BinOp::Cmp(CmpOp::Ne),
+            TokenKind::NotEq => BinOp::Cmp(CmpOp::Ne),
             TokenKind::Lt => BinOp::Cmp(CmpOp::Lt),
             TokenKind::Le => BinOp::Cmp(CmpOp::Le),
             TokenKind::Gt => BinOp::Cmp(CmpOp::Gt),

--- a/dora-parser/src/parser.rs
+++ b/dora-parser/src/parser.rs
@@ -182,7 +182,9 @@ impl<'a> Parser<'a> {
         let type_params = self.parse_type_params()?;
 
         self.expect_token(TokenKind::LBrace)?;
-        let variants = self.parse_comma_list(TokenKind::RBrace, |p| p.parse_enum_variant())?;
+        let variants = self.parse_list(TokenKind::Comma, TokenKind::RBrace, |p| {
+            p.parse_enum_variant()
+        })?;
         let span = self.span_from(start);
 
         Ok(Enum {
@@ -202,7 +204,7 @@ impl<'a> Parser<'a> {
 
         let types = if self.token.is(TokenKind::LParen) {
             self.advance_token()?;
-            Some(self.parse_comma_list(TokenKind::RParen, |p| p.parse_type())?)
+            Some(self.parse_list(TokenKind::Comma, TokenKind::RParen, |p| p.parse_type())?)
         } else {
             None
         };
@@ -357,7 +359,9 @@ impl<'a> Parser<'a> {
         let ident = self.expect_identifier()?;
 
         self.expect_token(TokenKind::LBrace)?;
-        let fields = self.parse_comma_list(TokenKind::RBrace, |p| p.parse_struct_field())?;
+        let fields = self.parse_list(TokenKind::Comma, TokenKind::RBrace, |p| {
+            p.parse_struct_field()
+        })?;
         let span = self.span_from(start);
 
         Ok(Struct {
@@ -453,7 +457,7 @@ impl<'a> Parser<'a> {
 
         if self.token.is(TokenKind::LBracket) {
             self.advance_token()?;
-            types = self.parse_comma_list(TokenKind::RBracket, |p| p.parse_type())?;
+            types = self.parse_list(TokenKind::Comma, TokenKind::RBracket, |p| p.parse_type())?;
         }
 
         Ok(types)
@@ -503,7 +507,9 @@ impl<'a> Parser<'a> {
     fn parse_type_params(&mut self) -> Result<Option<Vec<TypeParam>>, ParseErrorAndPos> {
         if self.token.is(TokenKind::LBracket) {
             self.advance_token()?;
-            let params = self.parse_comma_list(TokenKind::RBracket, |p| p.parse_type_param())?;
+            let params = self.parse_list(TokenKind::Comma, TokenKind::RBracket, |p| {
+                p.parse_type_param()
+            })?;
 
             Ok(Some(params))
         } else {
@@ -553,7 +559,9 @@ impl<'a> Parser<'a> {
 
         self.expect_token(TokenKind::LParen)?;
 
-        let params = self.parse_comma_list(TokenKind::RParen, |p| p.parse_expression())?;
+        let params = self.parse_list(TokenKind::Comma, TokenKind::RParen, |p| {
+            p.parse_expression()
+        })?;
 
         Ok(params)
     }
@@ -569,8 +577,9 @@ impl<'a> Parser<'a> {
         self.expect_token(TokenKind::LParen)?;
         cls.has_constructor = true;
 
-        let params =
-            self.parse_comma_list(TokenKind::RParen, |p| p.parse_constructor_param(cls))?;
+        let params = self.parse_list(TokenKind::Comma, TokenKind::RParen, |p| {
+            p.parse_constructor_param(cls)
+        })?;
 
         Ok(params)
     }
@@ -850,7 +859,7 @@ impl<'a> Parser<'a> {
         self.expect_token(TokenKind::LParen)?;
         self.param_idx = 0;
 
-        let params = self.parse_comma_list(TokenKind::RParen, |p| {
+        let params = self.parse_list(TokenKind::Comma, TokenKind::RParen, |p| {
             p.param_idx += 1;
 
             p.parse_function_param()
@@ -859,8 +868,9 @@ impl<'a> Parser<'a> {
         Ok(params)
     }
 
-    fn parse_comma_list<F, R>(
+    fn parse_list<F, R>(
         &mut self,
+        sep: TokenKind,
         stop: TokenKind,
         mut parse: F,
     ) -> Result<Vec<R>, ParseErrorAndPos>
@@ -874,14 +884,14 @@ impl<'a> Parser<'a> {
             if !comma {
                 return Err(ParseErrorAndPos::new(
                     self.token.position,
-                    ParseError::ExpectedToken(TokenKind::Comma.name().into(), self.token.name()),
+                    ParseError::ExpectedToken(sep.name().into(), self.token.name()),
                 ));
             }
 
             let entry = parse(self)?;
             data.push(entry);
 
-            comma = self.token.is(TokenKind::Comma);
+            comma = self.token.is(sep.clone());
             if comma {
                 self.advance_token()?;
             }
@@ -997,7 +1007,9 @@ impl<'a> Parser<'a> {
 
                 let params = if self.token.is(TokenKind::LBracket) {
                     self.advance_token()?;
-                    self.parse_comma_list(TokenKind::RBracket, |p| Ok(Box::new(p.parse_type()?)))?
+                    self.parse_list(TokenKind::Comma, TokenKind::RBracket, |p| {
+                        Ok(Box::new(p.parse_type()?))
+                    })?
                 } else {
                     Vec::new()
                 };
@@ -1015,7 +1027,7 @@ impl<'a> Parser<'a> {
             TokenKind::LParen => {
                 let start = self.token.span.start();
                 let token = self.advance_token()?;
-                let subtypes = self.parse_comma_list(TokenKind::RParen, |p| {
+                let subtypes = self.parse_list(TokenKind::Comma, TokenKind::RParen, |p| {
                     let ty = p.parse_type()?;
 
                     Ok(Box::new(ty))
@@ -1454,8 +1466,9 @@ impl<'a> Parser<'a> {
 
                 TokenKind::LParen => {
                     let tok = self.advance_token()?;
-                    let args =
-                        self.parse_comma_list(TokenKind::RParen, |p| p.parse_expression())?;
+                    let args = self.parse_list(TokenKind::Comma, TokenKind::RParen, |p| {
+                        p.parse_expression()
+                    })?;
                     let span = self.span_from(start);
 
                     Box::new(Expr::create_call(
@@ -1469,7 +1482,8 @@ impl<'a> Parser<'a> {
 
                 TokenKind::LBracket => {
                     let tok = self.advance_token()?;
-                    let types = self.parse_comma_list(TokenKind::RBracket, |p| p.parse_type())?;
+                    let types =
+                        self.parse_list(TokenKind::Comma, TokenKind::RBracket, |p| p.parse_type())?;
                     let span = self.span_from(start);
 
                     Box::new(Expr::create_type_param(
@@ -1836,7 +1850,7 @@ impl<'a> Parser<'a> {
             Vec::new()
         } else {
             self.param_idx = 0;
-            self.parse_comma_list(TokenKind::BitOr, |p| {
+            self.parse_list(TokenKind::Comma, TokenKind::BitOr, |p| {
                 p.param_idx += 1;
                 p.parse_function_param()
             })?

--- a/dora-parser/src/parser.rs
+++ b/dora-parser/src/parser.rs
@@ -1083,21 +1083,6 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_defer(&mut self) -> StmtResult {
-        let start = self.token.span.start();
-        let pos = self.expect_token(TokenKind::Defer)?.position;
-        let expr = self.parse_expression()?;
-        self.expect_semicolon()?;
-        let span = self.span_from(start);
-
-        Ok(Box::new(Stmt::create_defer(
-            self.generate_id(),
-            pos,
-            span,
-            expr,
-        )))
-    }
-
     fn parse_var(&mut self) -> StmtResult {
         let start = self.token.span.start();
         let reassignable = if self.token.is(TokenKind::Let) {
@@ -1210,7 +1195,6 @@ impl<'a> Parser<'a> {
                 self.token.position,
                 ParseError::MisplacedElse,
             )),
-            TokenKind::Defer => Ok(StmtOrExpr::Stmt(self.parse_defer()?)),
             TokenKind::For => Ok(StmtOrExpr::Stmt(self.parse_for()?)),
             _ => {
                 let expr = self.parse_expression()?;
@@ -3136,14 +3120,6 @@ mod tests {
         assert_eq!("a", *interner.str(call.callee.to_ident().unwrap().name));
         assert_eq!(1, call.args.len());
         assert_eq!("b", *interner.str(call.args[0].to_ident().unwrap().name));
-    }
-
-    #[test]
-    fn parse_defer() {
-        let stmt = parse_stmt("defer foo();");
-        let defer = stmt.to_defer().unwrap();
-
-        assert!(defer.expr.is_call());
     }
 
     #[test]

--- a/dora/src/baseline/codegen.rs
+++ b/dora/src/baseline/codegen.rs
@@ -3445,7 +3445,6 @@ impl<'a, 'ast> visit::Visitor<'ast> for AstCodeGen<'a, 'ast> {
             StmtBreak(ref stmt) => self.emit_stmt_break(stmt),
             StmtContinue(ref stmt) => self.emit_stmt_continue(stmt),
             StmtVar(ref stmt) => self.emit_stmt_var(stmt),
-            StmtDefer(_) => unimplemented!(),
         }
     }
 

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -138,7 +138,6 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             StmtExpr(ref expr) => self.visit_stmt_expr(expr),
             StmtVar(ref stmt) => self.visit_stmt_var(stmt),
             StmtWhile(ref stmt) => self.visit_stmt_while(stmt),
-            StmtDefer(_) => unimplemented!(),
             StmtFor(ref stmt) => self.visit_stmt_for(stmt),
         }
     }

--- a/dora/src/semck/returnck.rs
+++ b/dora/src/semck/returnck.rs
@@ -64,7 +64,6 @@ pub fn returns_value(s: &Stmt) -> Result<(), Position> {
         StmtContinue(ref stmt) => Err(stmt.pos),
         StmtVar(ref stmt) => Err(stmt.pos),
         StmtExpr(ref stmt) => expr_returns_value(&stmt.expr),
-        StmtDefer(ref stmt) => Err(stmt.pos),
     }
 }
 

--- a/dora/src/typeck/expr.rs
+++ b/dora/src/typeck/expr.rs
@@ -245,17 +245,6 @@ impl<'a, 'ast> TypeCheck<'a, 'ast> {
         }
     }
 
-    fn check_stmt_defer(&mut self, s: &'ast StmtDeferType) {
-        self.visit_expr(&s.expr);
-
-        if !s.expr.is_call() {
-            self.vm
-                .diag
-                .lock()
-                .report(self.file, s.pos, SemError::FctCallExpected);
-        }
-    }
-
     fn check_expr_block(&mut self, block: &'ast ExprBlockType) {
         for stmt in &block.stmts {
             self.visit_stmt(stmt);
@@ -1991,7 +1980,6 @@ impl<'a, 'ast> Visitor<'ast> for TypeCheck<'a, 'ast> {
             StmtWhile(ref stmt) => self.check_stmt_while(stmt),
             StmtFor(ref stmt) => self.check_stmt_for(stmt),
             StmtReturn(ref stmt) => self.check_stmt_return(stmt),
-            StmtDefer(ref stmt) => self.check_stmt_defer(stmt),
 
             // for the rest of the statements, no special handling is necessary
             StmtBreak(_) => visit::walk_stmt(self, s),

--- a/dora/src/typeck/tests.rs
+++ b/dora/src/typeck/tests.rs
@@ -522,24 +522,6 @@ fn type_array_assign() {
 }
 
 #[test]
-fn type_defer() {
-    ok("fun foo() { }
-            fun f() { defer foo(); }");
-
-    err(
-        "fun foo(a: Int) {} fun f() { defer foo();}",
-        pos(1, 39),
-        SemError::ParamTypesIncompatible("foo".into(), vec!["Int".into()], vec![]),
-    );
-
-    err(
-        "fun f() { defer 1; }",
-        pos(1, 11),
-        SemError::FctCallExpected,
-    );
-}
-
-#[test]
 fn let_without_initialization() {
     err(
         "fun f() { let x: Int; }",


### PR DESCRIPTION
- Try to sort the keywords into categories.
- Made `parse_comma_list` a bit more generic by allowing to specify the separator.
- Drop `~` which is not used anywhere, as we use `!` as bitwise negation.
- Drop `+=`, as it's not used – given how it makes it harder to read code (another precedence rule to keep in mind) I also think it would be better to simply not have it (just like we do not have `++`, `--`).