### PR TITLE
anno: introduce annotationck phase that initializes modifiers

### DIFF
--- a/dora/src/compiler/compile_stub.rs
+++ b/dora/src/compiler/compile_stub.rs
@@ -307,7 +307,7 @@ fn ensure_thunk(
     let callee_id = find_trait_impl(vm, fct_id, trait_id, object_ty.clone());
 
     let mut thunk_fct =
-        FctDefinition::new(vm, fct.file_id, fct.namespace_id, &fct.ast, FctParent::None);
+        FctDefinition::new(fct.file_id, fct.namespace_id, &fct.ast, FctParent::None);
     thunk_fct.type_params = fct.type_params.clone();
     let mut traits = HashSet::new();
     traits.insert(trait_id);

--- a/dora/src/language/clsdefck.rs
+++ b/dora/src/language/clsdefck.rs
@@ -98,7 +98,6 @@ impl<'x> ClsDefCheck<'x> {
 
     fn visit_ctor(&mut self, node: &Arc<ast::Function>) {
         let fct = FctDefinition::new(
-            self.sa,
             self.file_id,
             self.namespace_id,
             node,
@@ -114,7 +113,6 @@ impl<'x> ClsDefCheck<'x> {
 
     fn visit_method(&mut self, f: &Arc<ast::Function>) {
         let fct = FctDefinition::new(
-            self.sa,
             self.file_id,
             self.namespace_id,
             f,

--- a/dora/src/language/extensiondefck.rs
+++ b/dora/src/language/extensiondefck.rs
@@ -136,7 +136,6 @@ impl<'x> ExtensionCheck<'x> {
         }
 
         let fct = FctDefinition::new(
-            self.sa,
             self.file_id,
             self.namespace_id,
             f,

--- a/dora/src/language/globaldef.rs
+++ b/dora/src/language/globaldef.rs
@@ -417,7 +417,7 @@ impl<'x> visit::Visitor for GlobalDef<'x> {
             let mut classes = self.sa.classes.lock();
 
             let id: ClassDefinitionId = classes.len().into();
-            let cls = vm::ClassDefinition::new(&self.sa, id, self.file_id, node, self.namespace_id);
+            let cls = vm::ClassDefinition::new(id, self.file_id, self.namespace_id, node);
 
             classes.push(Arc::new(RwLock::new(cls)));
 
@@ -495,13 +495,7 @@ impl<'x> visit::Visitor for GlobalDef<'x> {
     }
 
     fn visit_fct(&mut self, node: &Arc<ast::Function>) {
-        let fct = FctDefinition::new(
-            self.sa,
-            self.file_id,
-            self.namespace_id,
-            node,
-            FctParent::None,
-        );
+        let fct = FctDefinition::new(self.file_id, self.namespace_id, node, FctParent::None);
         let fctid = self.sa.add_fct(fct);
         let sym = Sym::Fct(fctid);
 

--- a/dora/src/language/globaldef.rs
+++ b/dora/src/language/globaldef.rs
@@ -212,7 +212,7 @@ struct GlobalDef<'x> {
 
 impl<'x> visit::Visitor for GlobalDef<'x> {
     fn visit_namespace(&mut self, node: &Arc<ast::Namespace>) {
-        let namespace = NamespaceData::new(self.sa, self.namespace_id, node);
+        let namespace = NamespaceData::new(self.sa, self.file_id, self.namespace_id, node);
         let id = namespace.id.clone();
         let sym = Sym::Namespace(id);
 

--- a/dora/src/language/globaldefck.rs
+++ b/dora/src/language/globaldefck.rs
@@ -59,7 +59,6 @@ impl<'a> GlobalDefCheck<'a> {
 
         if let Some(ref initializer) = self.ast.initializer {
             let fct = FctDefinition::new(
-                self.sa,
                 self.file_id,
                 self.namespace_id,
                 initializer,

--- a/dora/src/language/impldefck.rs
+++ b/dora/src/language/impldefck.rs
@@ -195,13 +195,7 @@ impl<'x> ImplCheck<'x> {
 
         let parent = FctParent::Impl(self.impl_id);
 
-        let fct = FctDefinition::new(
-            self.sa,
-            self.file_id.into(),
-            self.namespace_id,
-            method,
-            parent,
-        );
+        let fct = FctDefinition::new(self.file_id.into(), self.namespace_id, method, parent);
         self.sa.add_fct(fct)
     }
 }

--- a/dora/src/language/moduledefck.rs
+++ b/dora/src/language/moduledefck.rs
@@ -93,7 +93,6 @@ impl<'x> ModuleCheck<'x> {
 
     fn visit_ctor(&mut self, f: &Arc<ast::Function>) {
         let fct = FctDefinition::new(
-            self.sa,
             self.file_id,
             self.namespace_id,
             f,
@@ -108,7 +107,6 @@ impl<'x> ModuleCheck<'x> {
 
     fn visit_method(&mut self, f: &Arc<ast::Function>) {
         let fct = FctDefinition::new(
-            self.sa,
             self.file_id,
             self.namespace_id,
             f,

--- a/dora/src/language/traitdefck.rs
+++ b/dora/src/language/traitdefck.rs
@@ -77,7 +77,6 @@ impl<'x> TraitCheck<'x> {
 
     fn visit_method(&mut self, node: &Arc<ast::Function>) {
         let mut fct = FctDefinition::new(
-            self.sa,
             self.file_id,
             self.namespace_id,
             node,

--- a/dora/src/vm/annotations.rs
+++ b/dora/src/vm/annotations.rs
@@ -1,3 +1,4 @@
+use crate::language::error::msg::SemError;
 use crate::language::ty::SourceType;
 use crate::utils::GrowableVec;
 use crate::vm::{FileId, NamespaceId, TypeParam, VM};
@@ -130,5 +131,27 @@ impl AnnotationDefinition {
             .read()
             .name;
         annotation_usages.contains(name)
+    }
+
+    pub fn reject_modifiers(
+        vm: &VM,
+        file_id: FileId,
+        modifiers: &AnnotationUsages,
+        rejects: &[AnnotationDefinitionId],
+    ) {
+        for reject in rejects.iter() {
+            let reject = vm.annotations.idx(*reject).read().name;
+            for modifier in modifiers.iter() {
+                if modifier.name == reject {
+                    vm.diag.lock().report(
+                        file_id,
+                        modifier.pos,
+                        SemError::MisplacedAnnotation(
+                            vm.interner.str(modifier.name).as_str().into(),
+                        ),
+                    );
+                }
+            }
+        }
     }
 }

--- a/dora/src/vm/enums.rs
+++ b/dora/src/vm/enums.rs
@@ -12,8 +12,9 @@ use dora_parser::lexer::position::Position;
 use crate::language::ty::{SourceType, SourceTypeArray};
 use crate::utils::GrowableVec;
 use crate::vm::{
-    extension_matches, impl_matches, namespace_path, Candidate, ClassInstanceId, ExtensionId,
-    FileId, ImplId, NamespaceId, TypeParam, TypeParamDefinition, TypeParamId, VM,
+    extension_matches, impl_matches, namespace_path, AnnotationDefinition, Candidate,
+    ClassInstanceId, ExtensionId, FileId, ImplId, NamespaceId, SemAnalysis, TypeParam,
+    TypeParamDefinition, TypeParamId, VM,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -59,6 +60,26 @@ pub struct EnumDefinition {
 }
 
 impl EnumDefinition {
+    pub fn init_modifiers(&mut self, sa: &SemAnalysis) {
+        let annotation_usages = &ast::AnnotationUsages::new();
+        self.is_pub = AnnotationDefinition::is_pub(annotation_usages, sa);
+        AnnotationDefinition::reject_modifiers(
+            sa,
+            self.file_id,
+            annotation_usages,
+            &[
+                sa.known.annotations.abstract_,
+                sa.known.annotations.final_,
+                sa.known.annotations.internal,
+                sa.known.annotations.open,
+                sa.known.annotations.optimize_immediately,
+                sa.known.annotations.override_,
+                sa.known.annotations.static_,
+                sa.known.annotations.test,
+            ],
+        );
+    }
+
     pub fn type_param(&self, id: TypeParamId) -> &TypeParam {
         &self.type_params[id.to_usize()]
     }

--- a/dora/src/vm/extensions.rs
+++ b/dora/src/vm/extensions.rs
@@ -5,7 +5,9 @@ use std::ops::Index;
 use std::sync::Arc;
 
 use crate::language::ty::SourceType;
-use crate::vm::{FctDefinitionId, FileId, NamespaceId, TypeParam, TypeParamId};
+use crate::vm::{
+    AnnotationDefinition, FctDefinitionId, FileId, NamespaceId, SemAnalysis, TypeParam, TypeParamId,
+};
 
 pub use self::matching::{extension_matches, extension_matches_ty};
 use dora_parser::ast;
@@ -42,6 +44,26 @@ pub struct ExtensionData {
 }
 
 impl ExtensionData {
+    pub fn init_modifiers(&mut self, sa: &SemAnalysis) {
+        let annotation_usages = &ast::AnnotationUsages::new();
+        AnnotationDefinition::reject_modifiers(
+            sa,
+            self.file_id,
+            annotation_usages,
+            &[
+                sa.known.annotations.abstract_,
+                sa.known.annotations.final_,
+                sa.known.annotations.internal,
+                sa.known.annotations.open,
+                sa.known.annotations.optimize_immediately,
+                sa.known.annotations.override_,
+                sa.known.annotations.pub_,
+                sa.known.annotations.static_,
+                sa.known.annotations.test,
+            ],
+        );
+    }
+
     pub fn type_param(&self, id: TypeParamId) -> &TypeParam {
         &self.type_params[id.to_usize()]
     }

--- a/dora/src/vm/globals.rs
+++ b/dora/src/vm/globals.rs
@@ -5,7 +5,9 @@ use crate::gc::Address;
 use crate::language::ty::SourceType;
 use crate::mem;
 use crate::utils::GrowableVec;
-use crate::vm::{namespace_path, FctDefinitionId, FileId, NamespaceId, VM};
+use crate::vm::{
+    namespace_path, AnnotationDefinition, FctDefinitionId, FileId, NamespaceId, SemAnalysis, VM,
+};
 
 use dora_parser::ast;
 use dora_parser::interner::Name;
@@ -43,6 +45,26 @@ pub struct GlobalDefinition {
 }
 
 impl GlobalDefinition {
+    pub fn init_modifiers(&mut self, sa: &SemAnalysis) {
+        let annotation_usages = &ast::AnnotationUsages::new();
+        self.is_pub = AnnotationDefinition::is_pub(annotation_usages, sa);
+        AnnotationDefinition::reject_modifiers(
+            sa,
+            self.file_id,
+            annotation_usages,
+            &[
+                sa.known.annotations.abstract_,
+                sa.known.annotations.final_,
+                sa.known.annotations.internal,
+                sa.known.annotations.open,
+                sa.known.annotations.optimize_immediately,
+                sa.known.annotations.override_,
+                sa.known.annotations.static_,
+                sa.known.annotations.test,
+            ],
+        );
+    }
+
     pub fn needs_initialization(&self) -> bool {
         self.initializer.is_some() && !self.is_initialized()
     }

--- a/dora/src/vm/impls.rs
+++ b/dora/src/vm/impls.rs
@@ -10,8 +10,8 @@ use dora_parser::lexer::position::Position;
 
 use crate::language::ty::{find_impl, SourceType, SourceTypeArray};
 use crate::vm::{
-    extension_matches_ty, FctDefinitionId, FileId, NamespaceId, TraitDefinitionId, TypeParam,
-    TypeParamDefinition, TypeParamId, VM,
+    extension_matches_ty, AnnotationDefinition, FctDefinitionId, FileId, NamespaceId, SemAnalysis,
+    TraitDefinitionId, TypeParam, TypeParamDefinition, TypeParamId, VM,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -40,6 +40,26 @@ pub struct ImplData {
 }
 
 impl ImplData {
+    pub fn init_modifiers(&mut self, sa: &SemAnalysis) {
+        let annotation_usages = &ast::AnnotationUsages::new();
+        AnnotationDefinition::reject_modifiers(
+            sa,
+            self.file_id,
+            annotation_usages,
+            &[
+                sa.known.annotations.abstract_,
+                sa.known.annotations.final_,
+                sa.known.annotations.internal,
+                sa.known.annotations.open,
+                sa.known.annotations.optimize_immediately,
+                sa.known.annotations.override_,
+                sa.known.annotations.pub_,
+                sa.known.annotations.static_,
+                sa.known.annotations.test,
+            ],
+        );
+    }
+
     pub fn trait_id(&self) -> TraitDefinitionId {
         self.trait_id.expect("trait_id not initialized yet.")
     }

--- a/dora/src/vm/namespaces.rs
+++ b/dora/src/vm/namespaces.rs
@@ -5,7 +5,7 @@ use dora_parser::ast;
 use dora_parser::interner::Name;
 
 use crate::language::sym::SymTable;
-use crate::vm::{FileId, VM};
+use crate::vm::{AnnotationDefinition, FileId, SemAnalysis, VM};
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct NamespaceId(pub usize);
@@ -74,6 +74,29 @@ impl NamespaceData {
             is_pub: ast.is_pub,
             parents,
             depth,
+        }
+    }
+
+    pub fn init_modifiers(&mut self, sa: &SemAnalysis) {
+        #[allow(unused_variables)]
+        if let Some(ast) = &self.ast {
+            let annotation_usages = &ast::AnnotationUsages::new();
+            self.is_pub = AnnotationDefinition::is_pub(annotation_usages, sa);
+            AnnotationDefinition::reject_modifiers(
+                sa,
+                self.file_id,
+                annotation_usages,
+                &[
+                    sa.known.annotations.abstract_,
+                    sa.known.annotations.final_,
+                    sa.known.annotations.internal,
+                    sa.known.annotations.open,
+                    sa.known.annotations.optimize_immediately,
+                    sa.known.annotations.override_,
+                    sa.known.annotations.static_,
+                    sa.known.annotations.test,
+                ],
+            );
         }
     }
 


### PR DESCRIPTION
This shows that the approach of initializing the modifiers in the individual *ck-phases might work if it wasn't for the `X_accessible_from` access-checks:

If the `X` is later than the phase we already checked, then it fails because `is_public` is `false`, because the modifiers haven't been initialized yet. So e. g. class → struct works, but struct → class does not.