### PR TITLE
change `Vec<NamespaceData>` → `Vec<RwLock<NamespaceData>>` to allow mutation of namespaces later on

### DIFF
--- a/dora/src/language/access.rs
+++ b/dora/src/language/access.rs
@@ -190,10 +190,10 @@ fn accessible_from(
     // find the common parent of both namespaces
     let common_parent_id = common_parent(sa, target_id, from_id);
 
-    let target = &sa.namespaces[target_id.to_usize()];
+    let target = &sa.namespaces[target_id.to_usize()].read();
 
     if let Some(common_parent_id) = common_parent_id {
-        let common_parent_depth = sa.namespaces[common_parent_id.to_usize()].depth;
+        let common_parent_depth = sa.namespaces[common_parent_id.to_usize()].read().depth;
 
         if common_parent_depth + 1 == target.depth {
             // siblings are accessible
@@ -201,7 +201,7 @@ fn accessible_from(
         } else {
             let start_depth = common_parent_depth + 2;
             for ns_id in &target.parents[start_depth..] {
-                let ns = &sa.namespaces[ns_id.to_usize()];
+                let ns = &sa.namespaces[ns_id.to_usize()].read();
                 if !ns.is_pub {
                     return false;
                 }
@@ -213,7 +213,7 @@ fn accessible_from(
         // no common parent: means we try to access another package
         // the whole path needs to be public
         for ns_id in &target.parents {
-            let ns = &sa.namespaces[ns_id.to_usize()];
+            let ns = &sa.namespaces[ns_id.to_usize()].read();
             if !ns.is_pub {
                 return false;
             }
@@ -232,8 +232,8 @@ fn common_parent(
         return Some(lhs_id);
     }
 
-    let lhs = &sa.namespaces[lhs_id.to_usize()];
-    let rhs = &sa.namespaces[rhs_id.to_usize()];
+    let lhs = &sa.namespaces[lhs_id.to_usize()].read();
+    let rhs = &sa.namespaces[rhs_id.to_usize()].read();
 
     if lhs.depth > rhs.depth {
         if lhs.parents[rhs.depth] == rhs_id {
@@ -265,6 +265,6 @@ pub fn namespace_contains(sa: &SemAnalysis, parent_id: NamespaceId, child_id: Na
         return true;
     }
 
-    let namespace = &sa.namespaces[child_id.to_usize()];
+    let namespace = &sa.namespaces[child_id.to_usize()].read();
     namespace.parents.contains(&parent_id)
 }

--- a/dora/src/language/fctbodyck/body.rs
+++ b/dora/src/language/fctbodyck/body.rs
@@ -2340,7 +2340,7 @@ impl<'a> TypeCheck<'a> {
                 }
 
                 let sym = {
-                    let namespace = &self.sa.namespaces[namespace_id.to_usize()];
+                    let namespace = &self.sa.namespaces[namespace_id.to_usize()].read();
                     let table = namespace.table.read();
 
                     table.get(method_name)
@@ -2490,7 +2490,7 @@ impl<'a> TypeCheck<'a> {
 
             match sym {
                 Some(Sym::Namespace(namespace_id)) => {
-                    let namespace = &self.sa.namespaces[namespace_id.to_usize()];
+                    let namespace = &self.sa.namespaces[namespace_id.to_usize()].read();
                     let symtable = namespace.table.read();
                     let sym = symtable.get(element_name);
 
@@ -2523,12 +2523,12 @@ impl<'a> TypeCheck<'a> {
             match sym {
                 Some(Sym::Namespace(namespace_id)) => {
                     if !namespace_accessible_from(self.sa, namespace_id, self.namespace_id) {
-                        let namespace = &self.sa.namespaces[namespace_id.to_usize()];
+                        let namespace = &self.sa.namespaces[namespace_id.to_usize()].read();
                         let msg = SemError::NotAccessible(namespace.name(self.sa));
                         self.sa.diag.lock().report(self.file_id, path.pos, msg);
                     }
 
-                    let namespace = &self.sa.namespaces[namespace_id.to_usize()];
+                    let namespace = &self.sa.namespaces[namespace_id.to_usize()].read();
                     let symtable = namespace.table.read();
                     sym = symtable.get(name);
                 }
@@ -2587,7 +2587,7 @@ impl<'a> TypeCheck<'a> {
         namespace_id: NamespaceId,
         element_name: Name,
     ) -> SourceType {
-        let namespace = &self.sa.namespaces[namespace_id.to_usize()];
+        let namespace = &self.sa.namespaces[namespace_id.to_usize()].read();
         let table = namespace.table.read();
 
         let sym = table.get(element_name);

--- a/dora/src/language/globaldef.rs
+++ b/dora/src/language/globaldef.rs
@@ -212,9 +212,12 @@ struct GlobalDef<'x> {
 
 impl<'x> visit::Visitor for GlobalDef<'x> {
     fn visit_namespace(&mut self, node: &Arc<ast::Namespace>) {
-        let id = NamespaceData::new(self.sa, self.namespace_id, node.name, node.is_pub);
-
+        let namespace = NamespaceData::new(self.sa, self.namespace_id, node);
+        let id = namespace.id.clone();
         let sym = Sym::Namespace(id);
+
+        self.sa.namespaces.push(RwLock::new(namespace));
+
         if let Some(sym) = self.insert(node.name, sym) {
             report_sym_shadow(self.sa, node.name, self.file_id, node.pos, sym);
         }

--- a/dora/src/language/importck.rs
+++ b/dora/src/language/importck.rs
@@ -26,7 +26,7 @@ fn check_import(sa: &SemAnalysis, import: &ImportData) {
         ImportContext::This => import.namespace_id,
         ImportContext::Package => namespace_package(sa, import.namespace_id),
         ImportContext::Super => {
-            let namespace = &sa.namespaces[import.namespace_id.to_usize()];
+            let namespace = &sa.namespaces[import.namespace_id.to_usize()].read();
             if let Some(namespace_id) = namespace.parent_namespace_id {
                 namespace_id
             } else {
@@ -58,7 +58,7 @@ fn check_import(sa: &SemAnalysis, import: &ImportData) {
         match sym {
             Some(Sym::Namespace(namespace_id)) => {
                 if !namespace_accessible_from(sa, namespace_id, import.namespace_id) {
-                    let namespace = &sa.namespaces[namespace_id.to_usize()];
+                    let namespace = &sa.namespaces[namespace_id.to_usize()].read();
                     let msg = SemError::NotAccessible(namespace.name(sa));
                     sa.diag.lock().report(import.file_id, import.ast.pos, msg);
                     return;
@@ -96,11 +96,11 @@ fn read_path(
         for &name in &path[1..] {
             match sym {
                 Some(Sym::Namespace(namespace_id)) => {
-                    let namespace = &sa.namespaces[namespace_id.to_usize()];
+                    let namespace = &sa.namespaces[namespace_id.to_usize()].read();
                     let symtable = namespace.table.read();
 
                     if !namespace_accessible_from(sa, namespace_id, import.namespace_id) {
-                        let namespace = &sa.namespaces[namespace_id.to_usize()];
+                        let namespace = &sa.namespaces[namespace_id.to_usize()].read();
                         let msg = SemError::NotAccessible(namespace.name(sa));
                         sa.diag.lock().report(import.file_id, import.ast.pos, msg);
                         return Err(());
@@ -139,7 +139,7 @@ fn import_namespace(
     element_name: Name,
     target_name: Name,
 ) {
-    let namespace = &sa.namespaces[namespace_id.to_usize()];
+    let namespace = &sa.namespaces[namespace_id.to_usize()].read();
     let sym = namespace.table.read().get(element_name);
 
     match sym {
@@ -159,7 +159,7 @@ fn import_namespace(
 
         Some(Sym::Namespace(namespace_id)) => {
             if !namespace_accessible_from(sa, namespace_id, import.namespace_id) {
-                let namespace = &sa.namespaces[namespace_id.to_usize()];
+                let namespace = &sa.namespaces[namespace_id.to_usize()].read();
                 let msg = SemError::NotAccessible(namespace.name(sa));
                 sa.diag.lock().report(import.file_id, import.ast.pos, msg);
             }

--- a/dora/src/language/readty.rs
+++ b/dora/src/language/readty.rs
@@ -157,7 +157,7 @@ fn table_for_namespace(
 ) -> Result<Arc<RwLock<SymTable>>, ()> {
     match sym {
         Some(Sym::Namespace(namespace_id)) => {
-            Ok(sa.namespaces[namespace_id.to_usize()].table.clone())
+            Ok(sa.namespaces[namespace_id.to_usize()].read().table.clone())
         }
 
         _ => {

--- a/dora/src/language/sem_analysis.rs
+++ b/dora/src/language/sem_analysis.rs
@@ -204,17 +204,22 @@ impl SemAnalysis {
     }
 
     pub fn namespace_table(&self, namespace_id: NamespaceId) -> Arc<RwLock<SymTable>> {
-        self.namespaces[namespace_id.to_usize()].table.clone()
+        self.namespaces[namespace_id.to_usize()]
+            .read()
+            .table
+            .clone()
     }
 
     pub fn stdlib_namespace(&self) -> Arc<RwLock<SymTable>> {
         self.namespaces[self.stdlib_namespace_id.to_usize()]
+            .read()
             .table
             .clone()
     }
 
     pub fn prelude_namespace(&self) -> Arc<RwLock<SymTable>> {
         self.namespaces[self.prelude_namespace_id.to_usize()]
+            .read()
             .table
             .clone()
     }

--- a/dora/src/language/sym.rs
+++ b/dora/src/language/sym.rs
@@ -49,19 +49,19 @@ impl<'a> NestedSymTable<'a> {
         }
 
         {
-            let namespace = &self.sa.namespaces[self.namespace_id.to_usize()];
+            let namespace = &self.sa.namespaces[self.namespace_id.to_usize()].read();
 
             if let Some(sym) = namespace.table.read().get(name) {
                 return Some(sym.clone());
-            }
+            };
         }
 
         {
-            let namespace = &self.sa.namespaces[self.sa.prelude_namespace_id.to_usize()];
+            let namespace = &self.sa.namespaces[self.sa.prelude_namespace_id.to_usize()].read();
 
             if let Some(sym) = namespace.table.read().get(name) {
                 return Some(sym.clone());
-            }
+            };
         }
 
         None

--- a/dora/src/vm.rs
+++ b/dora/src/vm.rs
@@ -138,9 +138,9 @@ pub struct FullSemAnalysis {
     pub modules: GrowableVec<RwLock<Module>>,         // stores all module source definitions
     pub module_defs: GrowableVec<RwLock<ModuleInstance>>, // stores all module definitions
     pub annotations: GrowableVec<RwLock<AnnotationDefinition>>, // stores all annotation source definitions
-    pub namespaces: Vec<NamespaceData>,                         // storer all namespace definitions
+    pub namespaces: Vec<RwLock<NamespaceData>>,                 // stores all namespace definitions
     pub fcts: GrowableVec<RwLock<FctDefinition>>, // stores all function source definitions
-    pub enums: Vec<RwLock<EnumDefinition>>,       // store all enum source definitions
+    pub enums: Vec<RwLock<EnumDefinition>>,       // stores all enum source definitions
     pub enum_defs: GrowableVec<EnumInstance>,     // stores all enum definitions
     pub traits: Vec<RwLock<TraitDefinition>>,     // stores all trait definitions
     pub impls: Vec<RwLock<ImplData>>,             // stores all impl definitions
@@ -174,10 +174,16 @@ impl FullSemAnalysis {
         let boots_name = interner.intern("boots");
 
         let namespaces = vec![
-            NamespaceData::predefined(prelude_namespace_id, None),
-            NamespaceData::predefined(stdlib_namespace_id, Some(stdlib_name)),
-            NamespaceData::predefined(global_namespace_id, None),
-            NamespaceData::predefined(boots_namespace_id, Some(boots_name)),
+            RwLock::new(NamespaceData::predefined(prelude_namespace_id, None)),
+            RwLock::new(NamespaceData::predefined(
+                stdlib_namespace_id,
+                Some(stdlib_name),
+            )),
+            RwLock::new(NamespaceData::predefined(global_namespace_id, None)),
+            RwLock::new(NamespaceData::predefined(
+                boots_namespace_id,
+                Some(boots_name),
+            )),
         ];
 
         let sa = Box::new(FullSemAnalysis {
@@ -297,7 +303,7 @@ pub struct VM {
     pub modules: GrowableVec<RwLock<Module>>,         // stores all module source definitions
     pub module_instances: GrowableVec<RwLock<ModuleInstance>>, // stores all module definitions
     pub annotations: GrowableVec<RwLock<AnnotationDefinition>>, // stores all annotation source definitions
-    pub namespaces: Vec<NamespaceData>,                         // stores all namespace definitions
+    pub namespaces: Vec<RwLock<NamespaceData>>,                 // stores all namespace definitions
     pub fcts: GrowableVec<RwLock<FctDefinition>>, // stores all function source definitions
     pub compiled_fcts: RwLock<HashMap<(FctDefinitionId, SourceTypeArray), CodeId>>,
     pub code: GrowableVec<Code>, // stores all function implementations
@@ -345,10 +351,16 @@ impl VM {
         let boots_name = interner.intern("boots");
 
         let namespaces = vec![
-            NamespaceData::predefined(prelude_namespace_id, None),
-            NamespaceData::predefined(stdlib_namespace_id, Some(stdlib_name)),
-            NamespaceData::predefined(global_namespace_id, None),
-            NamespaceData::predefined(boots_namespace_id, Some(boots_name)),
+            RwLock::new(NamespaceData::predefined(prelude_namespace_id, None)),
+            RwLock::new(NamespaceData::predefined(
+                stdlib_namespace_id,
+                Some(stdlib_name),
+            )),
+            RwLock::new(NamespaceData::predefined(global_namespace_id, None)),
+            RwLock::new(NamespaceData::predefined(
+                boots_namespace_id,
+                Some(boots_name),
+            )),
         ];
 
         let vm = Box::new(VM {


### PR DESCRIPTION
This is needed to initialize modifiers later on.