### PR TITLE
x64: drop raw-cpuid dependency, use feature from std library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,6 @@ dependencies = [
  "num_cpus",
  "parking_lot 0.11.1",
  "rand",
- "raw-cpuid",
  "regex",
  "scoped_threadpool",
  "serde",
@@ -399,17 +398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "7.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb71f708fe39b2c5e98076204c3cc094ee5a4c12c4cdb119a2b72dc34164f41"
-dependencies = [
- "bitflags",
- "cc",
- "rustc_version",
 ]
 
 [[package]]

--- a/dora/Cargo.toml
+++ b/dora/Cargo.toml
@@ -40,9 +40,6 @@ memoffset = "*"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "*", features = ["memoryapi"] }
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
-raw-cpuid = "7.0.*"
-
 [lib]
 name = "dora"
 path = "src/lib.rs"

--- a/dora/src/cpu/x64.rs
+++ b/dora/src/cpu/x64.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use raw_cpuid::{CpuId, ExtendedFeatures, FeatureInfo};
 use std::sync::atomic::{compiler_fence, Ordering};
 
 use crate::ty::SourceType;
@@ -19,9 +18,7 @@ pub fn has_popcnt() -> bool {
 }
 
 pub fn has_lzcnt() -> bool {
-    // Too conservative, but we currently lack an easy way to check support for ABM instructions:
-    // Revisit after https://github.com/gz/rust-cpuid/issues/30 is resolved.
-    *HAS_TZCNT
+    *HAS_LZCNT
 }
 
 pub fn has_tzcnt() -> bool {
@@ -29,13 +26,11 @@ pub fn has_tzcnt() -> bool {
 }
 
 lazy_static! {
-static ref FEATURES: FeatureInfo = CpuId::new().get_feature_info().unwrap();
-static ref FEATURES_EXTENDED: ExtendedFeatures = CpuId::new().get_extended_feature_info().unwrap();
-
 // support for floating point rounding
-static ref HAS_ROUND: bool = FEATURES.has_sse41();
-static ref HAS_POPCNT: bool = FEATURES.has_popcnt();
-static ref HAS_TZCNT: bool = FEATURES_EXTENDED.has_bmi1();
+static ref HAS_ROUND: bool = is_x86_feature_detected!("sse4.1");
+static ref HAS_POPCNT: bool = is_x86_feature_detected!("popcnt");
+static ref HAS_LZCNT: bool =  is_x86_feature_detected!("lzcnt");
+static ref HAS_TZCNT: bool = is_x86_feature_detected!("bmi1");
 }
 
 // first param offset to rbp is +16,


### PR DESCRIPTION
Fix https://github.com/dinfuehr/dora/issues/257.