### PR TITLE
bytecode: remove argument count from Invoke*

### DIFF
--- a/dora-boots/bytecode_dump.dora
+++ b/dora-boots/bytecode_dump.dora
@@ -86,14 +86,14 @@ class BytecodeDumper(let bc: BytecodeFunction): BytecodeVisitor {
         println(" ${r1}, ${gid.value}");
     }
 
-    fun emitFctVoid(name: String, fid: FctId, cnt: Int) {
+    fun emitFctVoid(name: String, fid: FctId) {
         self.emitStart(name);
-        println(" ${fid.value}, ${cnt}");
+        println(" ${fid.value}");
     }
 
-    fun emitFct(name: String, r1: BytecodeRegister, fid: FctId, cnt: Int) {
+    fun emitFct(name: String, r1: BytecodeRegister, fid: FctId) {
         self.emitStart(name);
-        println(" ${r1}, ${fid.value}, ${cnt}");
+        println(" ${r1}, ${fid.value}");
     }
 
     fun emitNew(name: String, r1: BytecodeRegister, cls: ClassDefId) {
@@ -313,35 +313,35 @@ class BytecodeDumper(let bc: BytecodeFunction): BytecodeVisitor {
     @override fun visitJump(offset: Int) { self.emitInt("Jump", offset); }
     @override fun visitJumpConst(idx: ConstPoolId) { self.emitIdx("JumpConst", idx); }
 
-    @override fun visitInvokeDirectVoid(fct: FctId, count: Int) { self.emitFctVoid("InvokeDirectVoid", fct, count); }
-    @override fun visitInvokeDirectBool(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeDirectBool", dest, fct, count); }
-    @override fun visitInvokeDirectByte(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeDirectByte", dest, fct, count); }
-    @override fun visitInvokeDirectChar(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeDirectChar", dest, fct, count); }
-    @override fun visitInvokeDirectInt(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeDirectInt", dest, fct, count); }
-    @override fun visitInvokeDirectLong(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeDirectLong", dest, fct, count); }
-    @override fun visitInvokeDirectFloat(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeDirectFloat", dest, fct, count); }
-    @override fun visitInvokeDirectDouble(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeDirectDouble", dest, fct, count); }
-    @override fun visitInvokeDirectPtr(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeDirectPtr", dest, fct, count); }
+    @override fun visitInvokeDirectVoid(fct: FctId) { self.emitFctVoid("InvokeDirectVoid", fct); }
+    @override fun visitInvokeDirectBool(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeDirectBool", dest, fct); }
+    @override fun visitInvokeDirectByte(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeDirectByte", dest, fct); }
+    @override fun visitInvokeDirectChar(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeDirectChar", dest, fct); }
+    @override fun visitInvokeDirectInt(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeDirectInt", dest, fct); }
+    @override fun visitInvokeDirectLong(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeDirectLong", dest, fct); }
+    @override fun visitInvokeDirectFloat(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeDirectFloat", dest, fct); }
+    @override fun visitInvokeDirectDouble(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeDirectDouble", dest, fct); }
+    @override fun visitInvokeDirectPtr(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeDirectPtr", dest, fct); }
 
-    @override fun visitInvokeVirtualVoid(fct: FctId, count: Int) { self.emitFctVoid("InvokeVirtualVoid", fct, count); }
-    @override fun visitInvokeVirtualBool(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeVirtualBool", dest, fct, count); }
-    @override fun visitInvokeVirtualByte(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeVirtualByte", dest, fct, count); }
-    @override fun visitInvokeVirtualChar(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeVirtualChar", dest, fct, count); }
-    @override fun visitInvokeVirtualInt(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeVirtualInt", dest, fct, count); }
-    @override fun visitInvokeVirtualLong(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeVirtualLong", dest, fct, count); }
-    @override fun visitInvokeVirtualFloat(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeVirtualFloat", dest, fct, count); }
-    @override fun visitInvokeVirtualDouble(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeVirtualDouble", dest, fct, count); }
-    @override fun visitInvokeVirtualPtr(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeVirtualPtr", dest, fct, count); }
+    @override fun visitInvokeVirtualVoid(fct: FctId) { self.emitFctVoid("InvokeVirtualVoid", fct); }
+    @override fun visitInvokeVirtualBool(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeVirtualBool", dest, fct); }
+    @override fun visitInvokeVirtualByte(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeVirtualByte", dest, fct); }
+    @override fun visitInvokeVirtualChar(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeVirtualChar", dest, fct); }
+    @override fun visitInvokeVirtualInt(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeVirtualInt", dest, fct); }
+    @override fun visitInvokeVirtualLong(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeVirtualLong", dest, fct); }
+    @override fun visitInvokeVirtualFloat(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeVirtualFloat", dest, fct); }
+    @override fun visitInvokeVirtualDouble(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeVirtualDouble", dest, fct); }
+    @override fun visitInvokeVirtualPtr(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeVirtualPtr", dest, fct); }
 
-    @override fun visitInvokeStaticVoid(fct: FctId, count: Int) { self.emitFctVoid("InvokeStaticVoid", fct, count); }
-    @override fun visitInvokeStaticBool(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeStaticBool", dest, fct, count); }
-    @override fun visitInvokeStaticByte(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeStaticByte", dest, fct, count); }
-    @override fun visitInvokeStaticChar(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeStaticChar", dest, fct, count); }
-    @override fun visitInvokeStaticInt(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeStaticInt", dest, fct, count); }
-    @override fun visitInvokeStaticLong(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeStaticLong", dest, fct, count); }
-    @override fun visitInvokeStaticFloat(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeStaticFloat", dest, fct, count); }
-    @override fun visitInvokeStaticDouble(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeStaticDouble", dest, fct, count); }
-    @override fun visitInvokeStaticPtr(dest: BytecodeRegister, fct: FctId, count: Int) { self.emitFct("InvokeStaticPtr", dest, fct, count); }
+    @override fun visitInvokeStaticVoid(fct: FctId) { self.emitFctVoid("InvokeStaticVoid", fct); }
+    @override fun visitInvokeStaticBool(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeStaticBool", dest, fct); }
+    @override fun visitInvokeStaticByte(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeStaticByte", dest, fct); }
+    @override fun visitInvokeStaticChar(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeStaticChar", dest, fct); }
+    @override fun visitInvokeStaticInt(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeStaticInt", dest, fct); }
+    @override fun visitInvokeStaticLong(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeStaticLong", dest, fct); }
+    @override fun visitInvokeStaticFloat(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeStaticFloat", dest, fct); }
+    @override fun visitInvokeStaticDouble(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeStaticDouble", dest, fct); }
+    @override fun visitInvokeStaticPtr(dest: BytecodeRegister, fct: FctId) { self.emitFct("InvokeStaticPtr", dest, fct); }
 
     @override fun visitNewObject(dest: BytecodeRegister, cls: ClassDefId) { self.emitNew("NewObject", dest, cls); }
     

--- a/dora-boots/bytecode_reader.dora
+++ b/dora-boots/bytecode_reader.dora
@@ -216,35 +216,35 @@ fun readBytecode(code: Array[Byte], visitor: BytecodeVisitor) {
     @open fun visitJump(offset: Int) { unimplemented(); }
     @open fun visitJumpConst(idx: ConstPoolId) { unimplemented(); }
 
-    @open fun visitInvokeDirectVoid(fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeDirectBool(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeDirectByte(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeDirectChar(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeDirectInt(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeDirectLong(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeDirectFloat(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeDirectDouble(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeDirectPtr(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
+    @open fun visitInvokeDirectVoid(fct: FctId) { unimplemented(); }
+    @open fun visitInvokeDirectBool(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeDirectByte(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeDirectChar(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeDirectInt(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeDirectLong(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeDirectFloat(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeDirectDouble(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeDirectPtr(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
 
-    @open fun visitInvokeVirtualVoid(fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeVirtualBool(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeVirtualByte(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeVirtualChar(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeVirtualInt(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeVirtualLong(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeVirtualFloat(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeVirtualDouble(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeVirtualPtr(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
+    @open fun visitInvokeVirtualVoid(fct: FctId) { unimplemented(); }
+    @open fun visitInvokeVirtualBool(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeVirtualByte(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeVirtualChar(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeVirtualInt(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeVirtualLong(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeVirtualFloat(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeVirtualDouble(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeVirtualPtr(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
 
-    @open fun visitInvokeStaticVoid(fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeStaticBool(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeStaticByte(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeStaticChar(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeStaticInt(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeStaticLong(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeStaticFloat(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeStaticDouble(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @open fun visitInvokeStaticPtr(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
+    @open fun visitInvokeStaticVoid(fct: FctId) { unimplemented(); }
+    @open fun visitInvokeStaticBool(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeStaticByte(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeStaticChar(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeStaticInt(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeStaticLong(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeStaticFloat(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeStaticDouble(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @open fun visitInvokeStaticPtr(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
 
     @open fun visitNewObject(dest: BytecodeRegister, cls: ClassDefId) { unimplemented(); }
     
@@ -471,35 +471,35 @@ fun readBytecode(code: Array[Byte], visitor: BytecodeVisitor) {
     @override fun visitJump(offset: Int) {}
     @override fun visitJumpConst(idx: ConstPoolId) {}
 
-    @override fun visitInvokeDirectVoid(fct: FctId, count: Int) {}
-    @override fun visitInvokeDirectBool(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeDirectByte(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeDirectChar(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeDirectInt(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeDirectLong(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeDirectFloat(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeDirectDouble(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeDirectPtr(dest: BytecodeRegister, fct: FctId, count: Int) {}
+    @override fun visitInvokeDirectVoid(fct: FctId) {}
+    @override fun visitInvokeDirectBool(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeDirectByte(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeDirectChar(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeDirectInt(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeDirectLong(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeDirectFloat(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeDirectDouble(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeDirectPtr(dest: BytecodeRegister, fct: FctId) {}
 
-    @override fun visitInvokeVirtualVoid(fct: FctId, count: Int) {}
-    @override fun visitInvokeVirtualBool(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeVirtualByte(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeVirtualChar(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeVirtualInt(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeVirtualLong(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeVirtualFloat(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeVirtualDouble(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeVirtualPtr(dest: BytecodeRegister, fct: FctId, count: Int) {}
+    @override fun visitInvokeVirtualVoid(fct: FctId) {}
+    @override fun visitInvokeVirtualBool(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeVirtualByte(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeVirtualChar(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeVirtualInt(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeVirtualLong(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeVirtualFloat(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeVirtualDouble(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeVirtualPtr(dest: BytecodeRegister, fct: FctId) {}
 
-    @override fun visitInvokeStaticVoid(fct: FctId, count: Int) {}
-    @override fun visitInvokeStaticBool(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeStaticByte(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeStaticChar(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeStaticInt(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeStaticLong(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeStaticFloat(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeStaticDouble(dest: BytecodeRegister, fct: FctId, count: Int) {}
-    @override fun visitInvokeStaticPtr(dest: BytecodeRegister, fct: FctId, count: Int) {}
+    @override fun visitInvokeStaticVoid(fct: FctId) {}
+    @override fun visitInvokeStaticBool(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeStaticByte(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeStaticChar(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeStaticInt(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeStaticLong(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeStaticFloat(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeStaticDouble(dest: BytecodeRegister, fct: FctId) {}
+    @override fun visitInvokeStaticPtr(dest: BytecodeRegister, fct: FctId) {}
 
     @override fun visitNewObject(dest: BytecodeRegister, cls: ClassDefId) {}
     
@@ -1377,138 +1377,111 @@ class BytecodeReader(let data: Array[Byte], let visitor: BytecodeVisitor) {
 
         } else if opcode == BC_INVOKE_DIRECT_VOID {
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeDirectVoid(fct, count);
+            self.visitor.visitInvokeDirectVoid(fct);
         } else if opcode == BC_INVOKE_DIRECT_BOOL {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeDirectBool(dest, fct, count);
+            self.visitor.visitInvokeDirectBool(dest, fct);
         } else if opcode == BC_INVOKE_DIRECT_BYTE {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeDirectByte(dest, fct, count);
+            self.visitor.visitInvokeDirectByte(dest, fct);
         } else if opcode == BC_INVOKE_DIRECT_CHAR {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeDirectChar(dest, fct, count);
+            self.visitor.visitInvokeDirectChar(dest, fct);
         } else if opcode == BC_INVOKE_DIRECT_INT {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeDirectInt(dest, fct, count);
+            self.visitor.visitInvokeDirectInt(dest, fct);
         } else if opcode == BC_INVOKE_DIRECT_LONG {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeDirectLong(dest, fct, count);
+            self.visitor.visitInvokeDirectLong(dest, fct);
         } else if opcode == BC_INVOKE_DIRECT_FLOAT {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeDirectFloat(dest, fct, count);
+            self.visitor.visitInvokeDirectFloat(dest, fct);
         } else if opcode == BC_INVOKE_DIRECT_DOUBLE {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeDirectDouble(dest, fct, count);
+            self.visitor.visitInvokeDirectDouble(dest, fct);
         } else if opcode == BC_INVOKE_DIRECT_PTR {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeDirectPtr(dest, fct, count);
+            self.visitor.visitInvokeDirectPtr(dest, fct);
 
         } else if opcode == BC_INVOKE_VIRTUAL_VOID {
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeVirtualVoid(fct, count);
+            self.visitor.visitInvokeVirtualVoid(fct);
         } else if opcode == BC_INVOKE_VIRTUAL_BOOL {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeVirtualBool(dest, fct, count);
+            self.visitor.visitInvokeVirtualBool(dest, fct);
         } else if opcode == BC_INVOKE_VIRTUAL_BYTE {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeVirtualByte(dest, fct, count);
+            self.visitor.visitInvokeVirtualByte(dest, fct);
         } else if opcode == BC_INVOKE_VIRTUAL_CHAR {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeVirtualChar(dest, fct, count);
+            self.visitor.visitInvokeVirtualChar(dest, fct);
         } else if opcode == BC_INVOKE_VIRTUAL_INT {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeVirtualInt(dest, fct, count);
+            self.visitor.visitInvokeVirtualInt(dest, fct);
         } else if opcode == BC_INVOKE_VIRTUAL_LONG {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeVirtualLong(dest, fct, count);
+            self.visitor.visitInvokeVirtualLong(dest, fct);
         } else if opcode == BC_INVOKE_VIRTUAL_FLOAT {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeVirtualFloat(dest, fct, count);
+            self.visitor.visitInvokeVirtualFloat(dest, fct);
         } else if opcode == BC_INVOKE_VIRTUAL_DOUBLE {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeVirtualDouble(dest, fct, count);
+            self.visitor.visitInvokeVirtualDouble(dest, fct);
         } else if opcode == BC_INVOKE_VIRTUAL_PTR {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeVirtualPtr(dest, fct, count);
+            self.visitor.visitInvokeVirtualPtr(dest, fct);
 
         } else if opcode == BC_INVOKE_STATIC_VOID {
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeStaticVoid(fct, count);
+            self.visitor.visitInvokeStaticVoid(fct);
         } else if opcode == BC_INVOKE_STATIC_BOOL {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeStaticBool(dest, fct, count);
+            self.visitor.visitInvokeStaticBool(dest, fct);
         } else if opcode == BC_INVOKE_STATIC_BYTE {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeStaticByte(dest, fct, count);
+            self.visitor.visitInvokeStaticByte(dest, fct);
         } else if opcode == BC_INVOKE_STATIC_CHAR {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeStaticChar(dest, fct, count);
+            self.visitor.visitInvokeStaticChar(dest, fct);
         } else if opcode == BC_INVOKE_STATIC_INT {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeStaticInt(dest, fct, count);
+            self.visitor.visitInvokeStaticInt(dest, fct);
         } else if opcode == BC_INVOKE_STATIC_LONG {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeStaticLong(dest, fct, count);
+            self.visitor.visitInvokeStaticLong(dest, fct);
         } else if opcode == BC_INVOKE_STATIC_FLOAT {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeStaticFloat(dest, fct, count);
+            self.visitor.visitInvokeStaticFloat(dest, fct);
         } else if opcode == BC_INVOKE_STATIC_DOUBLE {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeStaticDouble(dest, fct, count);
+            self.visitor.visitInvokeStaticDouble(dest, fct);
         } else if opcode == BC_INVOKE_STATIC_PTR {
             let dest = self.readRegister(wide);
             let fct = self.readFctId(wide);
-            let count = self.readIndex(wide);
-            self.visitor.visitInvokeStaticPtr(dest, fct, count);
+            self.visitor.visitInvokeStaticPtr(dest, fct);
 
         } else if opcode == BC_NEW_OBJECT {
             let dest = self.readRegister(wide);

--- a/dora-boots/ssagen.dora
+++ b/dora-boots/ssagen.dora
@@ -650,35 +650,35 @@ class SsaGen(let graph: Graph, let bc: BytecodeFunction, let blockBuilder: Block
         self.markBlockTerminated();
     }
 
-    @override fun visitInvokeDirectVoid(fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeDirectBool(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeDirectByte(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeDirectChar(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeDirectInt(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeDirectLong(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeDirectFloat(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeDirectDouble(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeDirectPtr(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
+    @override fun visitInvokeDirectVoid(fct: FctId) { unimplemented(); }
+    @override fun visitInvokeDirectBool(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeDirectByte(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeDirectChar(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeDirectInt(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeDirectLong(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeDirectFloat(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeDirectDouble(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeDirectPtr(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
 
-    @override fun visitInvokeVirtualVoid(fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeVirtualBool(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeVirtualByte(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeVirtualChar(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeVirtualInt(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeVirtualLong(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeVirtualFloat(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeVirtualDouble(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeVirtualPtr(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
+    @override fun visitInvokeVirtualVoid(fct: FctId) { unimplemented(); }
+    @override fun visitInvokeVirtualBool(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeVirtualByte(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeVirtualChar(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeVirtualInt(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeVirtualLong(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeVirtualFloat(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeVirtualDouble(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeVirtualPtr(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
 
-    @override fun visitInvokeStaticVoid(fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeStaticBool(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeStaticByte(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeStaticChar(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeStaticInt(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeStaticLong(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeStaticFloat(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeStaticDouble(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
-    @override fun visitInvokeStaticPtr(dest: BytecodeRegister, fct: FctId, count: Int) { unimplemented(); }
+    @override fun visitInvokeStaticVoid(fct: FctId) { unimplemented(); }
+    @override fun visitInvokeStaticBool(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeStaticByte(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeStaticChar(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeStaticInt(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeStaticLong(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeStaticFloat(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeStaticDouble(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
+    @override fun visitInvokeStaticPtr(dest: BytecodeRegister, fct: FctId) { unimplemented(); }
 
     @override fun visitNewObject(dest: BytecodeRegister, cls: ClassDefId) { unimplemented(); }
 

--- a/dora/src/bytecode/dumper.rs
+++ b/dora/src/bytecode/dumper.rs
@@ -105,14 +105,14 @@ impl<'a> BytecodeDumper<'a> {
         writeln!(self.w, " {}, {}", r1, gid.to_usize()).expect("write! failed");
     }
 
-    fn emit_fct_void(&mut self, name: &str, fid: FctDefId, cnt: u32) {
+    fn emit_fct_void(&mut self, name: &str, fid: FctDefId) {
         self.emit_start(name);
-        writeln!(self.w, " {}, {}", fid.to_usize(), cnt).expect("write! failed");
+        writeln!(self.w, " {}", fid.to_usize()).expect("write! failed");
     }
 
-    fn emit_fct(&mut self, name: &str, r1: Register, fid: FctDefId, cnt: u32) {
+    fn emit_fct(&mut self, name: &str, r1: Register, fid: FctDefId) {
         self.emit_start(name);
-        writeln!(self.w, " {}, {}, {}", r1, fid.to_usize(), cnt).expect("write! failed");
+        writeln!(self.w, " {}, {}", r1, fid.to_usize()).expect("write! failed");
     }
 
     fn emit_new(&mut self, name: &str, r1: Register, cls: ClassDefId) {
@@ -786,88 +786,88 @@ impl<'a> BytecodeVisitor for BytecodeDumper<'a> {
         self.emit_idx("JumpConst", idx);
     }
 
-    fn visit_invoke_direct_void(&mut self, fctdef: FctDefId, count: u32) {
-        self.emit_fct_void("InvokeDirectVoid", fctdef, count);
+    fn visit_invoke_direct_void(&mut self, fctdef: FctDefId) {
+        self.emit_fct_void("InvokeDirectVoid", fctdef);
     }
-    fn visit_invoke_direct_bool(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeDirectBool", dest, fctdef, count);
+    fn visit_invoke_direct_bool(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeDirectBool", dest, fctdef);
     }
-    fn visit_invoke_direct_byte(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeDirectByte", dest, fctdef, count);
+    fn visit_invoke_direct_byte(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeDirectByte", dest, fctdef);
     }
-    fn visit_invoke_direct_char(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeDirectChar", dest, fctdef, count);
+    fn visit_invoke_direct_char(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeDirectChar", dest, fctdef);
     }
-    fn visit_invoke_direct_int(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeDirectInt", dest, fctdef, count);
+    fn visit_invoke_direct_int(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeDirectInt", dest, fctdef);
     }
-    fn visit_invoke_direct_long(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeDirectLong", dest, fctdef, count);
+    fn visit_invoke_direct_long(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeDirectLong", dest, fctdef);
     }
-    fn visit_invoke_direct_float(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeDirectFloat", dest, fctdef, count);
+    fn visit_invoke_direct_float(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeDirectFloat", dest, fctdef);
     }
-    fn visit_invoke_direct_double(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeDirectDouble", dest, fctdef, count);
+    fn visit_invoke_direct_double(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeDirectDouble", dest, fctdef);
     }
-    fn visit_invoke_direct_ptr(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeDirectPtr", dest, fctdef, count);
-    }
-
-    fn visit_invoke_virtual_void(&mut self, fctdef: FctDefId, count: u32) {
-        self.emit_fct_void("InvokeVirtualVoid", fctdef, count);
-    }
-    fn visit_invoke_virtual_bool(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeVirtualBool", dest, fctdef, count);
-    }
-    fn visit_invoke_virtual_byte(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeVirtualByte", dest, fctdef, count);
-    }
-    fn visit_invoke_virtual_char(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeVirtualChar", dest, fctdef, count);
-    }
-    fn visit_invoke_virtual_int(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeVirtualInt", dest, fctdef, count);
-    }
-    fn visit_invoke_virtual_long(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeVirtualLong", dest, fctdef, count);
-    }
-    fn visit_invoke_virtual_float(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeVirtualFloat", dest, fctdef, count);
-    }
-    fn visit_invoke_virtual_double(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeVirtualDouble", dest, fctdef, count);
-    }
-    fn visit_invoke_virtual_ptr(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeVirtualPtr", dest, fctdef, count);
+    fn visit_invoke_direct_ptr(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeDirectPtr", dest, fctdef);
     }
 
-    fn visit_invoke_static_void(&mut self, fctdef: FctDefId, count: u32) {
-        self.emit_fct_void("InvokeStaticVoid", fctdef, count);
+    fn visit_invoke_virtual_void(&mut self, fctdef: FctDefId) {
+        self.emit_fct_void("InvokeVirtualVoid", fctdef);
     }
-    fn visit_invoke_static_bool(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeStaticBool", dest, fctdef, count);
+    fn visit_invoke_virtual_bool(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeVirtualBool", dest, fctdef);
     }
-    fn visit_invoke_static_byte(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeStaticByte", dest, fctdef, count);
+    fn visit_invoke_virtual_byte(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeVirtualByte", dest, fctdef);
     }
-    fn visit_invoke_static_char(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeStaticChar", dest, fctdef, count);
+    fn visit_invoke_virtual_char(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeVirtualChar", dest, fctdef);
     }
-    fn visit_invoke_static_int(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeStaticInt", dest, fctdef, count);
+    fn visit_invoke_virtual_int(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeVirtualInt", dest, fctdef);
     }
-    fn visit_invoke_static_long(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeStaticLong", dest, fctdef, count);
+    fn visit_invoke_virtual_long(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeVirtualLong", dest, fctdef);
     }
-    fn visit_invoke_static_float(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeStaticFloat", dest, fctdef, count);
+    fn visit_invoke_virtual_float(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeVirtualFloat", dest, fctdef);
     }
-    fn visit_invoke_static_double(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeStaticDouble", dest, fctdef, count);
+    fn visit_invoke_virtual_double(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeVirtualDouble", dest, fctdef);
     }
-    fn visit_invoke_static_ptr(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit_fct("InvokeStaticPtr", dest, fctdef, count);
+    fn visit_invoke_virtual_ptr(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeVirtualPtr", dest, fctdef);
+    }
+
+    fn visit_invoke_static_void(&mut self, fctdef: FctDefId) {
+        self.emit_fct_void("InvokeStaticVoid", fctdef);
+    }
+    fn visit_invoke_static_bool(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeStaticBool", dest, fctdef);
+    }
+    fn visit_invoke_static_byte(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeStaticByte", dest, fctdef);
+    }
+    fn visit_invoke_static_char(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeStaticChar", dest, fctdef);
+    }
+    fn visit_invoke_static_int(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeStaticInt", dest, fctdef);
+    }
+    fn visit_invoke_static_long(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeStaticLong", dest, fctdef);
+    }
+    fn visit_invoke_static_float(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeStaticFloat", dest, fctdef);
+    }
+    fn visit_invoke_static_double(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeStaticDouble", dest, fctdef);
+    }
+    fn visit_invoke_static_ptr(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit_fct("InvokeStaticPtr", dest, fctdef);
     }
 
     fn visit_new_object(&mut self, dest: Register, cls: ClassDefId) {

--- a/dora/src/bytecode/generator.rs
+++ b/dora/src/bytecode/generator.rs
@@ -154,7 +154,6 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         self.gen.emit_invoke_direct_ptr(
             iterator_reg,
             FctDef::fct_id(self.vm, for_type_info.make_iterator),
-            1,
         );
 
         self.gen.emit_push_register(iterator_reg);
@@ -164,11 +163,8 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
 
         // Emit: <cond> = <iterator>.hasNext() & jump to lbl_end if false
         let cond_reg = self.gen.add_register(BytecodeType::Bool);
-        self.gen.emit_invoke_direct_ptr(
-            cond_reg,
-            FctDef::fct_id(self.vm, for_type_info.has_next),
-            1,
-        );
+        self.gen
+            .emit_invoke_direct_ptr(cond_reg, FctDef::fct_id(self.vm, for_type_info.has_next));
         self.gen.emit_jump_if_false(cond_reg, lbl_end);
 
         // Emit: <var> = <iterator>.next()
@@ -181,12 +177,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
 
         self.gen.emit_push_register(iterator_reg);
 
-        self.emit_invoke_direct(
-            var_ty,
-            var_reg,
-            FctDef::fct_id(self.vm, for_type_info.next),
-            1,
-        );
+        self.emit_invoke_direct(var_ty, var_reg, FctDef::fct_id(self.vm, for_type_info.next));
 
         self.loops.push(LoopLabels::new(lbl_cond, lbl_end));
         self.visit_stmt(&stmt.block);
@@ -309,7 +300,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         // build StringBuffer::empty() call
         let fct_id = self.vm.vips.fct.string_buffer_empty;
         self.gen
-            .emit_invoke_static_ptr(buffer_register, FctDef::fct_id(self.vm, fct_id), 0);
+            .emit_invoke_static_ptr(buffer_register, FctDef::fct_id(self.vm, fct_id));
 
         let part_register = self.gen.add_register(BytecodeType::Ptr);
 
@@ -339,13 +330,11 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                         self.gen.emit_invoke_direct_ptr(
                             part_register,
                             FctDef::fct_id(self.vm, to_string_id),
-                            1,
                         );
                     } else {
                         self.gen.emit_invoke_static_ptr(
                             part_register,
                             FctDef::fct_id(self.vm, to_string_id),
-                            1,
                         );
                     }
                 }
@@ -356,14 +345,14 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             self.gen.emit_push_register(buffer_register);
             self.gen.emit_push_register(part_register);
             self.gen
-                .emit_invoke_direct_void(FctDef::fct_id(self.vm, fct_id), 2);
+                .emit_invoke_direct_void(FctDef::fct_id(self.vm, fct_id));
         }
 
         // build StringBuffer::toString() call
         let fct_id = self.vm.vips.fct.string_buffer_to_string;
         self.gen.emit_push_register(buffer_register);
         self.gen
-            .emit_invoke_static_ptr(buffer_register, FctDef::fct_id(self.vm, fct_id), 1);
+            .emit_invoke_static_ptr(buffer_register, FctDef::fct_id(self.vm, fct_id));
 
         buffer_register
     }
@@ -548,8 +537,6 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         let (arg_types, arg_bytecode_types, return_type) =
             self.determine_callee_types(&call_type, &*callee, dest);
 
-        let num_args = arg_bytecode_types.len();
-
         // Allocate register for result
         let return_reg = if return_type.is_unit() {
             Register::invalid()
@@ -588,7 +575,6 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             return_type,
             expr.pos,
             callee_def_id,
-            num_args,
             return_reg,
         );
 
@@ -780,14 +766,14 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         return_type: BuiltinType,
         pos: Position,
         fct_def_id: FctDefId,
-        num_args: usize,
+
         return_reg: Register,
     ) {
         self.gen.set_position(pos);
 
         match *call_type {
             CallType::Ctor(_, _) | CallType::CtorNew(_, _) => {
-                self.gen.emit_invoke_direct_void(fct_def_id, num_args);
+                self.gen.emit_invoke_direct_void(fct_def_id);
             }
 
             CallType::Method(_, _, _) => {
@@ -797,30 +783,30 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                     .unwrap_or(false);
 
                 if is_super_call {
-                    self.emit_invoke_direct(return_type, return_reg, fct_def_id, num_args);
+                    self.emit_invoke_direct(return_type, return_reg, fct_def_id);
                 } else if fct.is_virtual() {
-                    self.emit_invoke_virtual(return_type, return_reg, fct_def_id, num_args);
+                    self.emit_invoke_virtual(return_type, return_reg, fct_def_id);
                 } else if arg_bytecode_types[0] != BytecodeType::Ptr {
-                    self.emit_invoke_static(return_type, return_reg, fct_def_id, num_args);
+                    self.emit_invoke_static(return_type, return_reg, fct_def_id);
                 } else {
-                    self.emit_invoke_direct(return_type, return_reg, fct_def_id, num_args);
+                    self.emit_invoke_direct(return_type, return_reg, fct_def_id);
                 }
             }
             CallType::Fct(_, _, _) => {
-                self.emit_invoke_static(return_type, return_reg, fct_def_id, num_args);
+                self.emit_invoke_static(return_type, return_reg, fct_def_id);
             }
             CallType::Expr(_, _) => {
                 if fct.is_virtual() {
-                    self.emit_invoke_virtual(return_type, return_reg, fct_def_id, num_args);
+                    self.emit_invoke_virtual(return_type, return_reg, fct_def_id);
                 } else if arg_bytecode_types[0] != BytecodeType::Ptr {
-                    self.emit_invoke_static(return_type, return_reg, fct_def_id, num_args);
+                    self.emit_invoke_static(return_type, return_reg, fct_def_id);
                 } else {
-                    self.emit_invoke_direct(return_type, return_reg, fct_def_id, num_args);
+                    self.emit_invoke_direct(return_type, return_reg, fct_def_id);
                 }
             }
             CallType::Trait(_, _) => unimplemented!(),
             CallType::TraitStatic(_, _, _) => {
-                self.emit_invoke_static(return_type, return_reg, fct_def_id, num_args);
+                self.emit_invoke_static(return_type, return_reg, fct_def_id);
             }
             CallType::Intrinsic(_) => unreachable!(),
         }
@@ -861,38 +847,21 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         return_type: BuiltinType,
         return_reg: Register,
         callee_id: FctDefId,
-        num_args: usize,
     ) {
         if return_type.is_unit() {
-            self.gen.emit_invoke_virtual_void(callee_id, num_args);
+            self.gen.emit_invoke_virtual_void(callee_id);
         } else {
             let return_type: BytecodeType = return_type.into();
 
             match return_type.into() {
-                BytecodeType::Bool => self
-                    .gen
-                    .emit_invoke_virtual_bool(return_reg, callee_id, num_args),
-                BytecodeType::Byte => self
-                    .gen
-                    .emit_invoke_virtual_byte(return_reg, callee_id, num_args),
-                BytecodeType::Char => self
-                    .gen
-                    .emit_invoke_virtual_char(return_reg, callee_id, num_args),
-                BytecodeType::Int => self
-                    .gen
-                    .emit_invoke_virtual_int(return_reg, callee_id, num_args),
-                BytecodeType::Long => self
-                    .gen
-                    .emit_invoke_virtual_long(return_reg, callee_id, num_args),
-                BytecodeType::Float => self
-                    .gen
-                    .emit_invoke_virtual_float(return_reg, callee_id, num_args),
-                BytecodeType::Double => self
-                    .gen
-                    .emit_invoke_virtual_double(return_reg, callee_id, num_args),
-                BytecodeType::Ptr => self
-                    .gen
-                    .emit_invoke_virtual_ptr(return_reg, callee_id, num_args),
+                BytecodeType::Bool => self.gen.emit_invoke_virtual_bool(return_reg, callee_id),
+                BytecodeType::Byte => self.gen.emit_invoke_virtual_byte(return_reg, callee_id),
+                BytecodeType::Char => self.gen.emit_invoke_virtual_char(return_reg, callee_id),
+                BytecodeType::Int => self.gen.emit_invoke_virtual_int(return_reg, callee_id),
+                BytecodeType::Long => self.gen.emit_invoke_virtual_long(return_reg, callee_id),
+                BytecodeType::Float => self.gen.emit_invoke_virtual_float(return_reg, callee_id),
+                BytecodeType::Double => self.gen.emit_invoke_virtual_double(return_reg, callee_id),
+                BytecodeType::Ptr => self.gen.emit_invoke_virtual_ptr(return_reg, callee_id),
             }
         }
     }
@@ -902,38 +871,21 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         return_type: BuiltinType,
         return_reg: Register,
         callee_id: FctDefId,
-        num_args: usize,
     ) {
         if return_type.is_unit() {
-            self.gen.emit_invoke_direct_void(callee_id, num_args);
+            self.gen.emit_invoke_direct_void(callee_id);
         } else {
             let return_type: BytecodeType = return_type.into();
 
             match return_type.into() {
-                BytecodeType::Bool => self
-                    .gen
-                    .emit_invoke_direct_bool(return_reg, callee_id, num_args),
-                BytecodeType::Byte => self
-                    .gen
-                    .emit_invoke_direct_byte(return_reg, callee_id, num_args),
-                BytecodeType::Char => self
-                    .gen
-                    .emit_invoke_direct_char(return_reg, callee_id, num_args),
-                BytecodeType::Int => self
-                    .gen
-                    .emit_invoke_direct_int(return_reg, callee_id, num_args),
-                BytecodeType::Long => self
-                    .gen
-                    .emit_invoke_direct_long(return_reg, callee_id, num_args),
-                BytecodeType::Float => self
-                    .gen
-                    .emit_invoke_direct_float(return_reg, callee_id, num_args),
-                BytecodeType::Double => self
-                    .gen
-                    .emit_invoke_direct_double(return_reg, callee_id, num_args),
-                BytecodeType::Ptr => self
-                    .gen
-                    .emit_invoke_direct_ptr(return_reg, callee_id, num_args),
+                BytecodeType::Bool => self.gen.emit_invoke_direct_bool(return_reg, callee_id),
+                BytecodeType::Byte => self.gen.emit_invoke_direct_byte(return_reg, callee_id),
+                BytecodeType::Char => self.gen.emit_invoke_direct_char(return_reg, callee_id),
+                BytecodeType::Int => self.gen.emit_invoke_direct_int(return_reg, callee_id),
+                BytecodeType::Long => self.gen.emit_invoke_direct_long(return_reg, callee_id),
+                BytecodeType::Float => self.gen.emit_invoke_direct_float(return_reg, callee_id),
+                BytecodeType::Double => self.gen.emit_invoke_direct_double(return_reg, callee_id),
+                BytecodeType::Ptr => self.gen.emit_invoke_direct_ptr(return_reg, callee_id),
             }
         }
     }
@@ -943,38 +895,21 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         return_type: BuiltinType,
         return_reg: Register,
         callee_id: FctDefId,
-        num_args: usize,
     ) {
         if return_type.is_unit() {
-            self.gen.emit_invoke_static_void(callee_id, num_args);
+            self.gen.emit_invoke_static_void(callee_id);
         } else {
             let return_type: BytecodeType = return_type.into();
 
             match return_type.into() {
-                BytecodeType::Bool => self
-                    .gen
-                    .emit_invoke_static_bool(return_reg, callee_id, num_args),
-                BytecodeType::Byte => self
-                    .gen
-                    .emit_invoke_static_byte(return_reg, callee_id, num_args),
-                BytecodeType::Char => self
-                    .gen
-                    .emit_invoke_static_char(return_reg, callee_id, num_args),
-                BytecodeType::Int => self
-                    .gen
-                    .emit_invoke_static_int(return_reg, callee_id, num_args),
-                BytecodeType::Long => self
-                    .gen
-                    .emit_invoke_static_long(return_reg, callee_id, num_args),
-                BytecodeType::Float => self
-                    .gen
-                    .emit_invoke_static_float(return_reg, callee_id, num_args),
-                BytecodeType::Double => self
-                    .gen
-                    .emit_invoke_static_double(return_reg, callee_id, num_args),
-                BytecodeType::Ptr => self
-                    .gen
-                    .emit_invoke_static_ptr(return_reg, callee_id, num_args),
+                BytecodeType::Bool => self.gen.emit_invoke_static_bool(return_reg, callee_id),
+                BytecodeType::Byte => self.gen.emit_invoke_static_byte(return_reg, callee_id),
+                BytecodeType::Char => self.gen.emit_invoke_static_char(return_reg, callee_id),
+                BytecodeType::Int => self.gen.emit_invoke_static_int(return_reg, callee_id),
+                BytecodeType::Long => self.gen.emit_invoke_static_long(return_reg, callee_id),
+                BytecodeType::Float => self.gen.emit_invoke_static_float(return_reg, callee_id),
+                BytecodeType::Double => self.gen.emit_invoke_static_double(return_reg, callee_id),
+                BytecodeType::Ptr => self.gen.emit_invoke_static_ptr(return_reg, callee_id),
             }
         }
     }
@@ -1017,7 +952,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         self.gen.set_position(expr.pos);
         match *call_type {
             CallType::Ctor(_, _) => {
-                self.gen.emit_invoke_direct_void(fct_def_id, num_args);
+                self.gen.emit_invoke_direct_void(fct_def_id);
             }
 
             _ => unreachable!(),
@@ -1244,9 +1179,9 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
         self.gen.set_position(expr.pos);
 
         if lhs_type == BytecodeType::Ptr {
-            self.emit_invoke_direct(function_return_type, result, fct_def_id, 2);
+            self.emit_invoke_direct(function_return_type, result, fct_def_id);
         } else {
-            self.emit_invoke_static(function_return_type, result, fct_def_id, 2);
+            self.emit_invoke_static(function_return_type, result, fct_def_id);
         }
 
         match expr.op {
@@ -1592,19 +1527,13 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             }
             Intrinsic::FloatSqrt => {
                 self.gen.emit_push_register(src);
-                self.gen.emit_invoke_static_float(
-                    dest,
-                    FctDef::fct_id(self.vm, info.fct_id.unwrap()),
-                    1,
-                );
+                self.gen
+                    .emit_invoke_static_float(dest, FctDef::fct_id(self.vm, info.fct_id.unwrap()));
             }
             Intrinsic::DoubleSqrt => {
                 self.gen.emit_push_register(src);
-                self.gen.emit_invoke_static_double(
-                    dest,
-                    FctDef::fct_id(self.vm, info.fct_id.unwrap()),
-                    1,
-                );
+                self.gen
+                    .emit_invoke_static_double(dest, FctDef::fct_id(self.vm, info.fct_id.unwrap()));
             }
             Intrinsic::IntCountZeroBits
             | Intrinsic::IntCountZeroBitsLeading
@@ -1613,11 +1542,8 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             | Intrinsic::IntCountOneBitsLeading
             | Intrinsic::IntCountOneBitsTrailing => {
                 self.gen.emit_push_register(src);
-                self.gen.emit_invoke_static_int(
-                    dest,
-                    FctDef::fct_id(self.vm, info.fct_id.unwrap()),
-                    1,
-                );
+                self.gen
+                    .emit_invoke_static_int(dest, FctDef::fct_id(self.vm, info.fct_id.unwrap()));
             }
             Intrinsic::LongCountZeroBits
             | Intrinsic::LongCountZeroBitsLeading
@@ -1626,11 +1552,8 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
             | Intrinsic::LongCountOneBitsLeading
             | Intrinsic::LongCountOneBitsTrailing => {
                 self.gen.emit_push_register(src);
-                self.gen.emit_invoke_static_long(
-                    dest,
-                    FctDef::fct_id(self.vm, info.fct_id.unwrap()),
-                    1,
-                );
+                self.gen
+                    .emit_invoke_static_long(dest, FctDef::fct_id(self.vm, info.fct_id.unwrap()));
             }
             _ => {
                 panic!("unimplemented intrinsic {:?}", intrinsic);
@@ -1917,7 +1840,7 @@ impl<'a, 'ast> AstBytecodeGen<'a, 'ast> {
                 obj_ty.type_params(self.vm),
                 TypeList::empty(),
             );
-            self.gen.emit_invoke_direct_void(callee_id, 3);
+            self.gen.emit_invoke_direct_void(callee_id);
         }
     }
 

--- a/dora/src/bytecode/generator_tests.rs
+++ b/dora/src/bytecode/generator_tests.rs
@@ -1271,7 +1271,7 @@ fn gen_fct_call_void_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm.fct_def_by_name("g").expect("g not found");
-            let expected = vec![InvokeStaticVoid(fct_id, 0), RetVoid];
+            let expected = vec![InvokeStaticVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -1286,7 +1286,7 @@ fn gen_fct_call_int_with_0_args() {
             ",
         |vm, code| {
             let fct_id = vm.fct_def_by_name("g").expect("g not found");
-            let expected = vec![InvokeStaticInt(r(0), fct_id, 0), RetInt(r(0))];
+            let expected = vec![InvokeStaticInt(r(0), fct_id), RetInt(r(0))];
             assert_eq!(expected, code);
         },
     );
@@ -1301,7 +1301,7 @@ fn gen_fct_call_int_with_0_args_and_unused_result() {
             ",
         |vm, code| {
             let fct_id = vm.fct_def_by_name("g").expect("g not found");
-            let expected = vec![InvokeStaticVoid(fct_id, 0), RetVoid];
+            let expected = vec![InvokeStaticVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -1319,7 +1319,7 @@ fn gen_fct_call_void_with_1_arg() {
             let expected = vec![
                 ConstInt(r(0), 1),
                 PushRegister(r(0)),
-                InvokeStaticVoid(fct_id, 1),
+                InvokeStaticVoid(fct_id),
                 RetVoid,
             ];
             assert_eq!(expected, code);
@@ -1343,7 +1343,7 @@ fn gen_fct_call_void_with_3_args() {
                 PushRegister(r(0)),
                 PushRegister(r(1)),
                 PushRegister(r(2)),
-                InvokeStaticVoid(fct_id, 3),
+                InvokeStaticVoid(fct_id),
                 RetVoid,
             ];
             assert_eq!(expected, code);
@@ -1363,7 +1363,7 @@ fn gen_fct_call_int_with_1_arg() {
             let expected = vec![
                 ConstInt(r(1), 1),
                 PushRegister(r(1)),
-                InvokeStaticInt(r(0), fct_id, 1),
+                InvokeStaticInt(r(0), fct_id),
                 RetInt(r(0)),
             ];
             assert_eq!(expected, code);
@@ -1387,7 +1387,7 @@ fn gen_fct_call_int_with_3_args() {
                 PushRegister(r(1)),
                 PushRegister(r(2)),
                 PushRegister(r(3)),
-                InvokeStaticInt(r(0), fct_id, 3),
+                InvokeStaticInt(r(0), fct_id),
                 RetInt(r(0)),
             ];
             assert_eq!(expected, code);
@@ -1408,7 +1408,7 @@ fn gen_method_call_void_check_correct_self() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(1)), InvokeDirectVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(1)), InvokeDirectVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -1427,7 +1427,7 @@ fn gen_method_call_void_with_0_args() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -1450,7 +1450,7 @@ fn gen_method_call_void_with_1_arg() {
                 ConstInt(r(1), 1),
                 PushRegister(r(0)),
                 PushRegister(r(1)),
-                InvokeDirectVoid(fct_id, 2),
+                InvokeDirectVoid(fct_id),
                 RetVoid,
             ];
             assert_eq!(expected, code);
@@ -1479,7 +1479,7 @@ fn gen_method_call_void_with_3_args() {
                 PushRegister(r(1)),
                 PushRegister(r(2)),
                 PushRegister(r(3)),
-                InvokeDirectVoid(fct_id, 4),
+                InvokeDirectVoid(fct_id),
                 RetVoid,
             ];
             assert_eq!(expected, code);
@@ -1502,7 +1502,7 @@ fn gen_method_call_bool_with_0_args() {
                 .expect("g not found");
             let expected = vec![
                 PushRegister(r(0)),
-                InvokeDirectBool(r(1), fct_id, 1),
+                InvokeDirectBool(r(1), fct_id),
                 RetBool(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1523,7 +1523,7 @@ fn gen_method_call_bool_with_0_args_and_unused_result() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -1546,7 +1546,7 @@ fn gen_method_call_bool_with_1_arg() {
                 ConstTrue(r(2)),
                 PushRegister(r(0)),
                 PushRegister(r(2)),
-                InvokeDirectBool(r(1), fct_id, 2),
+                InvokeDirectBool(r(1), fct_id),
                 RetBool(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1575,7 +1575,7 @@ fn gen_method_call_bool_with_3_args() {
                 PushRegister(r(2)),
                 PushRegister(r(3)),
                 PushRegister(r(4)),
-                InvokeDirectBool(r(1), fct_id, 4),
+                InvokeDirectBool(r(1), fct_id),
                 RetBool(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1598,7 +1598,7 @@ fn gen_method_call_byte_with_0_args() {
                 .expect("g not found");
             let expected = vec![
                 PushRegister(r(0)),
-                InvokeDirectByte(r(1), fct_id, 1),
+                InvokeDirectByte(r(1), fct_id),
                 RetByte(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1619,7 +1619,7 @@ fn gen_method_call_byte_with_0_args_and_unused_result() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -1642,7 +1642,7 @@ fn gen_method_call_byte_with_1_arg() {
                 ConstByte(r(2), 1),
                 PushRegister(r(0)),
                 PushRegister(r(2)),
-                InvokeDirectByte(r(1), fct_id, 2),
+                InvokeDirectByte(r(1), fct_id),
                 RetByte(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1671,7 +1671,7 @@ fn gen_method_call_byte_with_3_args() {
                 PushRegister(r(2)),
                 PushRegister(r(3)),
                 PushRegister(r(4)),
-                InvokeDirectByte(r(1), fct_id, 4),
+                InvokeDirectByte(r(1), fct_id),
                 RetByte(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1694,7 +1694,7 @@ fn gen_method_call_char_with_0_args() {
                 .expect("g not found");
             let expected = vec![
                 PushRegister(r(0)),
-                InvokeDirectChar(r(1), fct_id, 1),
+                InvokeDirectChar(r(1), fct_id),
                 RetChar(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1715,7 +1715,7 @@ fn gen_method_call_char_with_0_args_and_unused_result() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -1738,7 +1738,7 @@ fn gen_method_call_char_with_1_arg() {
                 ConstChar(r(2), '1'),
                 PushRegister(r(0)),
                 PushRegister(r(2)),
-                InvokeDirectChar(r(1), fct_id, 2),
+                InvokeDirectChar(r(1), fct_id),
                 RetChar(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1767,7 +1767,7 @@ fn gen_method_call_char_with_3_args() {
                 PushRegister(r(2)),
                 PushRegister(r(3)),
                 PushRegister(r(4)),
-                InvokeDirectChar(r(1), fct_id, 4),
+                InvokeDirectChar(r(1), fct_id),
                 RetChar(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1790,7 +1790,7 @@ fn gen_method_call_int_with_0_args() {
                 .expect("g not found");
             let expected = vec![
                 PushRegister(r(0)),
-                InvokeDirectInt(r(1), fct_id, 1),
+                InvokeDirectInt(r(1), fct_id),
                 RetInt(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1811,7 +1811,7 @@ fn gen_method_call_int_with_0_args_and_unused_result() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -1834,7 +1834,7 @@ fn gen_method_call_int_with_1_arg() {
                 ConstInt(r(2), 1),
                 PushRegister(r(0)),
                 PushRegister(r(2)),
-                InvokeDirectInt(r(1), fct_id, 2),
+                InvokeDirectInt(r(1), fct_id),
                 RetInt(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1863,7 +1863,7 @@ fn gen_method_call_int_with_3_args() {
                 PushRegister(r(2)),
                 PushRegister(r(3)),
                 PushRegister(r(4)),
-                InvokeDirectInt(r(1), fct_id, 4),
+                InvokeDirectInt(r(1), fct_id),
                 RetInt(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1886,7 +1886,7 @@ fn gen_method_call_long_with_0_args() {
                 .expect("g not found");
             let expected = vec![
                 PushRegister(r(0)),
-                InvokeDirectLong(r(1), fct_id, 1),
+                InvokeDirectLong(r(1), fct_id),
                 RetLong(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1907,7 +1907,7 @@ fn gen_method_call_long_with_0_args_and_unused_result() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -1930,7 +1930,7 @@ fn gen_method_call_long_with_1_arg() {
                 ConstLong(r(2), 1),
                 PushRegister(r(0)),
                 PushRegister(r(2)),
-                InvokeDirectLong(r(1), fct_id, 2),
+                InvokeDirectLong(r(1), fct_id),
                 RetLong(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1959,7 +1959,7 @@ fn gen_method_call_long_with_3_args() {
                 PushRegister(r(2)),
                 PushRegister(r(3)),
                 PushRegister(r(4)),
-                InvokeDirectLong(r(1), fct_id, 4),
+                InvokeDirectLong(r(1), fct_id),
                 RetLong(r(1)),
             ];
             assert_eq!(expected, code);
@@ -1982,7 +1982,7 @@ fn gen_method_call_float_with_0_args() {
                 .expect("g not found");
             let expected = vec![
                 PushRegister(r(0)),
-                InvokeDirectFloat(r(1), fct_id, 1),
+                InvokeDirectFloat(r(1), fct_id),
                 RetFloat(r(1)),
             ];
             assert_eq!(expected, code);
@@ -2003,7 +2003,7 @@ fn gen_method_call_float_with_0_args_and_unused_result() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -2026,7 +2026,7 @@ fn gen_method_call_float_with_1_arg() {
                 ConstFloat(r(2), 1_f32),
                 PushRegister(r(0)),
                 PushRegister(r(2)),
-                InvokeDirectFloat(r(1), fct_id, 2),
+                InvokeDirectFloat(r(1), fct_id),
                 RetFloat(r(1)),
             ];
             assert_eq!(expected, code);
@@ -2055,7 +2055,7 @@ fn gen_method_call_float_with_3_args() {
                 PushRegister(r(2)),
                 PushRegister(r(3)),
                 PushRegister(r(4)),
-                InvokeDirectFloat(r(1), fct_id, 4),
+                InvokeDirectFloat(r(1), fct_id),
                 RetFloat(r(1)),
             ];
             assert_eq!(expected, code);
@@ -2078,7 +2078,7 @@ fn gen_method_call_double_with_0_args() {
                 .expect("g not found");
             let expected = vec![
                 PushRegister(r(0)),
-                InvokeDirectDouble(r(1), fct_id, 1),
+                InvokeDirectDouble(r(1), fct_id),
                 RetDouble(r(1)),
             ];
             assert_eq!(expected, code);
@@ -2099,7 +2099,7 @@ fn gen_method_call_double_with_0_args_and_unused_result() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -2122,7 +2122,7 @@ fn gen_method_call_double_with_1_arg() {
                 ConstDouble(r(2), 1_f64),
                 PushRegister(r(0)),
                 PushRegister(r(2)),
-                InvokeDirectDouble(r(1), fct_id, 2),
+                InvokeDirectDouble(r(1), fct_id),
                 RetDouble(r(1)),
             ];
             assert_eq!(expected, code);
@@ -2151,7 +2151,7 @@ fn gen_method_call_double_with_3_args() {
                 PushRegister(r(2)),
                 PushRegister(r(3)),
                 PushRegister(r(4)),
-                InvokeDirectDouble(r(1), fct_id, 4),
+                InvokeDirectDouble(r(1), fct_id),
                 RetDouble(r(1)),
             ];
             assert_eq!(expected, code);
@@ -2174,7 +2174,7 @@ fn gen_method_call_ptr_with_0_args() {
                 .expect("g not found");
             let expected = vec![
                 PushRegister(r(0)),
-                InvokeDirectPtr(r(1), fct_id, 1),
+                InvokeDirectPtr(r(1), fct_id),
                 RetPtr(r(1)),
             ];
             assert_eq!(expected, code);
@@ -2195,7 +2195,7 @@ fn gen_method_call_ptr_with_0_args_and_unused_result() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeDirectVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -2218,7 +2218,7 @@ fn gen_method_call_ptr_with_1_arg() {
                 ConstString(r(2), "1".to_string()),
                 PushRegister(r(0)),
                 PushRegister(r(2)),
-                InvokeDirectPtr(r(1), fct_id, 2),
+                InvokeDirectPtr(r(1), fct_id),
                 RetPtr(r(1)),
             ];
             assert_eq!(expected, code);
@@ -2247,7 +2247,7 @@ fn gen_method_call_ptr_with_3_args() {
                 PushRegister(r(2)),
                 PushRegister(r(3)),
                 PushRegister(r(4)),
-                InvokeDirectPtr(r(1), fct_id, 4),
+                InvokeDirectPtr(r(1), fct_id),
                 RetPtr(r(1)),
             ];
             assert_eq!(expected, code);
@@ -2271,7 +2271,7 @@ fn gen_virtual_method_call_void_check_correct_self() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(1)), InvokeVirtualVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(1)), InvokeVirtualVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -2293,7 +2293,7 @@ fn gen_virtual_method_call_void_with_0_args() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeVirtualVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeVirtualVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -2319,7 +2319,7 @@ fn gen_virtual_method_call_void_with_1_arg() {
                 ConstInt(r(1), 1),
                 PushRegister(r(0)),
                 PushRegister(r(1)),
-                InvokeVirtualVoid(fct_id, 2),
+                InvokeVirtualVoid(fct_id),
                 RetVoid,
             ];
             assert_eq!(expected, code);
@@ -2351,7 +2351,7 @@ fn gen_virtual_method_call_void_with_3_args() {
                 PushRegister(r(1)),
                 PushRegister(r(2)),
                 PushRegister(r(3)),
-                InvokeVirtualVoid(fct_id, 4),
+                InvokeVirtualVoid(fct_id),
                 RetVoid,
             ];
             assert_eq!(expected, code);
@@ -2375,7 +2375,7 @@ fn gen_virtual_method_call_int_with_0_args() {
             let fct_id = vm
                 .cls_method_def_by_name("Foo", "g", false)
                 .expect("g not found");
-            let expected = vec![PushRegister(r(0)), InvokeVirtualVoid(fct_id, 1), RetVoid];
+            let expected = vec![PushRegister(r(0)), InvokeVirtualVoid(fct_id), RetVoid];
             assert_eq!(expected, code);
         },
     );
@@ -2401,7 +2401,7 @@ fn gen_virtual_method_call_int_with_1_arg() {
                 ConstInt(r(1), 1),
                 PushRegister(r(0)),
                 PushRegister(r(1)),
-                InvokeVirtualVoid(fct_id, 2),
+                InvokeVirtualVoid(fct_id),
                 RetVoid,
             ];
             assert_eq!(expected, code);
@@ -2433,7 +2433,7 @@ fn gen_virtual_method_call_int_with_3_args() {
                 PushRegister(r(1)),
                 PushRegister(r(2)),
                 PushRegister(r(3)),
-                InvokeVirtualVoid(fct_id, 4),
+                InvokeVirtualVoid(fct_id),
                 RetVoid,
             ];
             assert_eq!(expected, code);
@@ -2449,7 +2449,7 @@ fn gen_new_object() {
         let expected = vec![
             NewObject(r(0), cls_id),
             PushRegister(r(0)),
-            InvokeDirectVoid(ctor_id, 1),
+            InvokeDirectVoid(ctor_id),
             RetPtr(r(0)),
         ];
         assert_eq!(expected, code);
@@ -2466,7 +2466,7 @@ fn gen_new_object_assign_to_var() {
             let expected = vec![
                 NewObject(r(0), cls_id),
                 PushRegister(r(0)),
-                InvokeDirectVoid(ctor_id, 1),
+                InvokeDirectVoid(ctor_id),
                 RetPtr(r(0)),
             ];
             assert_eq!(expected, code);
@@ -2495,7 +2495,7 @@ fn gen_new_array() {
                 NewArray(r(0), cls_id, r(1)),
                 PushRegister(r(0)),
                 PushRegister(r(1)),
-                InvokeDirectVoid(ctor_id, 2),
+                InvokeDirectVoid(ctor_id),
                 RetPtr(r(0)),
             ];
             assert_eq!(expected, code);
@@ -2831,7 +2831,7 @@ fn gen_new_object_with_multiple_args() {
                 PushRegister(r(1)),
                 PushRegister(r(2)),
                 PushRegister(r(3)),
-                InvokeDirectVoid(ctor_id, 4),
+                InvokeDirectVoid(ctor_id),
                 RetPtr(r(0)),
             ];
             assert_eq!(expected, code);
@@ -3247,7 +3247,7 @@ fn gen_string_concat() {
             let expected = vec![
                 PushRegister(r(0)),
                 PushRegister(r(1)),
-                InvokeDirectPtr(r(2), fct_id, 2),
+                InvokeDirectPtr(r(2), fct_id),
                 RetPtr(r(2)),
             ];
             assert_eq!(expected, code);
@@ -3266,7 +3266,7 @@ fn gen_string_equals() {
             let expected = vec![
                 PushRegister(r(0)),
                 PushRegister(r(1)),
-                InvokeDirectBool(r(2), fct_id, 2),
+                InvokeDirectBool(r(2), fct_id),
                 NotBool(r(2), r(2)),
                 RetBool(r(2)),
             ];
@@ -3283,7 +3283,7 @@ fn gen_bool_to_string() {
             .expect("Bool::toString not found");
         let expected = vec![
             PushRegister(r(0)),
-            InvokeStaticPtr(r(1), fct_id, 1),
+            InvokeStaticPtr(r(1), fct_id),
             RetPtr(r(1)),
         ];
         assert_eq!(expected, code);
@@ -3301,7 +3301,7 @@ fn gen_cmp_strings() {
             let expected = vec![
                 PushRegister(r(0)),
                 PushRegister(r(1)),
-                InvokeDirectInt(r(3), fct_id, 2),
+                InvokeDirectInt(r(3), fct_id),
                 ConstInt(r(4), 0),
                 TestLtInt(r(2), r(3), r(4)),
                 RetBool(r(2)),
@@ -3410,7 +3410,7 @@ fn gen_vec_load() {
             let expected = vec![
                 PushRegister(r(0)),
                 PushRegister(r(1)),
-                InvokeDirectInt(r(2), fct_def_id, 2),
+                InvokeDirectInt(r(2), fct_def_id),
                 RetInt(r(2)),
             ];
             assert_eq!(expected, code);
@@ -3434,7 +3434,7 @@ fn gen_vec_store() {
                 PushRegister(r(0)),
                 PushRegister(r(1)),
                 PushRegister(r(2)),
-                InvokeDirectVoid(fct_def_id, 3),
+                InvokeDirectVoid(fct_def_id),
                 RetVoid,
             ];
             assert_eq!(expected, code);
@@ -3710,35 +3710,35 @@ pub enum Bytecode {
     JumpIfFalse(Register, usize),
     JumpIfTrue(Register, usize),
 
-    InvokeDirectVoid(FctDefId, u32),
-    InvokeDirectBool(Register, FctDefId, u32),
-    InvokeDirectByte(Register, FctDefId, u32),
-    InvokeDirectChar(Register, FctDefId, u32),
-    InvokeDirectInt(Register, FctDefId, u32),
-    InvokeDirectLong(Register, FctDefId, u32),
-    InvokeDirectFloat(Register, FctDefId, u32),
-    InvokeDirectDouble(Register, FctDefId, u32),
-    InvokeDirectPtr(Register, FctDefId, u32),
+    InvokeDirectVoid(FctDefId),
+    InvokeDirectBool(Register, FctDefId),
+    InvokeDirectByte(Register, FctDefId),
+    InvokeDirectChar(Register, FctDefId),
+    InvokeDirectInt(Register, FctDefId),
+    InvokeDirectLong(Register, FctDefId),
+    InvokeDirectFloat(Register, FctDefId),
+    InvokeDirectDouble(Register, FctDefId),
+    InvokeDirectPtr(Register, FctDefId),
 
-    InvokeVirtualVoid(FctDefId, u32),
-    InvokeVirtualBool(Register, FctDefId, u32),
-    InvokeVirtualByte(Register, FctDefId, u32),
-    InvokeVirtualChar(Register, FctDefId, u32),
-    InvokeVirtualInt(Register, FctDefId, u32),
-    InvokeVirtualLong(Register, FctDefId, u32),
-    InvokeVirtualFloat(Register, FctDefId, u32),
-    InvokeVirtualDouble(Register, FctDefId, u32),
-    InvokeVirtualPtr(Register, FctDefId, u32),
+    InvokeVirtualVoid(FctDefId),
+    InvokeVirtualBool(Register, FctDefId),
+    InvokeVirtualByte(Register, FctDefId),
+    InvokeVirtualChar(Register, FctDefId),
+    InvokeVirtualInt(Register, FctDefId),
+    InvokeVirtualLong(Register, FctDefId),
+    InvokeVirtualFloat(Register, FctDefId),
+    InvokeVirtualDouble(Register, FctDefId),
+    InvokeVirtualPtr(Register, FctDefId),
 
-    InvokeStaticVoid(FctDefId, u32),
-    InvokeStaticBool(Register, FctDefId, u32),
-    InvokeStaticByte(Register, FctDefId, u32),
-    InvokeStaticChar(Register, FctDefId, u32),
-    InvokeStaticInt(Register, FctDefId, u32),
-    InvokeStaticLong(Register, FctDefId, u32),
-    InvokeStaticFloat(Register, FctDefId, u32),
-    InvokeStaticDouble(Register, FctDefId, u32),
-    InvokeStaticPtr(Register, FctDefId, u32),
+    InvokeStaticVoid(FctDefId),
+    InvokeStaticBool(Register, FctDefId),
+    InvokeStaticByte(Register, FctDefId),
+    InvokeStaticChar(Register, FctDefId),
+    InvokeStaticInt(Register, FctDefId),
+    InvokeStaticLong(Register, FctDefId),
+    InvokeStaticFloat(Register, FctDefId),
+    InvokeStaticDouble(Register, FctDefId),
+    InvokeStaticPtr(Register, FctDefId),
 
     NewObject(Register, ClassDefId),
     NewArray(Register, ClassDefId, Register),
@@ -4538,88 +4538,88 @@ impl<'a> BytecodeVisitor for BytecodeArrayBuilder<'a> {
         self.visit_jump(value as u32);
     }
 
-    fn visit_invoke_direct_void(&mut self, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeDirectVoid(fctdef, count));
+    fn visit_invoke_direct_void(&mut self, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeDirectVoid(fctdef));
     }
-    fn visit_invoke_direct_bool(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeDirectBool(dest, fctdef, count));
+    fn visit_invoke_direct_bool(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeDirectBool(dest, fctdef));
     }
-    fn visit_invoke_direct_byte(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeDirectByte(dest, fctdef, count));
+    fn visit_invoke_direct_byte(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeDirectByte(dest, fctdef));
     }
-    fn visit_invoke_direct_char(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeDirectChar(dest, fctdef, count));
+    fn visit_invoke_direct_char(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeDirectChar(dest, fctdef));
     }
-    fn visit_invoke_direct_int(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeDirectInt(dest, fctdef, count));
+    fn visit_invoke_direct_int(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeDirectInt(dest, fctdef));
     }
-    fn visit_invoke_direct_long(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeDirectLong(dest, fctdef, count));
+    fn visit_invoke_direct_long(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeDirectLong(dest, fctdef));
     }
-    fn visit_invoke_direct_float(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeDirectFloat(dest, fctdef, count));
+    fn visit_invoke_direct_float(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeDirectFloat(dest, fctdef));
     }
-    fn visit_invoke_direct_double(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeDirectDouble(dest, fctdef, count));
+    fn visit_invoke_direct_double(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeDirectDouble(dest, fctdef));
     }
-    fn visit_invoke_direct_ptr(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeDirectPtr(dest, fctdef, count));
-    }
-
-    fn visit_invoke_virtual_void(&mut self, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeVirtualVoid(fctdef, count));
-    }
-    fn visit_invoke_virtual_bool(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeVirtualBool(dest, fctdef, count));
-    }
-    fn visit_invoke_virtual_byte(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeVirtualByte(dest, fctdef, count));
-    }
-    fn visit_invoke_virtual_char(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeVirtualChar(dest, fctdef, count));
-    }
-    fn visit_invoke_virtual_int(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeVirtualInt(dest, fctdef, count));
-    }
-    fn visit_invoke_virtual_long(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeVirtualLong(dest, fctdef, count));
-    }
-    fn visit_invoke_virtual_float(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeVirtualFloat(dest, fctdef, count));
-    }
-    fn visit_invoke_virtual_double(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeVirtualDouble(dest, fctdef, count));
-    }
-    fn visit_invoke_virtual_ptr(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeVirtualPtr(dest, fctdef, count));
+    fn visit_invoke_direct_ptr(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeDirectPtr(dest, fctdef));
     }
 
-    fn visit_invoke_static_void(&mut self, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeStaticVoid(fctdef, count));
+    fn visit_invoke_virtual_void(&mut self, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeVirtualVoid(fctdef));
     }
-    fn visit_invoke_static_bool(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeStaticBool(dest, fctdef, count));
+    fn visit_invoke_virtual_bool(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeVirtualBool(dest, fctdef));
     }
-    fn visit_invoke_static_byte(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeStaticByte(dest, fctdef, count));
+    fn visit_invoke_virtual_byte(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeVirtualByte(dest, fctdef));
     }
-    fn visit_invoke_static_char(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeStaticChar(dest, fctdef, count));
+    fn visit_invoke_virtual_char(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeVirtualChar(dest, fctdef));
     }
-    fn visit_invoke_static_int(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeStaticInt(dest, fctdef, count));
+    fn visit_invoke_virtual_int(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeVirtualInt(dest, fctdef));
     }
-    fn visit_invoke_static_long(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeStaticLong(dest, fctdef, count));
+    fn visit_invoke_virtual_long(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeVirtualLong(dest, fctdef));
     }
-    fn visit_invoke_static_float(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeStaticFloat(dest, fctdef, count));
+    fn visit_invoke_virtual_float(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeVirtualFloat(dest, fctdef));
     }
-    fn visit_invoke_static_double(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeStaticDouble(dest, fctdef, count));
+    fn visit_invoke_virtual_double(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeVirtualDouble(dest, fctdef));
     }
-    fn visit_invoke_static_ptr(&mut self, dest: Register, fctdef: FctDefId, count: u32) {
-        self.emit(Bytecode::InvokeStaticPtr(dest, fctdef, count));
+    fn visit_invoke_virtual_ptr(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeVirtualPtr(dest, fctdef));
+    }
+
+    fn visit_invoke_static_void(&mut self, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeStaticVoid(fctdef));
+    }
+    fn visit_invoke_static_bool(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeStaticBool(dest, fctdef));
+    }
+    fn visit_invoke_static_byte(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeStaticByte(dest, fctdef));
+    }
+    fn visit_invoke_static_char(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeStaticChar(dest, fctdef));
+    }
+    fn visit_invoke_static_int(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeStaticInt(dest, fctdef));
+    }
+    fn visit_invoke_static_long(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeStaticLong(dest, fctdef));
+    }
+    fn visit_invoke_static_float(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeStaticFloat(dest, fctdef));
+    }
+    fn visit_invoke_static_double(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeStaticDouble(dest, fctdef));
+    }
+    fn visit_invoke_static_ptr(&mut self, dest: Register, fctdef: FctDefId) {
+        self.emit(Bytecode::InvokeStaticPtr(dest, fctdef));
     }
 
     fn visit_new_object(&mut self, dest: Register, cls: ClassDefId) {

--- a/dora/src/bytecode/reader.rs
+++ b/dora/src/bytecode/reader.rs
@@ -1053,164 +1053,137 @@ where
 
             BytecodeOpcode::InvokeDirectVoid => {
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_direct_void(fct, count);
+                self.visitor.visit_invoke_direct_void(fct);
             }
             BytecodeOpcode::InvokeDirectBool => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_direct_bool(dest, fct, count);
+                self.visitor.visit_invoke_direct_bool(dest, fct);
             }
             BytecodeOpcode::InvokeDirectByte => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_direct_byte(dest, fct, count);
+                self.visitor.visit_invoke_direct_byte(dest, fct);
             }
             BytecodeOpcode::InvokeDirectChar => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_direct_char(dest, fct, count);
+                self.visitor.visit_invoke_direct_char(dest, fct);
             }
             BytecodeOpcode::InvokeDirectInt => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_direct_int(dest, fct, count);
+                self.visitor.visit_invoke_direct_int(dest, fct);
             }
             BytecodeOpcode::InvokeDirectLong => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_direct_long(dest, fct, count);
+                self.visitor.visit_invoke_direct_long(dest, fct);
             }
             BytecodeOpcode::InvokeDirectFloat => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_direct_float(dest, fct, count);
+                self.visitor.visit_invoke_direct_float(dest, fct);
             }
             BytecodeOpcode::InvokeDirectDouble => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_direct_double(dest, fct, count);
+                self.visitor.visit_invoke_direct_double(dest, fct);
             }
             BytecodeOpcode::InvokeDirectPtr => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_direct_ptr(dest, fct, count);
+                self.visitor.visit_invoke_direct_ptr(dest, fct);
             }
 
             BytecodeOpcode::InvokeVirtualVoid => {
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_virtual_void(fct, count);
+                self.visitor.visit_invoke_virtual_void(fct);
             }
             BytecodeOpcode::InvokeVirtualBool => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_virtual_bool(dest, fct, count);
+                self.visitor.visit_invoke_virtual_bool(dest, fct);
             }
             BytecodeOpcode::InvokeVirtualByte => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_virtual_byte(dest, fct, count);
+                self.visitor.visit_invoke_virtual_byte(dest, fct);
             }
             BytecodeOpcode::InvokeVirtualChar => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_virtual_char(dest, fct, count);
+                self.visitor.visit_invoke_virtual_char(dest, fct);
             }
             BytecodeOpcode::InvokeVirtualInt => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_virtual_int(dest, fct, count);
+                self.visitor.visit_invoke_virtual_int(dest, fct);
             }
             BytecodeOpcode::InvokeVirtualLong => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_virtual_long(dest, fct, count);
+                self.visitor.visit_invoke_virtual_long(dest, fct);
             }
             BytecodeOpcode::InvokeVirtualFloat => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_virtual_float(dest, fct, count);
+                self.visitor.visit_invoke_virtual_float(dest, fct);
             }
             BytecodeOpcode::InvokeVirtualDouble => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_virtual_double(dest, fct, count);
+                self.visitor.visit_invoke_virtual_double(dest, fct);
             }
             BytecodeOpcode::InvokeVirtualPtr => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_virtual_ptr(dest, fct, count);
+                self.visitor.visit_invoke_virtual_ptr(dest, fct);
             }
 
             BytecodeOpcode::InvokeStaticVoid => {
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_static_void(fct, count);
+                self.visitor.visit_invoke_static_void(fct);
             }
             BytecodeOpcode::InvokeStaticBool => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_static_bool(dest, fct, count);
+                self.visitor.visit_invoke_static_bool(dest, fct);
             }
             BytecodeOpcode::InvokeStaticByte => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_static_byte(dest, fct, count);
+                self.visitor.visit_invoke_static_byte(dest, fct);
             }
             BytecodeOpcode::InvokeStaticChar => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_static_char(dest, fct, count);
+                self.visitor.visit_invoke_static_char(dest, fct);
             }
             BytecodeOpcode::InvokeStaticInt => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_static_int(dest, fct, count);
+                self.visitor.visit_invoke_static_int(dest, fct);
             }
             BytecodeOpcode::InvokeStaticLong => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_static_long(dest, fct, count);
+                self.visitor.visit_invoke_static_long(dest, fct);
             }
             BytecodeOpcode::InvokeStaticFloat => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_static_float(dest, fct, count);
+                self.visitor.visit_invoke_static_float(dest, fct);
             }
             BytecodeOpcode::InvokeStaticDouble => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_static_double(dest, fct, count);
+                self.visitor.visit_invoke_static_double(dest, fct);
             }
             BytecodeOpcode::InvokeStaticPtr => {
                 let dest = self.read_register(wide);
                 let fct = self.read_fct(wide);
-                let count = self.read_index(wide);
-                self.visitor.visit_invoke_static_ptr(dest, fct, count);
+                self.visitor.visit_invoke_static_ptr(dest, fct);
             }
 
             BytecodeOpcode::NewObject => {
@@ -2119,87 +2092,87 @@ pub trait BytecodeVisitor {
         unimplemented!();
     }
 
-    fn visit_invoke_direct_void(&mut self, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_direct_void(&mut self, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_direct_bool(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_direct_bool(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_direct_byte(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_direct_byte(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_direct_char(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_direct_char(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_direct_int(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_direct_int(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_direct_long(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_direct_long(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_direct_float(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_direct_float(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_direct_double(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_direct_double(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_direct_ptr(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
-        unimplemented!();
-    }
-
-    fn visit_invoke_virtual_void(&mut self, _fctdef: FctDefId, _count: u32) {
-        unimplemented!();
-    }
-    fn visit_invoke_virtual_bool(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
-        unimplemented!();
-    }
-    fn visit_invoke_virtual_byte(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
-        unimplemented!();
-    }
-    fn visit_invoke_virtual_char(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
-        unimplemented!();
-    }
-    fn visit_invoke_virtual_int(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
-        unimplemented!();
-    }
-    fn visit_invoke_virtual_long(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
-        unimplemented!();
-    }
-    fn visit_invoke_virtual_float(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
-        unimplemented!();
-    }
-    fn visit_invoke_virtual_double(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
-        unimplemented!();
-    }
-    fn visit_invoke_virtual_ptr(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_direct_ptr(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
 
-    fn visit_invoke_static_void(&mut self, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_virtual_void(&mut self, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_static_bool(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_virtual_bool(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_static_byte(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_virtual_byte(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_static_char(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_virtual_char(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_static_int(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_virtual_int(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_static_long(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_virtual_long(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_static_float(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_virtual_float(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_static_double(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_virtual_double(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
-    fn visit_invoke_static_ptr(&mut self, _dest: Register, _fctdef: FctDefId, _count: u32) {
+    fn visit_invoke_virtual_ptr(&mut self, _dest: Register, _fctdef: FctDefId) {
+        unimplemented!();
+    }
+
+    fn visit_invoke_static_void(&mut self, _fctdef: FctDefId) {
+        unimplemented!();
+    }
+    fn visit_invoke_static_bool(&mut self, _dest: Register, _fctdef: FctDefId) {
+        unimplemented!();
+    }
+    fn visit_invoke_static_byte(&mut self, _dest: Register, _fctdef: FctDefId) {
+        unimplemented!();
+    }
+    fn visit_invoke_static_char(&mut self, _dest: Register, _fctdef: FctDefId) {
+        unimplemented!();
+    }
+    fn visit_invoke_static_int(&mut self, _dest: Register, _fctdef: FctDefId) {
+        unimplemented!();
+    }
+    fn visit_invoke_static_long(&mut self, _dest: Register, _fctdef: FctDefId) {
+        unimplemented!();
+    }
+    fn visit_invoke_static_float(&mut self, _dest: Register, _fctdef: FctDefId) {
+        unimplemented!();
+    }
+    fn visit_invoke_static_double(&mut self, _dest: Register, _fctdef: FctDefId) {
+        unimplemented!();
+    }
+    fn visit_invoke_static_ptr(&mut self, _dest: Register, _fctdef: FctDefId) {
         unimplemented!();
     }
 

--- a/dora/src/bytecode/writer.rs
+++ b/dora/src/bytecode/writer.rs
@@ -945,112 +945,112 @@ impl BytecodeWriter {
         self.emit_reg1(BytecodeOpcode::PushRegister, src);
     }
 
-    pub fn emit_invoke_direct_void(&mut self, fid: FctDefId, num: usize) {
-        self.emit_fct_void(BytecodeOpcode::InvokeDirectVoid, fid, num);
+    pub fn emit_invoke_direct_void(&mut self, fid: FctDefId) {
+        self.emit_fct_void(BytecodeOpcode::InvokeDirectVoid, fid);
     }
 
-    pub fn emit_invoke_direct_bool(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectBool, dest, fid, num);
+    pub fn emit_invoke_direct_bool(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeDirectBool, dest, fid);
     }
 
-    pub fn emit_invoke_direct_byte(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectByte, dest, fid, num);
+    pub fn emit_invoke_direct_byte(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeDirectByte, dest, fid);
     }
 
-    pub fn emit_invoke_direct_char(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectChar, dest, fid, num);
+    pub fn emit_invoke_direct_char(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeDirectChar, dest, fid);
     }
 
-    pub fn emit_invoke_direct_int(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectInt, dest, fid, num);
+    pub fn emit_invoke_direct_int(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeDirectInt, dest, fid);
     }
 
-    pub fn emit_invoke_direct_long(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectLong, dest, fid, num);
+    pub fn emit_invoke_direct_long(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeDirectLong, dest, fid);
     }
 
-    pub fn emit_invoke_direct_float(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectFloat, dest, fid, num);
+    pub fn emit_invoke_direct_float(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeDirectFloat, dest, fid);
     }
 
-    pub fn emit_invoke_direct_double(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectDouble, dest, fid, num);
+    pub fn emit_invoke_direct_double(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeDirectDouble, dest, fid);
     }
 
-    pub fn emit_invoke_direct_ptr(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeDirectPtr, dest, fid, num);
+    pub fn emit_invoke_direct_ptr(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeDirectPtr, dest, fid);
     }
 
-    pub fn emit_invoke_virtual_void(&mut self, fid: FctDefId, num: usize) {
-        self.emit_fct_void(BytecodeOpcode::InvokeVirtualVoid, fid, num);
+    pub fn emit_invoke_virtual_void(&mut self, fid: FctDefId) {
+        self.emit_fct_void(BytecodeOpcode::InvokeVirtualVoid, fid);
     }
 
-    pub fn emit_invoke_virtual_bool(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualBool, dest, fid, num);
+    pub fn emit_invoke_virtual_bool(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeVirtualBool, dest, fid);
     }
 
-    pub fn emit_invoke_virtual_byte(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualByte, dest, fid, num);
+    pub fn emit_invoke_virtual_byte(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeVirtualByte, dest, fid);
     }
 
-    pub fn emit_invoke_virtual_char(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualChar, dest, fid, num);
+    pub fn emit_invoke_virtual_char(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeVirtualChar, dest, fid);
     }
 
-    pub fn emit_invoke_virtual_int(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualInt, dest, fid, num);
+    pub fn emit_invoke_virtual_int(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeVirtualInt, dest, fid);
     }
 
-    pub fn emit_invoke_virtual_long(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualLong, dest, fid, num);
+    pub fn emit_invoke_virtual_long(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeVirtualLong, dest, fid);
     }
 
-    pub fn emit_invoke_virtual_float(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualFloat, dest, fid, num);
+    pub fn emit_invoke_virtual_float(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeVirtualFloat, dest, fid);
     }
 
-    pub fn emit_invoke_virtual_double(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualDouble, dest, fid, num);
+    pub fn emit_invoke_virtual_double(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeVirtualDouble, dest, fid);
     }
 
-    pub fn emit_invoke_virtual_ptr(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeVirtualPtr, dest, fid, num);
+    pub fn emit_invoke_virtual_ptr(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeVirtualPtr, dest, fid);
     }
 
-    pub fn emit_invoke_static_void(&mut self, fid: FctDefId, num: usize) {
-        self.emit_fct_void(BytecodeOpcode::InvokeStaticVoid, fid, num);
+    pub fn emit_invoke_static_void(&mut self, fid: FctDefId) {
+        self.emit_fct_void(BytecodeOpcode::InvokeStaticVoid, fid);
     }
 
-    pub fn emit_invoke_static_bool(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticBool, dest, fid, num);
+    pub fn emit_invoke_static_bool(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeStaticBool, dest, fid);
     }
 
-    pub fn emit_invoke_static_byte(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticByte, dest, fid, num);
+    pub fn emit_invoke_static_byte(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeStaticByte, dest, fid);
     }
 
-    pub fn emit_invoke_static_char(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticChar, dest, fid, num);
+    pub fn emit_invoke_static_char(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeStaticChar, dest, fid);
     }
 
-    pub fn emit_invoke_static_int(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticInt, dest, fid, num);
+    pub fn emit_invoke_static_int(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeStaticInt, dest, fid);
     }
 
-    pub fn emit_invoke_static_long(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticLong, dest, fid, num);
+    pub fn emit_invoke_static_long(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeStaticLong, dest, fid);
     }
 
-    pub fn emit_invoke_static_float(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticFloat, dest, fid, num);
+    pub fn emit_invoke_static_float(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeStaticFloat, dest, fid);
     }
 
-    pub fn emit_invoke_static_double(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticDouble, dest, fid, num);
+    pub fn emit_invoke_static_double(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeStaticDouble, dest, fid);
     }
 
-    pub fn emit_invoke_static_ptr(&mut self, dest: Register, fid: FctDefId, num: usize) {
-        self.emit_fct(BytecodeOpcode::InvokeStaticPtr, dest, fid, num);
+    pub fn emit_invoke_static_ptr(&mut self, dest: Register, fid: FctDefId) {
+        self.emit_fct(BytecodeOpcode::InvokeStaticPtr, dest, fid);
     }
 
     pub fn emit_new_object(&mut self, dest: Register, cls_id: ClassDefId) {
@@ -1258,13 +1258,13 @@ impl BytecodeWriter {
         self.emit_values(inst, &values);
     }
 
-    fn emit_fct_void(&mut self, inst: BytecodeOpcode, fid: FctDefId, cnt: usize) {
-        let values = [fid.to_usize() as u32, cnt as u32];
+    fn emit_fct_void(&mut self, inst: BytecodeOpcode, fid: FctDefId) {
+        let values = [fid.to_usize() as u32];
         self.emit_values(inst, &values);
     }
 
-    fn emit_fct(&mut self, inst: BytecodeOpcode, r1: Register, fid: FctDefId, cnt: usize) {
-        let values = [r1.to_usize() as u32, fid.to_usize() as u32, cnt as u32];
+    fn emit_fct(&mut self, inst: BytecodeOpcode, r1: Register, fid: FctDefId) {
+        let values = [r1.to_usize() as u32, fid.to_usize() as u32];
         self.emit_values(inst, &values);
     }
 

--- a/dora/src/cannon/codegen.rs
+++ b/dora/src/cannon/codegen.rs
@@ -1535,7 +1535,7 @@ where
         assert!(num > 0);
 
         assert_eq!(self.argument_stack.len() as u32, num);
-        let arguments = self.argument_stack.drain(..).collect::<Vec<_>>();
+        let arguments = std::mem::replace(&mut self.argument_stack, Vec::new());
         let self_register = arguments[0];
 
         let bytecode_type_self = self.bytecode.register_type(self_register);
@@ -1595,7 +1595,7 @@ where
         assert!(num > 0);
 
         assert_eq!(self.argument_stack.len() as u32, num);
-        let arguments = self.argument_stack.drain(..).collect::<Vec<_>>();
+        let arguments = std::mem::replace(&mut self.argument_stack, Vec::new());
         let self_register = arguments[0];
 
         let bytecode_type_self = self.bytecode.register_type(self_register);
@@ -1676,7 +1676,7 @@ where
         }
 
         assert_eq!(self.argument_stack.len() as u32, num);
-        let arguments = self.argument_stack.drain(..).collect::<Vec<_>>();
+        let arguments = std::mem::replace(&mut self.argument_stack, Vec::new());
 
         let argsize = self.emit_invoke_arguments(arguments, num);
 
@@ -1718,7 +1718,7 @@ where
         num: u32,
     ) -> AnyReg {
         assert_eq!(self.argument_stack.len() as u32, num);
-        let arguments = self.argument_stack.drain(..).collect::<Vec<_>>();
+        let arguments = std::mem::replace(&mut self.argument_stack, Vec::new());
 
         match intrinsic {
             Intrinsic::FloatSqrt | Intrinsic::DoubleSqrt => {


### PR DESCRIPTION
After removing the register chain for arguments and explicitly pushing the argument registers, it is possible to remove the count argument for all Invoke bytecodes.

To ensure we have the correct number of arguments pushed, I added the parameter types to the specialized function (`FctDef`) and then compare the number of non-unit types with the number of pushed arguments. Right now, I didn't refactor the code in the bytecode generator to use this `Vec<BuiltinTypes>`, but theoretically this should allow to use the specialized types without specializing everywhere we need them. 
What do you think about this change? Maybe it could make sense to also add the specialized return type?