### PR TITLE
Return Option for HashMap#remove and Bool for HashSet#remove

### DIFF
--- a/dora/stdlib/HashMap.dora
+++ b/dora/stdlib/HashMap.dora
@@ -92,7 +92,7 @@ class HashMap[K: Hash + Equals, V] {
         return Option::none[V]();
     }
 
-    fun remove(key: K) -> V {
+    fun remove(key: K) -> Option[V] {
         self.shrink();
 
         var hash = key.hash();
@@ -110,7 +110,7 @@ class HashMap[K: Hash + Equals, V] {
                     self.values.set(idx, defaultValue[V]());
 
                     self.size = self.size - 1L;
-                    return value;
+                    return Option::some[V](value);
                 }
             } else {
                 break;
@@ -119,7 +119,7 @@ class HashMap[K: Hash + Equals, V] {
             idx = (idx + 1L) & (self.cap - 1L);
         }
 
-        return defaultValue[V]();
+        return Option::none[V]();
     }
 
     fun ensureCapacity(elements_to_add: Int64) {

--- a/dora/stdlib/HashSet.dora
+++ b/dora/stdlib/HashSet.dora
@@ -9,9 +9,7 @@ class HashSet[K: Hash + Equals] {
         self.map.contains(key)
     }
 
-    fun remove(key: K) {
-        self.map.remove(key);
-    }
+    fun remove(key: K) -> Bool = self.map.remove(key).isSome();
 
     fun length() -> Int64 {
         self.map.length()


### PR DESCRIPTION
In case of HashMap, this further reduces the amount of `nil`s we produce.